### PR TITLE
chore(repo): repo hygiene — CODEOWNERS, PR/issue templates, SECURITY/CONTRIBUTING

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @forcingfx

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report a defect in FeedZero
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more we can reproduce, the faster we can fix.
+
+        For security issues, please **do not** file a public issue — use
+        https://github.com/forcingfx/feedzero/security/advisories/new instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the bug.
+      placeholder: When I clicked "Add feed", the modal closed but the feed never appeared in the sidebar.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps that let us reproduce the issue.
+      placeholder: |
+        1. Open the app at https://feedzero.app
+        2. Click "Add feed"
+        3. Paste a valid RSS URL
+        4. Click "Add"
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser + version
+      description: e.g. "Firefox 128.0.3 on macOS 14.5"
+      placeholder: Firefox 128.0.3 on macOS 14.5
+
+  - type: input
+    id: reader-version
+    attributes:
+      label: Reader version
+      description: Visible in Settings.
+      placeholder: 0.10.2
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Console errors, screenshots, network logs, anything else useful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/forcingfx/feedzero/security/advisories/new
+    about: For sensitive disclosures, open a private GitHub Security Advisory instead of a public issue.
+  - name: General support
+    url: mailto:support@feedzero.app
+    about: For account, billing, or general help. (Address provisioning may lag this template — see SECURITY.md if it bounces.)

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a new capability or improvement
+title: "feature: "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. We prioritise features that solve a clear user need.
+        Vague "would be nice" requests are likely to sit. Specific user needs get attention.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user need does this address? Whose problem is it, and how does it bite them today?
+      placeholder: As a user reading 200+ feeds, I need a way to mute a feed for a week without unsubscribing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Optional. If you have a concrete idea, sketch it out.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. What else did you try, and why does it not work?

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,51 @@
+name: Security discussion
+description: Public discussion of an already-disclosed security issue
+title: "security: "
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **For sensitive disclosures, do not use this template.**
+        > Use https://github.com/forcingfx/feedzero/security/advisories/new instead, or
+        > email security@feedzero.app. See [SECURITY.md](../../SECURITY.md) for the full policy.
+        >
+        > This template is for **public discussion of issues that have already been disclosed**
+        > (e.g. via a published advisory or coordinated release).
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Your best estimate. We may revise after triage.
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the issue? What is the impact on FeedZero users?
+    validations:
+      required: true
+
+  - type: input
+    id: affected-versions
+    attributes:
+      label: Affected versions
+      description: Which versions are vulnerable? Visible in Settings.
+      placeholder: 0.9.0 through 0.10.1
+
+  - type: textarea
+    id: poc
+    attributes:
+      label: Proof of concept
+      description: |
+        Optional. A minimal reproduction.
+        **Do not include a working exploit if the issue is not yet patched** — open a private
+        advisory at https://github.com/forcingfx/feedzero/security/advisories/new instead.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+<!--
+  Thanks for the PR. Keep this template short — fill in what's relevant, delete the rest.
+  See CONTRIBUTING.md and CLAUDE.md for the full development workflow (RGR is mandatory).
+-->
+
+## Summary
+
+-
+-
+
+## Why
+
+<!-- Link a GitHub issue, GitLab issue, or describe the user-facing reason in one sentence. -->
+
+## Test plan
+
+- [ ] RED test exists (failing test added before production code)
+- [ ] GREEN minimal (smallest code to make the test pass)
+- [ ] REFACTOR done (Boy Scout Rule applied to touched files)
+- [ ] `npm test` green
+- [ ] `npx tsc --noEmit` clean
+- [ ] Smoke tested in a real browser if the change is user-visible
+
+## API change checklist (delete if no API change)
+
+When changing `/api/*` request format, HTTP method, URL structure, or headers, all three entry points must be updated and verified — see CLAUDE.md "Three-entry-point rule".
+
+- [ ] Shared handler updated (`src/core/proxy/proxy-handler.ts` or `src/core/sync/sync-handler.ts`)
+- [ ] Hono server updated (`server.ts`)
+- [ ] Vite dev proxy updated (`vite.config.js`)
+- [ ] Vercel wrapper(s) updated (`api/*.ts`) — every supported HTTP method exported
+- [ ] Routing contract test in `tests/server.test.ts` still passes
+
+## Deployment / rollback
+
+- [ ] Safe to deploy on merge (no migration coupling)
+- [ ] Rollback path: Vercel → Deployments → "Promote previous deployment" (instant)
+- [ ] Notes for on-call (env vars added, kill switches affected, etc.):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,16 @@
 # Contributing to FeedZero
 
