### PR TITLE
ci: enforce coverage thresholds (floor + ratchet plan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 
@@ -32,16 +31,14 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
-      - name: Tests
-        run: npm test
-
-      # Coverage report is generated and uploaded for visibility but does not
-      # gate the build. Pre-existing coverage is below the 90% target stated in
-      # CLAUDE.md (~81% lines, ~76% functions). Tracked in
-      # docs/internal/progress.md as a follow-up: either close the gap or
-      # adjust thresholds intentionally and ratchet up.
-      - name: Coverage report (non-blocking)
-        run: npm run test:coverage || true
+      # Coverage thresholds are enforced. Floors live in vitest.config.js.
+      # Current floor (post-uplift): branches 83 / functions 75 / lines 82 /
+      # statements 82. Ratchet target: 90/83/90/90, blocked on UI-component
+      # coverage. Do NOT lower these numbers — that is a regression by
+      # definition. `test:coverage` runs the full suite, so the separate
+      # `npm test` step above is no longer needed.
+      - name: Tests with coverage (thresholds enforced)
+        run: npm run test:coverage
 
       - name: Upload coverage artifact
         if: always()

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -21,13 +21,24 @@ export default defineConfig({
         "src/types/**",
         "src/core/extractor/adapters/types.ts",
         "src/core/sync/types.ts",
+        "src/core/catalog/catalog-types.ts",
         "src/components/ui/**",
       ],
+      // Thresholds are enforced — CI fails on regression. These are the
+      // floor; ratchet up as coverage improves.
+      //
+      // Target (next ratchet): branches 83, lines 90, statements 90, functions 90.
+      // Reaching the lines/statements/functions targets needs UI-component coverage
+      // (export-view, import-view, setup-wizard, feed-item, folder-item, feeds-page).
+      // Branches already exceed the stated 83 target; lines/statements/functions
+      // are just under. Ratchet up in dedicated PRs as new tests land. Do NOT
+      // lower these numbers without explicit justification — that is a regression
+      // by definition.
       thresholds: {
         branches: 83,
-        functions: 90,
-        lines: 90,
-        statements: 90,
+        functions: 75,
+        lines: 82,
+        statements: 82,
       },
     },
   },


### PR DESCRIPTION
## Summary

Closes the loop on the coverage push: CI's coverage step is now **blocking**, not advisory. Floors are set to current actuals so the gate is real on the day it ships.

| Metric | Floor | Actual on main | Stated target |
|---|---|---|---|
| Branches | 83 | 86.46 | 83 ✅ at target |
| Functions | 75 | 76.62 | 90 (ratchet) |
| Lines | 82 | 82.84 | 90 (ratchet) |
| Statements | 82 | 82.84 | 90 (ratchet) |

These floors ratchet **up only**. Lowering them is a regression by definition. Reaching 90/83/90/90 needs UI-component coverage (`export-view.tsx`, `import-view.tsx`, `setup-wizard.tsx`, `feed-item.tsx`, `folder-item.tsx`, `feeds-page.tsx`).

## Other small fixes folded in

- `pull_request` trigger no longer filters on `branches: [main]` — stacked PRs get CI now. (Was attempted in earlier branches but didn't propagate to main.)
- Removed the redundant `npm test` step; `npm run test:coverage` runs the full suite *plus* the threshold check.
- Added `src/core/catalog/catalog-types.ts` to coverage exclusions — types-only file that reports 0%.

## What's left out (intentionally)

- **Audit gate stays at `--audit-level=critical`.** PR #3 (audit-fix) was merged into the bootstrap branch *after* it had already merged to main, so its tightening to `--audit-level=high` did not reach main. A separate follow-up will re-run `npm audit fix` against today's main and re-tighten the gate.
- **Coding principles + `.claude/` granular ignore** (PR #2) similarly stuck on the dead bootstrap branch — separate follow-up to bring those changes onto main.

## Discovered during this work

PRs #2 and #3 show as `MERGED` in the GitHub UI but their changes are not on `main`. They were stacked on `chore/github-bootstrap` after that branch had already squashed-merged into main, so merging them updated only the (now-stale) bootstrap branch. **Recommend two cherry-pick PRs to bring those changes onto main.** I can prepare them if you want.

## Verification

- [x] `npm run test:coverage` → passes thresholds on current main
- [x] `npx tsc --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)