### PR TITLE
fix(articles): keep scroll position when clicking a visible article

### DIFF
--- a/src/components/articles/article-list.tsx
+++ b/src/components/articles/article-list.tsx
@@ -87,6 +87,16 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
   // off-screen items once the user scrolls) and the initial reveal of a
   // selection that was restored from URL state. NOT for click-driven
   // selection — see skipNextAutoScroll above.
+  //
+  // Deps are intentionally limited to `selectedId`: the auto-scroll must
+  // run only when the selection itself changes, not when the `articles`
+  // array reference changes. If we depended on `articles`, any unrelated
+  // mutation (auto-mark-as-read after selection, refresh, sync push) would
+  // re-fire the effect with the click-skip flag already consumed, and
+  // re-anchor the list to the previously-selected (now off-screen) article
+  // — see GitLab #12. We read the latest articles via a ref instead.
+  const articlesRef = useRef(articles);
+  articlesRef.current = articles;
   const selectedId = selectedArticle?.id;
   useEffect(() => {
     if (!selectedId) return;
@@ -94,9 +104,9 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
       skipNextAutoScroll.current = false;
       return;
     }
-    const index = articles.findIndex((a) => a.id === selectedId);
+    const index = articlesRef.current.findIndex((a) => a.id === selectedId);
     if (index !== -1) virtualizer.scrollToIndex(index, { align: "auto" });
-  }, [selectedId, articles, virtualizer]);
+  }, [selectedId, virtualizer]);
 
   // Empty/loading states render inside the scroll wrapper so the panel
   // layout stays consistent whether or not there are articles — callers

--- a/tests/components/articles/article-list.test.tsx
+++ b/tests/components/articles/article-list.test.tsx
@@ -212,6 +212,59 @@ describe("ArticleList", () => {
     expect(list!.className).toContain("pb-12");
   });
 
+  it("clicking a visible article does not re-anchor the virtualizer to the previously-selected (off-screen) article (GitLab #12)", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [],
+      selectedFeedId: "f1",
+      isLoading: false,
+      error: null,
+    });
+    // Long list so the virtualizer renders only a window of items.
+    const articles = Array.from({ length: 200 }, (_, i) =>
+      mockArticle(`a${i}`, `Article ${i}`),
+    );
+    // Pre-select the first article. The user has scrolled it off-screen.
+    useArticleStore.setState({
+      articles,
+      selectedArticle: articles[0],
+      isLoading: false,
+    });
+
+    const { container } = render(<ArticleList />);
+    const scrollEl = container.querySelector(".overflow-y-auto") as HTMLElement;
+    const virtualizerScrollSpy = vi.fn();
+    scrollEl.scrollTo = virtualizerScrollSpy as unknown as typeof scrollEl.scrollTo;
+    // Stub scrollBy as well — some virtualizer code paths use it.
+    scrollEl.scrollBy = vi.fn() as unknown as typeof scrollEl.scrollBy;
+
+    // Now mutate the articles array — this simulates anything that changes
+    // the array reference *without* changing the selection: the auto-mark-
+    // as-read timer firing, a refresh updating an article, sync push, etc.
+    // The selection is unchanged; the user has not re-selected anything.
+    // The list MUST NOT scroll just because the array reference changed.
+    const updatedArticles = articles.map((a) =>
+      a.id === "a0" ? { ...a, read: true } : a,
+    );
+    useArticleStore.setState({ articles: updatedArticles });
+
+    // Allow React to flush the effect triggered by the articles change.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Now click a still-visible article. The selection changes from a0 to
+    // whatever is rendered first. handleSelect sets the skip flag, so no
+    // scroll should happen for THIS selection change either.
+    const visibleOptions = screen.getAllByRole("option");
+    await user.click(visibleOptions[0]);
+
+    // Across the whole interaction (articles mutation + click), the list
+    // must never have re-anchored the scroll position. The bug was: a stray
+    // articles-reference-change effect call, plus the click effect, both
+    // calling scrollToIndex(previouslySelected) and bringing it back into
+    // view.
+    expect(virtualizerScrollSpy).not.toHaveBeenCalled();
+  });
+
   it("shows read/unread styling", () => {
     useFeedStore.setState({
       feeds: [],


### PR DESCRIPTION
## Summary

Fixes GitLab #12: when the user scrolled the article list so the currently-selected article was off-screen, then clicked a still-visible article, the list scroll position jumped to bring the previously-selected (off-screen) article back into view.

## Root cause

`ArticleList`'s auto-scroll-into-view effect depended on both `selectedId` *and* `articles`. The one-shot `skipNextAutoScroll` flag set by `handleSelect` was correctly consumed when the selection-change effect ran. But `selectArticle` schedules an auto-mark-as-read mutation that later replaces the article object in `articlesByFeedId`, changing the `articles` array reference. That fired the same effect a second time with the flag already false, calling `virtualizer.scrollToIndex(...)` and re-anchoring the list to the previously-selected article.

## Fix

Drop `articles` from the effect's dependency array and read the latest array via a ref. The auto-scroll-into-view contract is "scroll when the *selection* changes" — array-reference changes are not a selection change and must not trigger it.

## Test plan

- [x] New regression test in `tests/components/articles/article-list.test.tsx`: mutates the `articles` array (simulating auto-mark-as-read) before clicking a visible article and asserts the scroll container is never scrolled. Fails on `main`, passes with the fix.
- [x] Existing "clicking an article does not snap-scroll the list" test still passes.
- [x] All 1467 unit/integration tests pass.
- [x] `npx tsc --noEmit` clean.
- [ ] CI runs Playwright E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)