+[`CLAUDE.md`](./CLAUDE.md) is the source of truth for how this codebase is developed. This document is a quick-start that links into it — when in doubt, the longer doc wins.
+
 ## Development Workflow
 
 This project follows **Red-Green-Refactor (RGR)** for all code changes:
 
-1. **RED** - Write a failing test first
-2. **GREEN** - Write minimal code to make it pass
-3. **REFACTOR** - Clean up the code (this step is mandatory)
+1. **RED** — Write a failing test first
+2. **GREEN** — Write minimal code to make it pass
+3. **REFACTOR** — Clean up the code (this step is mandatory)
 
-No production code without a failing test. No commit without refactoring.
+No production code without a failing test. No commit without refactoring. The full sequence (PLAN → RED → GREEN → VERIFY → REFACTOR → DOCUMENT) is in [CLAUDE.md → Development Workflow](./CLAUDE.md#development-workflow).
 
 ## Getting Started
 
@@ -82,13 +84,13 @@ UI components subscribe to store slices. Stores call core modules directly. URL 
    npm run test:e2e  # If touching UI
    ```
 
-4. **Write descriptive commits**:
-   - Use conventional prefixes: `feat:`, `fix:`, `test:`, `docs:`, `refactor:`, `chore:`
-   - For bug fixes, include: What (symptom), Why (root cause), Fix (what changed), Prevention (tests added)
+4. **Write descriptive commits**: Conventional prefixes (`feat:`, `fix:`, `test:`, `docs:`, `refactor:`, `chore:`); bug fixes need What / Why / Fix / Prevention. Full rules in [CLAUDE.md → Commit Messages](./CLAUDE.md#commit-messages).
 
-5. **Keep PRs focused**: One feature or fix per PR. Split large changes.
+5. **Open the PR**: The [pull request template](.github/pull_request_template.md) walks through the RGR + smoke-test checklist and the three-entry-point checklist for API changes. Tick the boxes that apply, delete the sections that don't.
 
-6. **Update documentation**: If you changed behavior, update `docs/` to match.
+6. **Keep PRs focused**: One feature or fix per PR. Split large changes.
+
+7. **Update documentation**: If you changed behavior, update `docs/` to match.
 
 ## What We're Looking For
 
@@ -107,7 +109,7 @@ UI components subscribe to store slices. Stores call core modules directly. URL 
 
 ## Reporting security issues
 
-Do not open a public issue for security vulnerabilities. Email `security@feedzero.app` with a description and reproduction steps. We respond within 48 hours and credit you publicly when fixed (with your consent).
+Do not open a public issue for security vulnerabilities. See [SECURITY.md](./SECURITY.md) for the disclosure policy — preferred channel is a private [GitHub Security Advisory](https://github.com/forcingfx/feedzero/security/advisories/new); email `security@feedzero.app` is also accepted.
 
 ## Questions?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,17 +8,28 @@ All claims are verifiable from source code. A [source reference table](#source-v
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in FeedZero, please report it responsibly:
+FeedZero is used by journalists, activists, and people living under surveillance. **FeedZero protects people. Act accordingly.** If you find something, please tell us privately — public disclosure of an unpatched flaw can cost real users their safety.
 
-1. **Do not** open a public GitHub issue
-2. Email the maintainers directly (see repository owner's profile for contact info)
-3. Include:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if any)
+Two private reporting channels:
 
-We aim to respond within 48 hours and will work with you to understand and address the issue.
+1. **GitHub Security Advisories (preferred):** https://github.com/forcingfx/feedzero/security/advisories/new
+2. **Email:** `security@feedzero.app` (PGP key: TBD — until then, treat the channel as transit-encrypted only and avoid pasting sensitive PoC payloads)
+
+Please **do not** open a public GitHub issue or discuss the issue on social media until a fix has shipped.
+
+Include:
+- A description of the vulnerability and its impact
+- Steps to reproduce (or a minimal PoC)
+- Affected versions if known
+- Any suggested mitigation
+
+We aim to acknowledge within 48 hours and to ship a fix within the disclosure timeline below.
+
+### Disclosure timeline
+
+- **Standard:** 90 days from initial report to public disclosure.
+- **May extend** when user impact requires (e.g. coordinated disclosure with downstream packages, complex remediation, or active exploitation in the wild).
+- We will credit reporters publicly when the fix ships, with your consent.
 
 ## Scope
 
@@ -28,7 +39,8 @@ The following are in scope for security reports:
 |------|----------|
 | **Cryptographic issues** | Weak key derivation, IV reuse, encryption bypass |
 | **XSS vulnerabilities** | Bypassing DOMPurify sanitization, script injection via feeds |
-| **SSRF in proxy** | Bypassing private IP blocking, accessing internal resources |
+| **SSRF in proxy** | Bypassing private IP blocking, accessing internal resources via `/api/feed`, `/api/page`, or `/api/icon` |
+| **Privacy leaks via the proxy** | Logging of feed URLs or user IPs, header leakage to upstream feed publishers |
 | **Data leakage** | Unintended data exposure to server, logging of sensitive data |
 | **Authentication bypass** | Accessing another user's encrypted vault |
 
@@ -36,7 +48,8 @@ The following are **out of scope**:
 
 - Social engineering attacks
 - Physical access attacks (if someone has your device, derived keys in localStorage can decrypt local data — but cannot recover the passphrase or access the cloud vault)
-- Denial of service (the app is client-side; there's no meaningful DoS vector)
+- Volumetric DDoS (mitigated at the edge by Cloudflare; please report to Cloudflare directly)
+- Missing security headers below high severity, where no exploit path is demonstrated
 - Issues in dependencies without a demonstrated exploit path in FeedZero
 
 ---


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS`, PR template, and bug/feature/security issue forms (with `config.yml` steering blank issues away and toward security advisories).
- Sharpens `SECURITY.md` reporting block (private GitHub Security Advisory + `security@feedzero.app`, 90-day disclosure timeline, scope updates) without losing the existing technical content.
- Updates `CONTRIBUTING.md` to point at `CLAUDE.md` as the source of truth, link the new PR template, and route security reports through `SECURITY.md`.

## Why

Phase -1 repo hygiene from the internal strategy doc — `docs/internal/strategy.md` §10.4 (repository hygiene checklist) and §9.5 (one-time hygiene during Phase -1). These are prereqs before Phase 0 because the rest of the operational stack assumes GitHub-native workflows (CODEOWNERS for review routing, issue templates for triage, PR template for the RGR + three-entry-point checklist).

PR H of a four-PR Phase -1 batch (F/G/J in flight in sister worktrees). Scope deliberately excludes `.github/workflows/*`, `.github/dependabot.yml`, husky, package.json, and the API/flag plumbing — those are owned by sibling PRs.

## Test plan

- [x] RED test exists — N/A, no production code changed
- [x] GREEN minimal — only docs + GitHub config
- [x] REFACTOR done — Boy Scout pass on `SECURITY.md` and `CONTRIBUTING.md`
- [x] `npm test` green (1479 passed, 2 skipped, ~10.5s)
- [x] `npx tsc --noEmit` clean
- [x] YAML templates parse cleanly via `yaml.safe_load`

## API change checklist

N/A — no API surface touched.

## Deployment / rollback

- Safe to merge: docs + GitHub repo config only. No runtime impact, no Vercel deploy implications.
- Rollback: revert the merge commit. Issue templates + PR template are activated on next issue/PR creation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)