### PR TITLE
feat(observability): add /api/health endpoint and first-pass kill switches

### DIFF
--- a/api/health.ts
+++ b/api/health.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+// api/health.ts
+function isFlagEnabled(name, env = process.env) {
+  return env[name] === "1";
+}
+function resolveVersion() {
+  const viteVersion = readViteAppVersion();
+  if (viteVersion) return viteVersion;
+  return process.env.APP_VERSION ?? "unknown";
+}
+function readViteAppVersion() {
+  try {
+    const env = import.meta.env;
+    return env?.VITE_APP_VERSION;
+  } catch {
+    return void 0;
+  }
+}
+function jsonHealthResponse(body, status) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store"
+    }
+  });
+}
+function handleHealthRequest(_request) {
+  const body = {
+    ok: true,
+    version: resolveVersion(),
+    time: (/* @__PURE__ */ new Date()).toISOString()
+  };
+  if (isFlagEnabled("MAINTENANCE_MODE")) {
+    return jsonHealthResponse(
+      { ...body, ok: false, maintenance: true },
+      503
+    );
+  }
+  return jsonHealthResponse(body, 200);
+}
+function GET(req) {
+  return handleHealthRequest(req);
+}
+export {
+  GET
+};

--- a/server.ts
+++ b/server.ts
@@ -5,6 +5,7 @@ import { handleSyncRequest } from "./src/core/sync/sync-handler";
 import { handleSyncStatsRequest } from "./src/core/sync/sync-stats-handler";
 import { handleFaviconRequest } from "./src/core/favicon/favicon-handler";
 import { handleCatalogRequest } from "./src/core/catalog/catalog-handler";
+import { handleHealthRequest } from "./src/core/health/health-handler";
 import { createMemoryAdapter } from "./src/core/sync/adapters/memory-adapter";
 import { createMemoryCatalogAdapter } from "./src/core/catalog/adapters/memory-adapter";
 import { resolveAdapter } from "./src/core/sync/adapters/resolve-adapter";
@@ -125,6 +126,7 @@ export function createApp(
   app.get("/api/stats-sync", (c) => handleSyncStatsRequest(c.req.raw, syncAdapter));
   app.post("/api/feedback", (c) => handleFeedbackRequest(c.req.raw));
   app.get("/api/catalog", (c) => handleCatalogRequest(c.req.raw, catalog));
+  app.get("/api/health", (c) => handleHealthRequest(c.req.raw));
 
   return app;
 }

--- a/src/core/flags/flags.ts
+++ b/src/core/flags/flags.ts
@@ -1,0 +1,43 @@
+/**
+ * Kill switches and feature flags.
+ *
+ * First-pass implementation: env-var only. A later iteration will read from
+ * Vercel KV (or equivalent) so an operator can flip a flag without redeploying.
+ *
+ * Source-of-truth rule: a flag is enabled iff its env var is the literal
+ * string "1". "true", "yes", "on", "0", "" — all of these are NOT enabled.
+ * The strict equality is deliberate so "did I enable maintenance mode?" has
+ * an unambiguous answer in an incident.
+ *
+ * See docs/internal/strategy.md §6.4 (Kill switches) for the full menu.
+ */
+
+/**
+ * Every kill switch / feature flag the operator can flip.
+ *
+ * All day-one flags from strategy §6.4 are enumerated here even though only
+ * MAINTENANCE_MODE is wired into a code path in this PR. Listing them all
+ * gives downstream code a single source of truth for which strings are valid.
+ */
+export type FlagName =
+  | "MAINTENANCE_MODE"
+  | "KILL_BRIDGES"
+  | "KILL_AI"
+  | "KILL_ALERTS"
+  | "KILL_FETCHERS"
+  | "KILL_SIGNUPS"
+  | "READONLY_SYNC";
+
+/**
+ * Returns true iff the named flag is enabled.
+ *
+ * @param name - One of the supported FlagName values.
+ * @param env - Environment map. Defaults to process.env. Injectable for tests
+ *              and for callers that want to scope flag reads to a request.
+ */
+export function isFlagEnabled(
+  name: FlagName,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env[name] === "1";
+}

