### PR TITLE
chore: restore coding principles + .claude/ tightening (re-apply of #2)

### DIFF
--- a/.claude/hooks/rgr-check.sh
+++ b/.claude/hooks/rgr-check.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# RGR pre-edit check: reminds Claude to write tests first for source files
+FILE=$(jq -r '.tool_input.file_path // .tool_response.filePath // ""')
+
+# Skip test files, config files, non-source files
+if echo "$FILE" | grep -qE '\.(test|spec)\.' || ! echo "$FILE" | grep -qE '\.(ts|tsx|js|jsx)$'; then
+  exit 0
+fi
+
+echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"RGR CHECK: Is there a failing test for this change? If not, write the test FIRST. (1) RED: failing test exists? (2) GREEN: minimum code to pass? (3) REFACTOR: clean up after green?"}}'

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,13 @@ coverage/
 .env.*
 test-results/
 playwright-report/
-.claude/
+# Personal Claude Code config + permissions, not for the public repo.
+# Skills and hooks ARE tracked because they describe shared workflows
+# (e.g. /new-release) and contributor automation (RGR pre-edit hook).
+.claude/*
+!.claude/skills/
+!.claude/hooks/
+
 .vercel
 .env*.local
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,71 @@ FeedZero exists to protect its users. It is used by journalists, activists, and 
 - **Clean code** — Self-evident naming, small single-responsibility functions, explicit error handling via Result types. Functions should do one thing and their name should say what that thing is. If you need a comment to explain *what* code does, rename or extract instead. Comments only for *why* — never *what*.
 - **Reliability and resilience** — The app must work. Core flows (adding feeds, reading articles, syncing) must never regress. Every deployment artifact must be tested. Every client-server boundary must have a contract test. If a mock replaces a real boundary, a separate test must verify the contract across that boundary.
 
+### Clean Code rules
+
+Adapted from [Wojtek Lukaszuk's clean-code summary](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29), itself a distillation of Robert C. Martin's *Clean Code*. The rules below are the working code-review checklist for this project. They sit alongside (not above) the Principles in this section.
+
+**General**
+- Follow standard conventions of the language and the surrounding code.
+- Keep it simple. Reduce complexity as much as possible. Simpler is always better.
+- Apply the Boy Scout Rule. Leave every file you touched cleaner than you found it.
+- Always find the root cause. A symptom-fix that doesn't explain the symptom is a bug waiting to recur.
+
+**Design**
+- Push configurable data to high levels (caller-controlled, not hard-coded deep in helpers).
+- Prefer polymorphism / dispatch tables to long `if/else` or `switch`. State machines belong in dedicated modules, not scattered conditionals.
+- Use dependency injection. Functions and modules receive their collaborators rather than reaching for globals or singletons.
+- Follow the Law of Demeter. A function should only call methods on: its parameters, its own object, objects it created, and its direct collaborators. No `a.b().c().d()` chains.
+- Don't over-configure. Flags, options, and toggles are debt; only add them when there's a real second use case.
+
+**Names**
+- Descriptive, unambiguous, pronounceable, searchable. `i`/`j`/`tmp` only in tight loops where the meaning is obvious.
+- Replace magic numbers with named constants in `src/utils/constants.ts` or a near-the-call `const`.
+- Make meaningful distinctions: `userInfo` vs `userData` is a smell. Pick one and use it everywhere.
+- Avoid type-encoding prefixes (`strName`, `IUser`).
+
+**Functions**
+- Small. If a function spans more than one screen, extract.
+- Do one thing. The function's name should fully describe what it does.
+- Prefer fewer arguments. Three is plenty; four is suspicious; five is a refactor.
+- Have no side effects beyond what the name says. A function called `validateUrl()` must not also write to localStorage.
+- No flag arguments (`function foo(bar, isBaz)`). Split into two functions with intention-revealing names.
+
+**Comments**
+- Always try to explain yourself in code first. Rename, extract, restructure.
+- Don't repeat what the code says. `// increment counter` next to `counter++` is noise.
+- Don't leave commented-out code. Delete it. Git remembers.
+- Use comments for *why*: hidden constraints, surprising performance trade-offs, references to bug reports or external specs.
+
+**Structure**
+- Separate concepts vertically with blank lines.
+- Related code stays vertically dense.
+- Declare variables close to where they're used. Top-of-function declaration blocks are an anti-pattern.
+- Functions called by another function should appear below it (top-down readability).
+- Keep lines short. Long lines force horizontal scrolling and hide intent.
+- Don't horizontally align `=` or types. The first time someone renames a variable, the alignment breaks.
+
+**Objects and data structures**
+- Hide internal structure (encapsulation). Don't return mutable references that callers can mutate behind your back.
+- Prefer data structures (plain TypeScript types/interfaces) for transport between modules; reserve classes for behaviour with invariants.
+- Small. Few instance variables. Single responsibility.
+- Prefer composition over inheritance. Inheritance is a strong coupling we rarely need.
+
+**Tests**
+- One logical assertion per test. (Multiple `expect()` lines for one assertion are fine; multiple assertions are not.)
+- Readable. A test is a worked example of how to use the unit under test.
+- Independent. No test should require another to have run first.
+- Repeatable. Same input, same outcome, every time. No clocks, no random unless seeded, no external network in unit tests.
+- Fast. Slow tests stop being run. The full suite is currently ~9s — keep it that way.
+
+**Code smells to avoid (vocabulary for code review)**
+- **Rigidity** — a small change cascades into many.
+- **Fragility** — a change in one place breaks unrelated places.
+- **Immobility** — code can't be reused because it's tangled with its current context.
+- **Needless complexity** — anticipated requirements that haven't materialised.
+- **Needless repetition** — copy-pasted code instead of extraction.
+- **Opacity** — code whose intent isn't clear at a glance.
+
 ### Key Patterns
 
 - All core functions return `Result<T>` types — never throw for expected errors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ No production code without a failing test. No commit without refactoring.
 ## Getting Started
 
 ```bash
-git clone https://github.com/user/feedzero.git
+git clone https://github.com/forcingfx/feedzero.git
 cd feedzero
-npm install
+npm ci
 npm run dev     # Dev server at http://localhost:3000
 npm test        # Run tests
 ```
@@ -23,19 +23,21 @@ npm test        # Run tests
 ## Running Tests
 
 ```bash
-npm test              # All unit/integration tests
+npm test              # All unit/integration tests (~9s)
 npm run test:watch    # Watch mode
-npm run test:coverage # Coverage report (90% threshold enforced)
+npm run test:coverage # Coverage report — thresholds enforced in CI
 npm run test:e2e      # Playwright E2E tests
-npx tsc --noEmit      # Type check
+npx tsc --noEmit      # Type check (strict)
 ```
 
 ## Code Style
 
 - TypeScript strict mode (no `any` except in type declarations for untyped libraries)
-- No ESLint/Prettier - TypeScript compiler is the primary static analysis tool
+- No ESLint/Prettier — TypeScript compiler is the primary static analysis tool
 - Self-documenting code: if you need a comment to explain *what*, rename or extract instead
 - Comments only for *why* (intent, trade-offs, non-obvious decisions)
+
+For the full code-review checklist (clean code rules, naming, function size, structure, code smells), see the **Clean Code rules** section of [`CLAUDE.md`](./CLAUDE.md). It is the source of truth for engineering style on this project.
 
 ## Architecture Guidelines
 
@@ -102,6 +104,10 @@ UI components subscribe to store slices. Stores call core modules directly. URL 
 - Analytics, telemetry, or tracking of any kind
 - Dependencies that make network calls without user action
 - UI redesigns without prior discussion
+
+## Reporting security issues
+
+Do not open a public issue for security vulnerabilities. Email `security@feedzero.app` with a description and reproduction steps. We respond within 48 hours and credit you publicly when fixed (with your consent).
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

PR #2 was merged into the bootstrap branch *after* it had already squashed into main, so the merge of #2 didn't reach main. This re-applies the substantive work onto main directly.

Three concerns:

1. **Clean Code rules** in CLAUDE.md — code-review checklist adapted from [Wojtek Lukaszuk's gist](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29). Sits *alongside* existing Principles.
2. **`.claude/` granular ignore** — `settings.local.json` (personal paths/permissions) stays hidden; `skills/` and `hooks/` are tracked because they describe shared workflows.
3. **CONTRIBUTING.md** — real GitHub URL, link to new Clean Code rules, security disclosure section.

## Test plan

- [x] CI green
- [x] `git ls-files .claude/` shows `skills/new-release/SKILL.md` and `hooks/rgr-check.sh`, NOT `settings.local.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)