### PR TITLE
fix(layout): persist panel widths and stop sidebar resize on /explore

### DIFF
--- a/src/pages/feeds-page.tsx
+++ b/src/pages/feeds-page.tsx
@@ -6,7 +6,7 @@ import { useIsDesktop } from "@/hooks/use-media-query.ts";
 import { useKeyboardNav } from "@/hooks/use-keyboard-nav.ts";
 import { useSidebar } from "@/components/ui/sidebar.tsx";
 import { ScrollArea } from "@/components/ui/scroll-area.tsx";
-import { ALL_FEEDS_ID } from "@/utils/constants.ts";
+import { ALL_FEEDS_ID, PANEL_LAYOUT_ID } from "@/utils/constants.ts";
 import { findNextArticle, findPrevArticle } from "@/lib/next-article.ts";
 import {
   ResizablePanelGroup,
@@ -293,12 +293,19 @@ export function FeedsPage() {
   // and participates naturally in the panel layout.
   const exploreOrEmpty = isExplorePage || feeds.length === 0;
   const showStats = isStatsPage;
+  // Distinct group ids per layout shape: react-resizable-panels persists
+  // panel widths under this id, so the 3-panel feeds layout and the 2-panel
+  // explore/stats layout must not share an id (otherwise switching layouts
+  // visibly rebalances the sidebar — see GitLab #13a).
+  const layoutId =
+    showStats || exploreOrEmpty ? PANEL_LAYOUT_ID.SINGLE : PANEL_LAYOUT_ID.FEEDS;
 
   return (
     <SidebarProvider className="h-svh overflow-hidden">
       <SidebarKeyboardToggle />
-      <ResizablePanelGroup direction="horizontal" className="h-svh">
+      <ResizablePanelGroup id={layoutId} direction="horizontal" className="h-svh">
         <ResizablePanel
+          id="sidebar"
           defaultSize="17%"
           minSize="150px"
           maxSize="280px"
@@ -312,13 +319,13 @@ export function FeedsPage() {
         </ResizablePanel>
         <ResizableHandle />
         {showStats ? (
-          <ResizablePanel className="overflow-hidden">
+          <ResizablePanel id="stats" className="overflow-hidden">
             <ScrollArea className="h-full">
               <Suspense><StatsPage /></Suspense>
             </ScrollArea>
           </ResizablePanel>
         ) : exploreOrEmpty ? (
-          <ResizablePanel className="overflow-hidden">
+          <ResizablePanel id="explore" className="overflow-hidden">
             <ScrollArea className="h-full">
               <Suspense><ExploreCatalog onFeedAdded={handleFeedAdded} /></Suspense>
             </ScrollArea>
@@ -326,6 +333,7 @@ export function FeedsPage() {
         ) : (
           <>
             <ResizablePanel
+              id="article-list"
               defaultSize="33%"
               minSize="180px"
               className="overflow-hidden"
@@ -334,6 +342,7 @@ export function FeedsPage() {
             </ResizablePanel>
             <ResizableHandle />
             <ResizablePanel
+              id="reader"
               defaultSize="50%"
               minSize="200px"
               className="overflow-hidden"

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,6 +71,19 @@ export const LOCAL_STORAGE = {
   AUTO_ORGANIZE_DISMISSED_COUNT: "feedzero:auto-organize-dismissed-count",
 } as const;
 
+/**
+ * Group ids for the desktop ResizablePanelGroup. Each layout shape gets its own
+ * id so react-resizable-panels persists widths independently — switching from
+ * the 3-panel feeds layout to the 2-panel explore/stats layout must not
+ * clobber the user's preferred sidebar/article-list/reader proportions.
+ */
+export const PANEL_LAYOUT_ID = {
+  /** 3-panel: sidebar + article list + reader. */
+  FEEDS: "feedzero:layout:feeds",
+  /** 2-panel: sidebar + single content area (explore or stats). */
+  SINGLE: "feedzero:layout:single",
+} as const;
+
 const textEncoder = new TextEncoder();
 
 export const SYNC = {

--- a/tests/components/layout/feeds-page-layout.test.tsx
+++ b/tests/components/layout/feeds-page-layout.test.tsx
@@ -193,6 +193,49 @@ describe("FeedsPage layout — desktop", () => {
     expect(handles).toHaveLength(2);
   });
 
+  it("each ResizablePanel has a stable id so the layout library can persist sizes across re-renders", () => {
+    // Without stable ids, react-resizable-panels falls back to useId() and
+    // generates fresh keys on every mount/route change — which breaks
+    // persistence and causes a visible re-balance when the panel count
+    // changes (e.g. switching to /explore drops the reader panel).
+    const { container } = renderPage();
+    const panels = container.querySelectorAll("[data-panel]");
+    expect(panels).toHaveLength(3);
+    const ids = Array.from(panels).map((p) => p.getAttribute("id"));
+    expect(ids).toEqual(
+      expect.arrayContaining(["sidebar", "article-list", "reader"]),
+    );
+    // No id should be auto-generated (react useId values start with ":r")
+    for (const id of ids) {
+      expect(id).not.toMatch(/^:/);
+    }
+  });
+
+  it("uses the 3-panel layout id on the feeds route so widths persist independently of the explore layout", () => {
+    // The Group must carry a stable id matching the layout shape; switching
+    // to /explore (which drops the reader) must use a different id so widths
+    // for each layout are remembered separately.
+    const { container } = renderPage("/feeds/f1");
+    const group = container.querySelector("[data-slot='resizable-panel-group']");
+    expect(group).not.toBeNull();
+    expect(group!.getAttribute("id")).toBe("feedzero:layout:feeds");
+  });
+
+  it("uses the single-content layout id on the explore route", () => {
+    const { container } = renderPage("/explore");
+    const group = container.querySelector("[data-slot='resizable-panel-group']");
+    expect(group).not.toBeNull();
+    expect(group!.getAttribute("id")).toBe("feedzero:layout:single");
+  });
+
+  it("explore layout exposes stable ids for sidebar and explore panels", () => {
+    const { container } = renderPage("/explore");
+    const panels = container.querySelectorAll("[data-panel]");
+    expect(panels).toHaveLength(2);
+    const ids = Array.from(panels).map((p) => p.getAttribute("id"));
+    expect(ids).toEqual(expect.arrayContaining(["sidebar", "explore"]));
+  });
+
   it("sidebar CSS variable is at most 14rem so three panels fit at 1024px", () => {
     // At 1024px: sidebar (≤14rem = 224px) + article list (≥180px) + reader (≥200px)
     // = 224 + 180 + 200 = 604px — well within 1024px. If the sidebar grows beyond


### PR DESCRIPTION
## Summary

Fixes two GitLab-tracked desktop layout bugs by giving the `ResizablePanelGroup` and every `ResizablePanel` stable ids.

- **GitLab #10** — Panel widths are lost on reload because `react-resizable-panels` falls back to `useId()` when no `id` is supplied, so its persistence keys change every mount.
- **GitLab #13a** — Switching to `/explore` (or `/stats`) drops the reader panel; without stable ids the library re-balances flex math from scratch and the sidebar visibly resizes.

## Changes

- Added stable `id` to every `ResizablePanel`: `sidebar`, `article-list`, `reader`, `explore`, `stats`.
- Added a `PANEL_LAYOUT_ID` constant (`feedzero:layout:feeds`, `feedzero:layout:single`) and applied it to the `ResizablePanelGroup` so each layout shape persists independently.
- New structural assertions in `tests/components/layout/feeds-page-layout.test.tsx` verify the ids and the correct per-route group id.

## Test plan

- [x] `npm test` (1470 passed, 2 skipped)
- [x] `npx tsc --noEmit` (clean)
- [ ] Manual: drag a column on `/feeds`, reload, confirm width persists.
- [ ] Manual: drag the sidebar on `/feeds`, navigate to `/explore`, confirm sidebar does not jump; navigate back to `/feeds` and confirm both layouts remember their own widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)