### PR TITLE
ci: add e2e, security, and dependabot workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # JavaScript/TypeScript dependencies — group minor + patch into one PR per
+  # week to keep noise low; majors get their own PR for review.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: main
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions versions — group everything into one weekly PR.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: main
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,45 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Playwright E2E (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Playwright config defines two projects (desktop + mobile), both Chromium.
+      - name: Install Playwright browser (chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,66 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Weekly Monday 06:00 UTC — catches new advisories against the locked tree.
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codeql:
+    name: CodeQL (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"
+
+  audit-and-secrets:
+    name: npm audit + gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # gitleaks history scan needs full git history.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Matches the existing CI gate in ci.yml — production deps only, high+.
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Gitleaks history scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          # Open-source invocation — no GITLEAKS_LICENSE for solo repos.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Implements the remaining GitHub-side gates from `docs/internal/strategy.md` §10.3:

- **`.github/workflows/e2e.yml`** — Playwright E2E (chromium) on PR + push to `main`. Uploads `playwright-report/` as an artifact on failure. Per-ref concurrency cancellation to save minutes.
- **`.github/workflows/security.yml`**
  - `codeql` job: CodeQL `init@v3` + `analyze@v3` for `javascript-typescript`, with the required `security-events: write` / `actions: read` / `contents: read` permissions.
  - `audit-and-secrets` job: `npm audit --omit=dev --audit-level=high` (matches the existing CI gate in `ci.yml`) plus a gitleaks history scan via `gitleaks/gitleaks-action@v2` (open-source invocation; no `GITLEAKS_LICENSE`).
  - Triggers: PR, push to `main`, weekly Monday 06:00 UTC cron.
- **`.github/dependabot.yml`** — weekly npm + github-actions updates, target `main`, minor/patch grouped into one PR per ecosystem, majors as separate PRs, open-PR limit 5 each.

No source files touched: existing `Tests & type check` and `Build (SPA + serverless functions)` checks should remain green.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 1479 passed / 2 skipped
- [x] YAML syntax validated locally with `js-yaml`
- [ ] New `E2E` and `Security` workflows execute on this PR
- [ ] `Tests & type check` and `Build (SPA + serverless functions)` remain green

Refs: `docs/internal/strategy.md` §10.3 (and §9.3 CI workflow conventions).