### PR TITLE
feat(feedback): submit on Cmd+Enter / Ctrl+Enter (GitLab #13)

### DIFF
--- a/src/components/feedback/feedback-dialog.tsx
+++ b/src/components/feedback/feedback-dialog.tsx
@@ -50,6 +50,16 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
     }
   }
 
+  // Cmd+Enter (mac) / Ctrl+Enter (others) submits without leaving the textarea.
+  // Plain Enter still inserts a newline so multi-line feedback stays natural.
+  function handleTextareaKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      if (isSending || !message.trim()) return;
+      void handleSubmit(e);
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -65,6 +75,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           <textarea
             value={message}
             onChange={(e) => setMessage(e.target.value)}
+            onKeyDown={handleTextareaKeyDown}
             placeholder="What's on your mind?"
             maxLength={MAX_LENGTH}
             rows={5}

--- a/tests/components/feedback/feedback-dialog.test.tsx
+++ b/tests/components/feedback/feedback-dialog.test.tsx
@@ -134,4 +134,76 @@ describe("FeedbackDialog", () => {
     // no fetch should fire.
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  describe("keyboard submit (GitLab #13)", () => {
+    it("submits on Cmd+Enter inside the textarea", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+
+      const textarea = screen.getByPlaceholderText("What's on your mind?");
+      await userEvent.type(textarea, "shipped via Cmd+Enter");
+      await userEvent.keyboard("{Meta>}{Enter}{/Meta}");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ message: "shipped via Cmd+Enter" }),
+        }),
+      );
+    });
+
+    it("submits on Ctrl+Enter inside the textarea", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+
+      const textarea = screen.getByPlaceholderText("What's on your mind?");
+      await userEvent.type(textarea, "shipped via Ctrl+Enter");
+      await userEvent.keyboard("{Control>}{Enter}{/Control}");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ message: "shipped via Ctrl+Enter" }),
+        }),
+      );
+    });
+
+    it("does not submit on plain Enter (newline only)", async () => {
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+
+      const textarea = screen.getByPlaceholderText("What's on your mind?");
+      await userEvent.type(textarea, "first line");
+      await userEvent.keyboard("{Enter}");
+      await userEvent.type(textarea, "second line");
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect((textarea as HTMLTextAreaElement).value).toBe(
+        "first line\nsecond line",
+      );
+    });
+
+    it("does not submit on Cmd+Enter with empty/whitespace message", async () => {
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+
+      const textarea = screen.getByPlaceholderText("What's on your mind?");
+      await userEvent.type(textarea, "   ");
+      await userEvent.keyboard("{Meta>}{Enter}{/Meta}");
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds Cmd+Enter (mac) / Ctrl+Enter keyboard submit to the feedback textarea so users can send feedback without grabbing the mouse.
- Plain Enter still inserts a newline; whitespace-only and `isSending` states are respected.
- Closes part of GitLab issue forcingfx/feedzero#13 (the keyboard-submit half — sidebar resize on /explore is a separate PR).

## Why
The dialog auto-focuses the textarea on open but offered no way to submit from the keyboard. Users with anything more than a one-word note had to tab or mouse to the Send button, breaking flow.

## Test plan
- [x] Unit: 4 new tests in `tests/components/feedback/feedback-dialog.test.tsx`
  - Cmd+Enter submits
  - Ctrl+Enter submits
  - Plain Enter does not submit (inserts newline)
  - Cmd+Enter with whitespace-only message does not submit
- [x] `npm test` — 1470 passed, 2 skipped, 0 failures
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke on `npm run dev`: open feedback dialog, type, press Cmd+Enter (Mac) / Ctrl+Enter — submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)