### PR TITLE
test(favicon): cover handler + resolver edge cases (66% → 100%)

### DIFF
--- a/tests/core/favicon/favicon-handler.test.ts
+++ b/tests/core/favicon/favicon-handler.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleFaviconRequest } from "@/core/favicon/favicon-handler";
+
+const FAVICON_PIXEL_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+
+function imageHeadResponse(size = "1000"): Response {
+  return new Response(null, {
+    status: 200,
+    headers: { "content-type": "image/x-icon", "content-length": size },
+  });
+}
+
+describe("handleFaviconRequest", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 400 when domain query param is missing", async () => {
+    const res = await handleFaviconRequest(
+      new Request("http://localhost/api/favicon"),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.text()).toMatch(/domain/i);
+  });
+
+  it("returns 400 when domain fails SSRF validation (private IP)", async () => {
+    const res = await handleFaviconRequest(
+      new Request("http://localhost/api/favicon?domain=127.0.0.1"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns the fetched icon body with content-type and no-cache header", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(imageHeadResponse()) // resolver finds /favicon.ico
+      .mockResolvedValueOnce(
+        new Response(FAVICON_PIXEL_BYTES, {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleFaviconRequest(
+      new Request("http://localhost/api/favicon?domain=example.com"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("cache-control")).toBe("no-cache");
+    const body = await res.arrayBuffer();
+    expect(body.byteLength).toBe(FAVICON_PIXEL_BYTES.byteLength);
+  });
+
+  it("falls back to image/x-icon when upstream omits content-type", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(imageHeadResponse())
+      .mockResolvedValueOnce(
+        new Response(FAVICON_PIXEL_BYTES, { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleFaviconRequest(
+      new Request("http://localhost/api/favicon?domain=example.com"),
+    );
+    expect(res.headers.get("content-type")).toBe("image/x-icon");
+  });
+
+  it("returns 404 when the resolved icon URL responds non-OK", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(imageHeadResponse()) // resolver finds /favicon.ico
+      .mockResolvedValueOnce(new Response(null, { status: 500 })); // image GET fails
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleFaviconRequest(
+      new Request("http://localhost/api/favicon?domain=example.com"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 502 when the icon fetch throws (network/timeout)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(imageHeadResponse())
+      .mockRejectedValueOnce(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleFaviconRequest(
+      new Request("http://localhost/api/favicon?domain=example.com"),
+    );
+    expect(res.status).toBe(502);
+    expect(await res.text()).toMatch(/failed/i);
+  });
+});

--- a/tests/core/favicon/favicon-resolver.test.ts
+++ b/tests/core/favicon/favicon-resolver.test.ts
@@ -157,4 +157,62 @@ describe("resolveIconUrl", () => {
     // No valid icon in HTML, falls back to DuckDuckGo
     expect(result).toBe("https://icons.duckduckgo.com/ip3/example.com.ico");
   });
+
+  it("survives fetch HEAD throwing (timeout/network) and tries the next path", async () => {
+    const fetchMock = vi.fn()
+      // First well-known HEAD aborts (e.g. AbortSignal timeout) — falls through
+      .mockRejectedValueOnce(new Error("aborted"))
+      // Second well-known HEAD also throws — falls through
+      .mockRejectedValueOnce(new Error("network down"))
+      // Third well-known HEAD also throws — falls through to HTML parsing
+      .mockRejectedValueOnce(new Error("network down"))
+      // HTML fetch returns a valid icon
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            '<html><head><link rel="icon" href="/icon.png" sizes="64x64"></head></html>',
+          ),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await resolveIconUrl("https://example.com");
+    expect(result).toBe("https://example.com/icon.png");
+  });
+
+  it("falls back to DuckDuckGo when the HTML fetch itself throws", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      // HTML fetch throws (DNS error, TLS handshake failure, etc.)
+      .mockRejectedValueOnce(new TypeError("fetch failed"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await resolveIconUrl("https://example.com");
+    expect(result).toBe("https://icons.duckduckgo.com/ip3/example.com.ico");
+  });
+
+  it("skips href values that fail URL parsing (e.g. out-of-range port)", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            '<html><head>' +
+            // Port 99999 is out of range — `new URL` throws TypeError
+            '<link rel="icon" href="http://broken.example:99999/icon.png">' +
+            '<link rel="icon" href="/good.png" sizes="32x32">' +
+            '</head></html>',
+          ),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // The bad href is silently skipped; the good href wins.
+    const result = await resolveIconUrl("https://example.com");
+    expect(result).toBe("https://example.com/good.png");
+  });
 });


### PR DESCRIPTION
## Summary

First in a series of coverage-uplift PRs working toward the 90% lines/funcs/statements + 83% branches thresholds in vitest.config.ts. Picked `src/core/favicon` first because it was the lowest at 66.66% lines and small surface area (174 lines of source).

**Result: `src/core/favicon` is now at 100% lines, 93.87% branches, 100% functions, 100% statements.** All four metrics exceed the project's strict thresholds.

## What's covered

### `favicon-handler.ts` (was ~5% covered, now 100%)
New `tests/core/favicon/favicon-handler.test.ts` with six tests:
- Missing `?domain` query param → 400
- SSRF-rejected domain (private IP) → 400
- Happy path: returns body + content-type + `Cache-Control: no-cache`
- Upstream omits `content-type` → falls back to `image/x-icon`
- Resolved-icon URL responds non-OK → 404
- Resolved-icon fetch throws → 502

### `favicon-resolver.ts` edge cases (lines 42, 70-71, 114-115)
Three additional tests in the existing `favicon-resolver.test.ts`:
- Well-known HEAD throws (timeout / network error) → tries next path
- HTML fetch throws → falls back to DuckDuckGo
- HREF with out-of-range port (`:99999`) → URL constructor throws, candidate skipped, next valid candidate wins

## No production code changed

Pure characterization tests against existing behaviour. No bugs surfaced — every test passed on first run.

## Test plan

- [x] `npx vitest run tests/core/favicon/` → 16/16 pass
- [x] `npm test` (full suite) → 1349/1349 pass, no regressions
- [x] `npx tsc --noEmit` → clean
- [x] Coverage on `src/core/favicon`: 100/93.87/100/100

## Next steps in the coverage push (separate PRs)

| Module | Lines now | Targets |
|---|---|---|
| `src/core/favicon` | **100%** | done (this PR) |
| `src/core/parser` | 91% lines / **65% branches** | next — branches |
| `src/core/feeds` | 76% | |
| `src/core/storage` | 73% | |
| `src/core/feedback` | 73% | |

Once all are above the 90/83 thresholds, flip CI's coverage step from non-blocking to blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)