### PR TITLE
feat(license): Phase 0 — license token payload format

### DIFF
--- a/src/core/license/format.ts
+++ b/src/core/license/format.ts
@@ -1,0 +1,97 @@
+/**
+ * License token payload encoding/decoding.
+ *
+ * Wire format (compact, colon-joined):
+ *   v1:tier:expirySec:customerId:keyId:issuedAtSec
+ *
+ * The leading `v1:` reserves a forward-compatible bump path. If we ever need
+ * a v2 with different fields, decoders can dispatch on the prefix.
+ *
+ * Why a custom format and not JWT:
+ *   - JWT's algorithm-choice header is a footgun (alg=none, alg confusion).
+ *   - JWT is heavier on the wire (~200 bytes vs ~80 for our payload).
+ *   - We control both ends — we don't need third-party interop.
+ *
+ * Encoding/decoding is signature-agnostic. Signing happens in `sign.ts` and
+ * verification in `verify.ts`; this module only handles the payload shape.
+ */
+
+import { ok, err, type Result } from "@/utils/result";
+
+export type LicenseTier = "free" | "personal" | "pro";
+
+const TIERS: readonly LicenseTier[] = ["free", "personal", "pro"] as const;
+
+export interface LicensePayload {
+  tier: LicenseTier;
+  /** Unix epoch seconds when the license stops being valid. */
+  expirySec: number;
+  /** Stripe customer id (`cus_...`). */
+  customerId: string;
+  /** 32-char hex; the primary identifier used for revocation lookup. */
+  keyId: string;
+  /** Unix epoch seconds when the license was issued. */
+  issuedAtSec: number;
+}
+
+const VERSION = "v1";
+
+/**
+ * Encode a payload to its wire string. Throws synchronously on inputs that
+ * would corrupt the format — colons in `customerId` or `keyId` would create
+ * extra fields and produce a token that decodes to garbage.
+ */
+export function encodeLicensePayload(payload: LicensePayload): string {
+  if (payload.customerId.includes(":")) {
+    throw new Error("customerId must not contain a colon (corrupts format)");
+  }
+  if (payload.keyId.includes(":")) {
+    throw new Error("keyId must not contain a colon (corrupts format)");
+  }
+  return [
+    VERSION,
+    payload.tier,
+    String(payload.expirySec),
+    payload.customerId,
+    payload.keyId,
+    String(payload.issuedAtSec),
+  ].join(":");
+}
+
+/**
+ * Decode a wire string to a payload. Returns `Result` rather than throwing
+ * because malformed input is expected at this boundary (untrusted clients).
+ */
+export function decodeLicensePayload(encoded: string): Result<LicensePayload> {
+  if (!encoded) return err("empty input");
+
+  const parts = encoded.split(":");
+  if (parts.length !== 6) {
+    return err(`invalid format: expected 6 fields, got ${parts.length}`);
+  }
+
+  const [version, tier, expirySecRaw, customerId, keyId, issuedAtSecRaw] =
+    parts;
+
+  if (version !== VERSION) {
+    return err(`unknown version: ${version}`);
+  }
+  if (!isLicenseTier(tier)) {
+    return err(`unknown tier: ${tier}`);
+  }
+
+  const expirySec = Number(expirySecRaw);
+  if (!Number.isFinite(expirySec) || !Number.isInteger(expirySec)) {
+    return err(`expiry must be an integer number, got ${expirySecRaw}`);
+  }
+  const issuedAtSec = Number(issuedAtSecRaw);
+  if (!Number.isFinite(issuedAtSec) || !Number.isInteger(issuedAtSec)) {
+    return err(`issuedAt must be an integer number, got ${issuedAtSecRaw}`);
+  }
+
+  return ok({ tier, expirySec, customerId, keyId, issuedAtSec });
+}
+
+function isLicenseTier(value: string): value is LicenseTier {
+  return (TIERS as readonly string[]).includes(value);
+}

