### PR TITLE
test(storage): cover key-manager API surface (39% → 95%)

### DIFF
--- a/tests/core/storage/key-manager.test.ts
+++ b/tests/core/storage/key-manager.test.ts
@@ -5,9 +5,18 @@ vi.mock("@/core/sync/sync-service", () => ({
   deleteVault: vi.fn().mockResolvedValue({ ok: true, value: true }),
 }));
 
-import { initFresh } from "@/core/storage/key-manager";
+import {
+  initFresh,
+  restore,
+  addVaultKeys,
+  removeVaultKeys,
+  destroy,
+  destroyLocal,
+  rekeyFromPassphrase,
+} from "@/core/storage/key-manager";
 import { close } from "@/core/storage/db";
 import { deleteVault } from "@/core/sync/sync-service";
+import { LOCAL_STORAGE } from "@/utils/constants";
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -41,11 +50,10 @@ describe("key-manager", () => {
     indexedDB.deleteDatabase("feedzero");
   });
 
-  describe("initFresh with skipServerCleanup", () => {
+  describe("initFresh", () => {
     it("does not attempt to delete server vault when skipServerCleanup is true", async () => {
-      // Simulate stored vault keys from a previous session
       localStorageMock.setItem(
-        "feedzero:derived-keys",
+        LOCAL_STORAGE.DERIVED_KEYS,
         JSON.stringify({
           dbKeyJwk: {},
           hmacKeyJwk: {},
@@ -63,17 +71,243 @@ describe("key-manager", () => {
       expect(deleteVault).not.toHaveBeenCalled();
     });
 
-    it("returns ok with sync credentials when sync is enabled", async () => {
+    it("returns sync credentials with hex vaultId when sync is enabled", async () => {
       const result = await initFresh("test passphrase here now", {
         sync: true,
         skipServerCleanup: true,
       });
-
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value.credentials).not.toBeNull();
         expect(result.value.credentials?.vaultId).toMatch(/^[0-9a-f]{64}$/);
       }
+    });
+
+    it("returns null credentials and persists local storage mode for local-only init", async () => {
+      const result = await initFresh("test passphrase here now", {
+        sync: false,
+        skipServerCleanup: true,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.credentials).toBeNull();
+      }
+      expect(localStorageMock.getItem(LOCAL_STORAGE.STORAGE_MODE)).toBe("local");
+      expect(localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS)).not.toBeNull();
+    });
+
+    it("attempts to delete previous server vault when skipServerCleanup is false and stored vault keys exist", async () => {
+      // Run a real sync init first so stored vault keys are valid JWK,
+      // then a second init without skipServerCleanup should trigger deleteVault.
+      await initFresh("first passphrase here now", {
+        sync: true,
+        skipServerCleanup: true,
+      });
+      vi.mocked(deleteVault).mockClear();
+
+      await initFresh("second passphrase here now", { sync: true });
+      expect(deleteVault).toHaveBeenCalledOnce();
+    });
+
+    it("does not call deleteVault when no previous vault keys exist", async () => {
+      // No stored keys at all
+      await initFresh("brand new passphrase", { sync: true });
+      expect(deleteVault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("restore", () => {
+    it("returns no-keys when localStorage has nothing", async () => {
+      const status = await restore();
+      expect(status.status).toBe("no-keys");
+    });
+
+    it("returns invalid-keys when stored JSON cannot decrypt the database", async () => {
+      // Plant garbage that parses as JSON but fails as JWK
+      localStorageMock.setItem(
+        LOCAL_STORAGE.DERIVED_KEYS,
+        JSON.stringify({
+          dbKeyJwk: { kty: "oct", k: "AAAAAAAAAAAAAAAAAAAAAA" },
+          hmacKeyJwk: { kty: "oct", k: "AAAAAAAAAAAAAAAAAAAAAA" },
+          dbSalt: [1, 2, 3],
+        }),
+      );
+
+      const status = await restore();
+      expect(status.status).toBe("invalid-keys");
+    });
+
+    it("returns no-keys when stored JSON is malformed", async () => {
+      localStorageMock.setItem(LOCAL_STORAGE.DERIVED_KEYS, "{not json");
+      const status = await restore();
+      expect(status.status).toBe("no-keys");
+    });
+
+    it("returns ready with credentials=null after a fresh local init", async () => {
+      const init = await initFresh("test passphrase here now", {
+        sync: false,
+        skipServerCleanup: true,
+      });
+      expect(init.ok).toBe(true);
+      close();
+
+      const status = await restore();
+      expect(status.status).toBe("ready");
+      if (status.status === "ready") {
+        expect(status.isSyncUser).toBe(false);
+        expect(status.credentials).toBeNull();
+      }
+    });
+
+    it("returns ready with credentials after a fresh sync init", async () => {
+      const init = await initFresh("test passphrase here now", {
+        sync: true,
+        skipServerCleanup: true,
+      });
+      expect(init.ok).toBe(true);
+      close();
+
+      const status = await restore();
+      expect(status.status).toBe("ready");
+      if (status.status === "ready") {
+        expect(status.isSyncUser).toBe(true);
+        expect(status.credentials).not.toBeNull();
+        expect(status.credentials?.vaultId).toMatch(/^[0-9a-f]{64}$/);
+      }
+    });
+  });
+
+  describe("addVaultKeys", () => {
+    it("returns err when there are no stored keys", async () => {
+      const result = await addVaultKeys("any passphrase");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/No stored keys/);
+      }
+    });
+
+    it("derives + persists vault keys on top of an existing local session", async () => {
+      // Local-only init first
+      await initFresh("local passphrase here now", {
+        sync: false,
+        skipServerCleanup: true,
+      });
+      expect(localStorageMock.getItem(LOCAL_STORAGE.STORAGE_MODE)).toBe("local");
+
+      const result = await addVaultKeys("local passphrase here now");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.vaultId).toMatch(/^[0-9a-f]{64}$/);
+      }
+      // Storage mode should now be sync
+      expect(localStorageMock.getItem(LOCAL_STORAGE.STORAGE_MODE)).toBe("sync");
+
+      // Stored material should now contain vaultId + vaultKeyJwk
+      const raw = localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS);
+      expect(raw).not.toBeNull();
+      const stored = JSON.parse(raw!);
+      expect(stored.vaultId).toBeDefined();
+      expect(stored.vaultKeyJwk).toBeDefined();
+    });
+  });
+
+  describe("removeVaultKeys", () => {
+    it("is a no-op when there are no stored keys", () => {
+      expect(() => removeVaultKeys()).not.toThrow();
+      expect(localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS)).toBeNull();
+    });
+
+    it("strips vaultId/vaultKeyJwk while preserving DB keys", async () => {
+      await initFresh("test passphrase here now", {
+        sync: true,
+        skipServerCleanup: true,
+      });
+      // Pre-condition: stored material has vault fields
+      const before = JSON.parse(
+        localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS)!,
+      );
+      expect(before.vaultId).toBeDefined();
+
+      removeVaultKeys();
+
+      const after = JSON.parse(
+        localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS)!,
+      );
+      expect(after.vaultId).toBeUndefined();
+      expect(after.vaultKeyJwk).toBeUndefined();
+      expect(after.dbKeyJwk).toEqual(before.dbKeyJwk);
+      expect(after.hmacKeyJwk).toEqual(before.hmacKeyJwk);
+      // Storage mode flag cleared
+      expect(localStorageMock.getItem(LOCAL_STORAGE.STORAGE_MODE)).toBeNull();
+    });
+  });
+
+  describe("destroy and destroyLocal", () => {
+    it("destroyLocal clears local storage but leaves the server vault alone", async () => {
+      await initFresh("test passphrase here now", {
+        sync: true,
+        skipServerCleanup: true,
+      });
+      expect(localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS)).not.toBeNull();
+
+      await destroyLocal();
+      expect(deleteVault).not.toHaveBeenCalled();
+      expect(localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS)).toBeNull();
+      expect(localStorageMock.getItem(LOCAL_STORAGE.STORAGE_MODE)).toBeNull();
+      expect(localStorageMock.getItem(LOCAL_STORAGE.ONBOARDING_COMPLETE)).toBeNull();
+    });
+
+    it("destroy clears local storage AND attempts server vault deletion", async () => {
+      await initFresh("test passphrase here now", {
+        sync: true,
+        skipServerCleanup: true,
+      });
+
+      await destroy();
+      expect(deleteVault).toHaveBeenCalledOnce();
+      expect(localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS)).toBeNull();
+    });
+  });
+
+  describe("rekeyFromPassphrase", () => {
+    it("re-derives keys for a local session", async () => {
+      // Bootstrap a DB so getSalt() has something to read
+      await initFresh("first passphrase here now", {
+        sync: false,
+        skipServerCleanup: true,
+      });
+
+      const result = await rekeyFromPassphrase("first passphrase here now", {
+        sync: false,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.credentials).toBeNull();
+      }
+      expect(localStorageMock.getItem(LOCAL_STORAGE.STORAGE_MODE)).toBe("local");
+    });
+
+    it("re-derives keys + vault material for a sync session", async () => {
+      await initFresh("first passphrase here now", {
+        sync: true,
+        skipServerCleanup: true,
+      });
+
+      const result = await rekeyFromPassphrase("first passphrase here now", {
+        sync: true,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.credentials).not.toBeNull();
+        expect(result.value.credentials?.vaultId).toMatch(/^[0-9a-f]{64}$/);
+      }
+      expect(localStorageMock.getItem(LOCAL_STORAGE.STORAGE_MODE)).toBe("sync");
+
+      const stored = JSON.parse(
+        localStorageMock.getItem(LOCAL_STORAGE.DERIVED_KEYS)!,
+      );
+      expect(stored.vaultId).toBeDefined();
+      expect(stored.vaultKeyJwk).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

Phase 4 of the coverage uplift. Targets the worst-covered file in `src/core/storage`: `key-manager.ts` was at **39% lines, 31% branches** — far below the project's 90/83 thresholds.

**Result**: `key-manager.ts` is now at **95.38% lines, 71.92% branches, 100% functions**. The whole storage module moved from 73.69% → 86.01% lines.

## Why one file in this PR

`src/core/storage` has four other files (db.ts, crypto.ts, key-material.ts, schema.ts). The remaining gap is db.ts (75%/67%), which is 616 lines and needs its own focused PR. Keeping this PR scoped to key-manager so it's reviewable.

## What's tested

**`initFresh`** — added local-mode init, skipServerCleanup=false with prior vault keys (calls deleteVault), skipServerCleanup=false without prior vault keys (no deleteVault).

**`restore`** — no-keys, garbage-JSON-no-keys, bogus-JWK-invalid-keys, fresh-local-ready, fresh-sync-ready paths.

**`addVaultKeys`** — no-stored-keys err, local→sync upgrade success.

**`removeVaultKeys`** — no-op when no keys, strips vault material preserving DB keys.

**`destroy` / `destroyLocal`** — destroyLocal leaves server alone, destroy attempts deleteVault.

**`rekeyFromPassphrase`** — local + sync modes both covered.

## Coverage roadmap

| Module | Status |
|---|---|
| `src/core/favicon` | **100%** ✅ |
| `src/core/parser` | **98.58/86.92** ✅ |
| `src/core/feeds` | **96.55/83.33** ✅ |
| `src/core/storage` | 86.01/72.35 — **partial** (this PR) |
| `src/core/feedback` | 73% — next |
| Then: db.ts focused PR | |

## Verification

- [x] `npx vitest run tests/core/storage/key-manager.test.ts` → 18 pass
- [x] `npm test` → 1365/1365 pass
- [x] `npx tsc --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)