### PR TITLE
fix(reader): reset scroll to top when switching articles

### DIFF
--- a/src/components/reader/reader-panel.tsx
+++ b/src/components/reader/reader-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, type ReactNode } from "react";
 import { useIsDesktop } from "@/hooks/use-media-query.ts";
 import { ChevronLeft, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
 import { decodeEntities } from "@/lib/decode-entities.ts";
@@ -57,8 +57,14 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-  // Reset scroll and view mode when article changes
-  useEffect(() => {
+  // Reset scroll and view mode when article changes.
+  //
+  // useLayoutEffect (not useEffect) is required: the scroll reset must run
+  // synchronously after the DOM mutation but BEFORE the browser paints the
+  // new article. With useEffect the user briefly sees article B at the
+  // previous (article A) scroll offset before the position snaps back to 0.
+  // See GitLab #8.
+  useLayoutEffect(() => {
     resetForArticle();
     if (scrollContainerRef.current) scrollContainerRef.current.scrollTop = 0;
   }, [article?.id, resetForArticle]);
@@ -126,11 +132,18 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
 
   // Wraps empty/loading states in the flex column so layout is stable and the
   // nav bar (including back button) is always visible when onNavigate is provided.
+  // The scroll container shares its ref + testid with the loaded-article path
+  // so the scroll-reset effect always targets a stable element across state
+  // transitions (loading → article).
   function wrap(content: ReactNode) {
     if (onNavigate) {
       return (
         <div className="h-full flex flex-col">
-          <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-y-none">
+          <div
+            ref={scrollContainerRef}
+            data-testid="reader-scroll-container"
+            className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-y-none"
+          >
             {content}
           </div>
           {navPills}

--- a/tests/components/reader/reader-panel.test.tsx
+++ b/tests/components/reader/reader-panel.test.tsx
@@ -474,6 +474,107 @@ describe("ReaderPanel", () => {
     });
   });
 
+  describe("scroll reset on article change (GitLab #8)", () => {
+    const articleA = mockArticle({ id: "a1", title: "Article A" });
+    const articleB = mockArticle({
+      id: "a2",
+      title: "Article B",
+      link: "https://example.com/b",
+    });
+
+    beforeEach(() => {
+      mockIsDesktop = true;
+    });
+
+    it("resets reader scroll to top when switching articles", () => {
+      useArticleStore.setState({
+        selectedArticle: articleA,
+        articles: [articleA, articleB],
+        isLoading: false,
+      });
+
+      const { rerender } = render(
+        <ReaderPanel nextArticle={articleB} onNavigate={vi.fn()} />,
+      );
+
+      const scrollContainer = document.querySelector(
+        "[data-testid='reader-scroll-container']",
+      ) as HTMLDivElement | null;
+      expect(scrollContainer).not.toBeNull();
+
+      // User scrolls into article A.
+      scrollContainer!.scrollTop = 500;
+      expect(scrollContainer!.scrollTop).toBe(500);
+
+      // User selects article B (mimicking j/k or click on article list).
+      act(() => {
+        useArticleStore.setState({ selectedArticle: articleB });
+      });
+
+      rerender(<ReaderPanel nextArticle={articleB} onNavigate={vi.fn()} />);
+
+      const scrollAfter = document.querySelector(
+        "[data-testid='reader-scroll-container']",
+      ) as HTMLDivElement;
+      expect(scrollAfter.scrollTop).toBe(0);
+    });
+
+    it("loading-state scroll container exposes the same testid as the article container", () => {
+      // The reset effect targets a single scroll container by ref. When the
+      // panel is in its loading/empty wrap() path, that container must still
+      // be discoverable so React reuses it across renders. Without a stable
+      // testid both branches share, the user-visible scroll position can leak
+      // across the loading→article transition.
+      useArticleStore.setState({
+        selectedArticle: null,
+        articles: [],
+        isLoading: true,
+      });
+      render(<ReaderPanel nextArticle={articleB} onNavigate={vi.fn()} />);
+      expect(
+        document.querySelector("[data-testid='reader-scroll-container']"),
+      ).not.toBeNull();
+    });
+
+    it("resets reader scroll to top when transitioning from loading to article", () => {
+      // Reproduces GitLab #8 path: loading state renders a scroll container
+      // WITHOUT the ref, then the article arrives and a different scroll
+      // container is mounted. The new container must start at scrollTop 0
+      // even though the previous (refless) one had been scrolled by the user.
+      useArticleStore.setState({
+        selectedArticle: null,
+        articles: [],
+        isLoading: true,
+      });
+
+      const { rerender } = render(
+        <ReaderPanel nextArticle={articleB} onNavigate={vi.fn()} />,
+      );
+
+      // Loading-state scroll container (no ref, in wrap()).
+      const loadingScrollEl = document
+        .querySelectorAll(".overflow-y-auto")[0] as HTMLDivElement | undefined;
+      expect(loadingScrollEl).toBeDefined();
+      // User had scrolled the previous article before this navigation began.
+      loadingScrollEl!.scrollTop = 500;
+
+      // Article arrives.
+      act(() => {
+        useArticleStore.setState({
+          selectedArticle: articleA,
+          articles: [articleA, articleB],
+          isLoading: false,
+        });
+      });
+      rerender(<ReaderPanel nextArticle={articleB} onNavigate={vi.fn()} />);
+
+      const scrollAfter = document.querySelector(
+        "[data-testid='reader-scroll-container']",
+      ) as HTMLDivElement;
+      expect(scrollAfter.scrollTop).toBe(0);
+    });
+  });
+
   describe("mobile navigation pills", () => {
     const nextArt = { ...mockArticle(), id: "a2", title: "Next Article" };
     const prevArt = { ...mockArticle(), id: "a0", title: "Prev Article" };


### PR DESCRIPTION
## Summary
Fixes GitLab #8: navigating from article A (scrolled mid-page) to article B opened article B at A's scroll offset.

- Switched scroll-reset effect from `useEffect` to `useLayoutEffect` so the reset happens before the browser paints — eliminates the visible flash.
- Attached `scrollContainerRef` + matching `data-testid` to `wrap()`'s scroll container so the loading/empty path and the loaded-article path share one stable scroll element. The reset effect can now always target it across loading → article transitions.

## Root cause
- `useEffect` runs after paint, so the user briefly saw the new article rendered at the old scroll position before it snapped back to 0.
- `wrap()` rendered a separate scroll container without the ref, so on loading → article transitions the reset effect silently no-op'd.

## Test plan
- [x] `npm test` — 1469 passed, 2 skipped
- [x] `npx tsc --noEmit` — clean
- [x] New regression tests cover article→article switch and loading→article transition
- [ ] Manual visual check on a long article: scroll to middle, press `j`, confirm B opens at top with no flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)