### PR TITLE
fix(articles): pill spacing — clear the last article (GitLab #11)

### DIFF
--- a/src/components/articles/article-list.tsx
+++ b/src/components/articles/article-list.tsx
@@ -131,7 +131,10 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
       <ul
         role="listbox"
         aria-label="Articles"
-        className="list-none m-0 p-0 relative"
+        // pb-12 reserves space at the end of the list so the sticky "Mark N
+        // read" pill (h-7 + bottom-3 = ~40px) cannot overlap the last article
+        // when the user scrolls to the bottom. See GitLab #11.
+        className="list-none m-0 p-0 pb-12 relative"
         style={{ height: totalSize }}
       >
         {virtualItems.map((virtualItem) => {

--- a/tests/components/articles/article-list.test.tsx
+++ b/tests/components/articles/article-list.test.tsx
@@ -185,6 +185,33 @@ describe("ArticleList", () => {
     expect(scrollToSpy).not.toHaveBeenCalled();
   });
 
+  it("reserves bottom space inside the scroll container so the sticky 'Mark N read' pill does not overlap the last article", () => {
+    // The pill is `sticky bottom-3` with height `h-7`. Without bottom padding
+    // on the list, the last article sits flush against the pill at the end
+    // of the scroll container — that's GitLab #11. Reserving padding equal
+    // to or greater than the pill's height + offset keeps them apart.
+    useFeedStore.setState({
+      feeds: [],
+      selectedFeedId: "f1",
+      isLoading: false,
+      error: null,
+    });
+    useArticleStore.setState({
+      articles: [
+        mockArticle("a1", "First", false),
+        mockArticle("a2", "Second", false),
+      ],
+      selectedArticle: null,
+      isLoading: false,
+    });
+
+    const { container } = render(<ArticleList />);
+    const list = container.querySelector('ul[role="listbox"]');
+    expect(list).not.toBeNull();
+    // pb-12 = 48px ≥ pill height (h-7 = 28px) + bottom offset (bottom-3 = 12px).
+    expect(list!.className).toContain("pb-12");
+  });
+
   it("shows read/unread styling", () => {
     useFeedStore.setState({
       feeds: [],


### PR DESCRIPTION
## Summary
- Adds `pb-12` to the article list `<ul>` so the sticky **Mark N read** pill no longer overlaps the bottom border of the last article when the user is scrolled to the end of a long unread list.
- Closes GitLab issue forcingfx/feedzero#11.

## Why
The list `<ul>` had no bottom padding, so the virtualizer's `totalSize` ended flush with the scroll container. The pill (`h-7` + `bottom-3` ≈ 40px) is a sibling sticky element inside that same scroll container, and it visually overlapped the trailing items at the bottom of the scroll.

`pb-12` = 48px ≥ pill height (28px) + bottom offset (12px) with 8px of breathing room.

## Test plan
- [x] Unit: new tier-2 structural assertion in `tests/components/articles/article-list.test.tsx` verifies the listbox `<ul>` carries `pb-12`. RED before the fix, GREEN after.
- [x] `npm test` — 1467 passed, 2 skipped, 0 failures
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:e2e` — 76 passed, 1 skipped, 0 failures
- [ ] Manual smoke on `npm run dev`: scroll to end of a long unread list; pill no longer touches the last article

🤖 Generated with [Claude Code](https://claude.com/claude-code)