--- a/tests/core/license/format.test.ts
+++ b/tests/core/license/format.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeLicensePayload,
+  decodeLicensePayload,
+  type LicensePayload,
+} from "@/core/license/format";
+
+const validPayload: LicensePayload = {
+  tier: "pro",
+  expirySec: 1_800_000_000,
+  customerId: "cus_NQpJjB7ehjf2QH",
+  keyId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+  issuedAtSec: 1_700_000_000,
+};
+
+describe("license format — encodeLicensePayload", () => {
+  it("encodes a payload as v1:tier:exp:cid:kid:iat (colon-joined string)", () => {
+    expect(encodeLicensePayload(validPayload)).toBe(
+      "v1:pro:1800000000:cus_NQpJjB7ehjf2QH:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6:1700000000",
+    );
+  });
+
+  it("encodes each tier verbatim", () => {
+    expect(encodeLicensePayload({ ...validPayload, tier: "free" })).toContain(":free:");
+    expect(encodeLicensePayload({ ...validPayload, tier: "personal" })).toContain(":personal:");
+    expect(encodeLicensePayload({ ...validPayload, tier: "pro" })).toContain(":pro:");
+  });
+
+  it("rejects payloads with colons in customerId (would corrupt the format)", () => {
+    expect(() =>
+      encodeLicensePayload({ ...validPayload, customerId: "cus_with:colon" }),
+    ).toThrowError(/colon/i);
+  });
+
+  it("rejects payloads with colons in keyId", () => {
+    expect(() =>
+      encodeLicensePayload({ ...validPayload, keyId: "key:with:colons" }),
+    ).toThrowError(/colon/i);
+  });
+});
+
+describe("license format — decodeLicensePayload", () => {
+  it("round-trips an encoded payload", () => {
+    const encoded = encodeLicensePayload(validPayload);
+    const result = decodeLicensePayload(encoded);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(validPayload);
+  });
+
+  it("returns err for an unknown version", () => {
+    const result = decodeLicensePayload(
+      "v2:pro:1800000000:cus_x:abc:1700000000",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/version/i);
+  });
+
+  it("returns err for a malformed payload (wrong field count)", () => {
+    const result = decodeLicensePayload("v1:pro:1800000000:cus_x:abc");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/format|fields/i);
+  });
+
+  it("returns err for an unknown tier", () => {
+    const result = decodeLicensePayload(
+      "v1:enterprise:1800000000:cus_x:abc:1700000000",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/tier/i);
+  });
+
+  it("returns err for a non-numeric expiry", () => {
+    const result = decodeLicensePayload(
+      "v1:pro:not-a-number:cus_x:abc:1700000000",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/expiry|number/i);
+  });
+
+  it("returns err for a non-numeric issuedAt", () => {
+    const result = decodeLicensePayload(
+      "v1:pro:1800000000:cus_x:abc:not-a-number",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/issued|number/i);
+  });
+
+  it("returns err for empty input", () => {
+    const result = decodeLicensePayload("");
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("license format — round-trip property tests", () => {
+  // Random fuzz across realistic payloads — encode, decode, expect equality.
+  // Catches off-by-one errors in field parsing or accidental coercion (e.g.
+  // `parseInt` losing precision on large timestamps).
+  const tiers = ["free", "personal", "pro"] as const;
+  const FUZZ_ITERATIONS = 50;
+
+  for (let i = 0; i < FUZZ_ITERATIONS; i++) {
+    it(`round-trips a randomized payload (case ${i})`, () => {
+      const payload: LicensePayload = {
+        tier: tiers[Math.floor(Math.random() * tiers.length)],
+        // Realistic Stripe customer IDs are short alphanumerics; constrain accordingly
+        customerId: "cus_" + Math.random().toString(36).slice(2, 18),
+        keyId: Array.from({ length: 32 }, () =>
+          Math.floor(Math.random() * 16).toString(16),
+        ).join(""),
+        issuedAtSec: Math.floor(Math.random() * 2_000_000_000),
+        expirySec: Math.floor(Math.random() * 2_000_000_000),
+      };
+      const encoded = encodeLicensePayload(payload);
+      const decoded = decodeLicensePayload(encoded);
+      expect(decoded.ok).toBe(true);
+      if (decoded.ok) expect(decoded.value).toEqual(payload);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- First brick of Phase 0 (account/payments architecture). Defines the on-the-wire license token payload format and its encode/decode functions.
- Wire format: `v1:tier:expirySec:customerId:keyId:issuedAtSec` (compact, colon-joined)
- Tiers: `free | personal | pro` matching strategy §2 pricing
- Pure module: no signing yet, no Stripe yet, no storage yet — just the payload contract that the rest of the license stack builds on

## Why this format (and not JWT)
- JWT's `alg` header is a footgun (`alg=none`, alg-confusion bypasses)
- JWT is heavy (~200 bytes vs ~80 here); license tokens go in URLs and emails
- We control both ends — third-party interop isn't needed
- Leading `v1:` reserves a forward-compatible bump; decoders dispatch on the prefix

## What changed
- New: `src/core/license/format.ts` (~70 lines)
- New: `tests/core/license/format.test.ts` (61 tests — 11 explicit + 50 randomized round-trip fuzz)

## Three-entry-point check
- N/A — pure module, no API surface yet. Future PRs add `/api/license/verify` and `/api/stripe/webhook`.

## Test plan
- [x] 11 explicit unit tests (encode round-trip, colon-injection guards, decode error paths for empty/unknown-version/wrong-field-count/unknown-tier/non-numeric)
- [x] 50 randomized fuzz tests (encode→decode equality)
- [x] `npm test` — 1559 passed, 2 skipped, 0 failures
- [x] `npx tsc --noEmit` — clean
- [ ] N/A — no UI, no E2E

## Next in Phase 0
1. `sign.ts` + `verify.ts` — HMAC-SHA256 wrapping the encoded payload (Web Crypto API)
2. `storage.ts` — `LicenseStorage` interface + `MemoryAdapter` + `VercelKVAdapter` scaffold (deny-list)
3. `middleware.ts` — `verifyLicense(request)` → `Result<LicensePayload>`
4. `src/core/stripe/webhook-handler.ts` + Stripe event handlers
5. `/api/license/verify` and `/api/stripe/webhook` endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)