--- a/src/core/health/health-handler.ts
+++ b/src/core/health/health-handler.ts
@@ -1,0 +1,106 @@
+import { isFlagEnabled } from "../flags/flags";
+
+/**
+ * HTTP methods the health endpoint supports.
+ *
+ * Used by routing contract tests to enforce the three-entry-point rule:
+ * Hono server, Vite dev proxy, and the Vercel api/health.ts wrapper must all
+ * agree on which methods are exposed.
+ */
+export const SUPPORTED_METHODS: readonly string[] = ["GET"];
+
+/**
+ * Body of a healthy response. Kept tiny on purpose — uptime monitors should
+ * be cheap to parse and easy to alert on.
+ */
+interface HealthBody {
+  ok: boolean;
+  version: string;
+  time: string;
+  maintenance?: boolean;
+}
+
+/**
+ * Resolve the build-identifying version string.
+ *
+ * Tries Vite's build-time injected `VITE_APP_VERSION` first, then a Node-side
+ * fallback so this works in Hono / Vercel without Vite. Returns "unknown" so
+ * a missing env never crashes the health endpoint — degraded info beats a
+ * 500 on the one URL meant to tell you the server is up.
+ *
+ * TODO(observability): replace with a build-time constant injected by the
+ * Vite/Vercel build (and Sentry release tag) once that wiring lands.
+ */
+function resolveVersion(): string {
+  const viteVersion = readViteAppVersion();
+  if (viteVersion) return viteVersion;
+  return process.env.APP_VERSION ?? "unknown";
+}
+
+/**
+ * Reads `import.meta.env.VITE_APP_VERSION` without making this module fail
+ * to load in plain Node (where `import.meta.env` is undefined).
+ */
+function readViteAppVersion(): string | undefined {
+  try {
+    const env = (import.meta as ImportMeta & { env?: Record<string, string> })
+      .env;
+    return env?.VITE_APP_VERSION;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Builds a JSON Response with `Cache-Control: no-store`.
+ *
+ * Health responses must never be cached — uptime monitors and operators need
+ * the live state of the process, not what the CDN saw five minutes ago.
+ */
+function jsonHealthResponse(body: HealthBody, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+/**
+ * Build identity: same version + timestamp returned regardless of flag state.
+ * Operators want this even in a maintenance response so they can confirm
+ * which build they are looking at.
+ */
+function currentBuildIdentity(): Pick<HealthBody, "version" | "time"> {
+  return {
+    version: resolveVersion(),
+    time: new Date().toISOString(),
+  };
+}
+
+/**
+ * Health endpoint handler.
+ *
+ * - 200 with `{ ok: true, version, time }` when serving normally.
+ * - 503 with `{ ok: false, version, time, maintenance: true }` when the
+ *   MAINTENANCE_MODE kill switch is enabled. The 503 distinguishes "we know
+ *   we are down" from "the world is on fire" (which would surface as a
+ *   timeout or 5xx from the platform).
+ *
+ * @param _request - Web standard Request. Currently unused; reserved so the
+ *                   signature matches the other shared handlers and so future
+ *                   diagnostics (per-region, request-id) have a place to land.
+ */
+export function handleHealthRequest(_request: Request): Response {
+  const identity = currentBuildIdentity();
+
+  if (isFlagEnabled("MAINTENANCE_MODE")) {
+    return jsonHealthResponse(
+      { ok: false, maintenance: true, ...identity },
+      503,
+    );
+  }
+
+  return jsonHealthResponse({ ok: true, ...identity }, 200);
+}

--- a/tests/core/flags/flags.test.ts
+++ b/tests/core/flags/flags.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { isFlagEnabled, type FlagName } from "../../../src/core/flags/flags";
+
+describe("isFlagEnabled", () => {
+  it("returns false when the env var is unset", () => {
+    expect(isFlagEnabled("MAINTENANCE_MODE", {})).toBe(false);
+  });
+
+  it("returns true when the env var is exactly \"1\"", () => {
+    expect(isFlagEnabled("MAINTENANCE_MODE", { MAINTENANCE_MODE: "1" })).toBe(
+      true,
+    );
+  });
+
+  it("returns false when the env var is \"true\"", () => {
+    expect(
+      isFlagEnabled("MAINTENANCE_MODE", { MAINTENANCE_MODE: "true" }),
+    ).toBe(false);
+  });
+
+  it("returns false when the env var is \"yes\"", () => {
+    expect(
+      isFlagEnabled("MAINTENANCE_MODE", { MAINTENANCE_MODE: "yes" }),
+    ).toBe(false);
+  });
+
+  it("returns false when the env var is \"0\"", () => {
+    expect(
+      isFlagEnabled("MAINTENANCE_MODE", { MAINTENANCE_MODE: "0" }),
+    ).toBe(false);
+  });
+
+  it("returns false when the env var is an arbitrary string", () => {
+    expect(
+      isFlagEnabled("MAINTENANCE_MODE", { MAINTENANCE_MODE: "anything-else" }),
+    ).toBe(false);
+  });
+
+  it("returns false when the env var is empty string", () => {
+    expect(isFlagEnabled("MAINTENANCE_MODE", { MAINTENANCE_MODE: "" })).toBe(
+      false,
+    );
+  });
+
+  it("treats every defined FlagName independently", () => {
+    const names: FlagName[] = [
+      "MAINTENANCE_MODE",
+      "KILL_BRIDGES",
+      "KILL_AI",
+      "KILL_ALERTS",
+      "KILL_FETCHERS",
+      "KILL_SIGNUPS",
+      "READONLY_SYNC",
+    ];
+    for (const name of names) {
+      expect(isFlagEnabled(name, { [name]: "1" })).toBe(true);
+      expect(isFlagEnabled(name, {})).toBe(false);
+    }
+  });
+});

--- a/tests/core/health/health-handler.test.ts
+++ b/tests/core/health/health-handler.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { handleHealthRequest } from "../../../src/core/health/health-handler";
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("handleHealthRequest", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MAINTENANCE_MODE;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("returns 200 with ok:true and a version+time payload", async () => {
+    const res = await handleHealthRequest(
+      new Request("http://localhost/api/health"),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.version).toBe("string");
+    expect(typeof body.time).toBe("string");
+    // ISO timestamp parse round-trip
+    expect(new Date(body.time).toISOString()).toBe(body.time);
+  });
+
+  it("sets Cache-Control: no-store so uptime monitors always hit live state", async () => {
+    const res = await handleHealthRequest(
+      new Request("http://localhost/api/health"),
+    );
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("returns 503 with maintenance:true when MAINTENANCE_MODE=1", async () => {
+    process.env.MAINTENANCE_MODE = "1";
+
+    const res = await handleHealthRequest(
+      new Request("http://localhost/api/health"),
+    );
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.maintenance).toBe(true);
+    expect(typeof body.version).toBe("string");
+    expect(typeof body.time).toBe("string");
+  });
+
+  it("ignores MAINTENANCE_MODE values other than \"1\"", async () => {
+    process.env.MAINTENANCE_MODE = "true";
+
+    const res = await handleHealthRequest(
+      new Request("http://localhost/api/health"),
+    );
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4,11 +4,13 @@ import { SUPPORTED_METHODS } from "../src/core/sync/sync-handler";
 import { SUPPORTED_METHODS as PROXY_SUPPORTED_METHODS } from "../src/core/proxy/proxy-handler";
 import { SUPPORTED_METHODS as CATALOG_SUPPORTED_METHODS } from "../src/core/catalog/catalog-handler";
 import { SUPPORTED_METHODS as FEEDBACK_SUPPORTED_METHODS } from "../src/core/feedback/feedback-handler";
+import { SUPPORTED_METHODS as HEALTH_SUPPORTED_METHODS } from "../src/core/health/health-handler";
 import * as vercelSyncExports from "../api/sync";
 import * as vercelFeedExports from "../api/feed";
 import * as vercelPageExports from "../api/page";
 import * as vercelCatalogExports from "../api/catalog";
 import * as vercelFeedbackExports from "../api/feedback";
+import * as vercelHealthExports from "../api/health";
 
 // Mock fetch globally for proxy handler tests
 const mockFetch = vi.fn();
@@ -576,6 +578,83 @@ describe("server", () => {
       });
       // Endpoint is registered: status is whatever the handler returns,
       // not 404 (route missing) or 405 (method not allowed).
+      expect(res.status).not.toBe(404);
+      expect(res.status).not.toBe(405);
+    });
+  });
+
+  describe("health endpoint", () => {
+    const ORIGINAL_ENV = { ...process.env };
+
+    beforeEach(() => {
+      process.env = { ...ORIGINAL_ENV };
+      delete process.env.MAINTENANCE_MODE;
+    });
+
+    it("GET /api/health returns 200 with ok:true", async () => {
+      const res = await createApp().request("/api/health");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(typeof body.version).toBe("string");
+      expect(typeof body.time).toBe("string");
+    });
+
+    it("GET /api/health returns 503 when MAINTENANCE_MODE=1", async () => {
+      process.env.MAINTENANCE_MODE = "1";
+      const res = await createApp().request("/api/health");
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.maintenance).toBe(true);
+    });
+
+    it("GET /api/health sets Cache-Control: no-store", async () => {
+      const res = await createApp().request("/api/health");
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+    });
+  });
+
+  describe("health routing contract", () => {
+    it("HEALTH_SUPPORTED_METHODS lists GET", () => {
+      expect(HEALTH_SUPPORTED_METHODS).toContain("GET");
+    });
+
+    it("Vercel api/health.ts exports a handler for every supported method", () => {
+      for (const method of HEALTH_SUPPORTED_METHODS) {
+        expect(
+          vercelHealthExports,
+          `api/health.ts is missing export for ${method}`,
+        ).toHaveProperty(method);
+        expect(
+          typeof (vercelHealthExports as Record<string, unknown>)[method],
+        ).toBe("function");
+      }
+    });
+
+    it("Vercel api/health.ts does not export unsupported methods", () => {
+      const allHttpMethods = [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE",
+        "HEAD",
+        "OPTIONS",
+      ];
+      const unsupported = allHttpMethods.filter(
+        (m) => !HEALTH_SUPPORTED_METHODS.includes(m),
+      );
+      for (const method of unsupported) {
+        expect(
+          vercelHealthExports,
+          `api/health.ts should not export ${method}`,
+        ).not.toHaveProperty(method);
+      }
+    });
+
+    it("Hono server accepts GET /api/health", async () => {
+      const app = createApp();
+      const res = await app.request("/api/health");
       expect(res.status).not.toBe(404);
       expect(res.status).not.toBe(405);
     });

--- a/vite.config.js
+++ b/vite.config.js
@@ -146,6 +146,15 @@ function apiProxyPlugin() {
         const webRes = await handleFeedbackRequest(webReq);
         await sendWebResponse(webRes, res);
       });
+
+      server.middlewares.use("/api/health", async (req, res) => {
+        const { handleHealthRequest } = await import(
+          "./src/core/health/health-handler.ts"
+        );
+        const webReq = await toWebRequest(req);
+        const webRes = await handleHealthRequest(webReq);
+        await sendWebResponse(webRes, res);
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary

- Adds `/api/health` — uptime probe returning `{ ok, version, time }` with `Cache-Control: no-store`. Returns **503 + `maintenance: true`** when the `MAINTENANCE_MODE` kill switch is on, so monitors can distinguish "intentionally down" from "broken".
- Adds `src/core/flags/flags.ts` — first-pass `isFlagEnabled(name, env?)` module. Strict equality to `"1"` (not `"true"`/`"yes"`) so an incident has an unambiguous answer to "did I enable this flag?". Enumerates every day-one flag from strategy §6.4 in `FlagName` even though only `MAINTENANCE_MODE` is wired this PR.
- Wires the endpoint through all three entry points per CLAUDE.md's three-entry-point rule: Hono (`server.ts`), Vercel (`api/health.ts` thin wrapper bundled by `scripts/build-api.js`), and the Vite dev proxy (`vite.config.js`).

## Why

- Strategy [§10.7 Observability minimum](docs/internal/strategy.md) requires a health URL an uptime monitor can hit. We had `/api/diagnostics` for ad-hoc checks but nothing that distinguished maintenance from broken.
- Strategy [§6.4 Kill switches](docs/internal/strategy.md) requires "every paid feature has a kill switch". This PR lands the module and the first working flag.
- CLAUDE.md "Three-entry-point rule" enforced by a routing contract test in `tests/server.test.ts` that checks `api/health.ts` exports a handler for every method in `HEALTH_SUPPORTED_METHODS`.

## Test plan

- [x] `tests/core/flags/flags.test.ts` — strict-`"1"` semantics, every `FlagName`.
- [x] `tests/core/health/health-handler.test.ts` — 200 happy path, 503 maintenance, `Cache-Control: no-store`, ignores non-`"1"` values.
- [x] `tests/server.test.ts` — extended with health endpoint behavior tests + routing contract test (Vercel wrapper exports match `HEALTH_SUPPORTED_METHODS`, Hono mount works).
- [x] `npm test` — 1498 passed / 2 skipped.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build:all` — succeeded; `health.ts` bundled into the 9 Vercel functions.
- [ ] CI checks: "Tests & type check" + "Build (SPA + serverless functions)".

## Follow-ups (not in this PR)

- Build-time `VITE_APP_VERSION` injection (Vite + Vercel + Sentry release tag) so `version` reports the deployed build hash instead of `"unknown"`.
- Move flags off env-vars to Vercel KV so flips don't require a redeploy.
- Wire the remaining `FlagName` entries (`KILL_BRIDGES`, `KILL_AI`, `KILL_ALERTS`, `KILL_FETCHERS`, `KILL_SIGNUPS`, `READONLY_SYNC`) into their respective code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)