### PR TITLE
feat(stripe): add webhook receiver with signature verification + dispatch

### DIFF
--- a/src/core/stripe/test-fixtures.ts
+++ b/src/core/stripe/test-fixtures.ts
@@ -1,0 +1,167 @@
+/**
+ * Hand-crafted minimal Stripe event fixtures for webhook handler tests.
+ *
+ * These are NOT real Stripe API responses — they include only the fields
+ * the webhook handler actually reads. Keeping them minimal makes the test
+ * contract explicit: if the handler starts reading a new field, the fixture
+ * must grow, which is a deliberate signal during code review.
+ *
+ * Each factory returns the event object plus a `signature(secret, ts)`
+ * helper that computes a fresh Stripe-Signature header value at test time
+ * so tests can simulate stale timestamps and bad signatures.
+ */
+
+import { createHmac } from "node:crypto";
+
+export interface StripeFixture {
+  event: Record<string, unknown>;
+  /**
+   * Build a Stripe-Signature header value (`t=<ts>,v1=<sig>`) for the
+   * fixture's serialized event body.
+   */
+  signature: (secret: string, ts: number) => string;
+}
+
+function buildSignature(
+  event: Record<string, unknown>,
+  secret: string,
+  ts: number,
+): string {
+  const body = JSON.stringify(event);
+  const signed = `${ts}.${body}`;
+  const sig = createHmac("sha256", secret).update(signed).digest("hex");
+  return `t=${ts},v1=${sig}`;
+}
+
+interface SubscriptionCreatedArgs {
+  customerId: string;
+  subscriptionId: string;
+  tier: "personal" | "pro";
+}
+
+export function subscriptionCreatedEvent(
+  args: SubscriptionCreatedArgs,
+): StripeFixture {
+  const event = {
+    id: `evt_${args.subscriptionId}_created`,
+    type: "customer.subscription.created",
+    data: {
+      object: {
+        id: args.subscriptionId,
+        customer: args.customerId,
+        items: {
+          data: [
+            {
+              price: {
+                metadata: { tier: args.tier },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return {
+    event,
+    signature: (secret, ts) => buildSignature(event, secret, ts),
+  };
+}
+
+interface SubscriptionDeletedArgs {
+  customerId: string;
+  subscriptionId: string;
+}
+
+export function subscriptionDeletedEvent(
+  args: SubscriptionDeletedArgs,
+): StripeFixture {
+  const event = {
+    id: `evt_${args.subscriptionId}_deleted`,
+    type: "customer.subscription.deleted",
+    data: {
+      object: {
+        id: args.subscriptionId,
+        customer: args.customerId,
+      },
+    },
+  };
+  return {
+    event,
+    signature: (secret, ts) => buildSignature(event, secret, ts),
+  };
+}
+
+interface SubscriptionUpdatedArgs {
+  customerId: string;
+  subscriptionId: string;
+  status: string;
+  cancel_at_period_end: boolean;
+  current_period_end: number;
+}
+
+export function subscriptionUpdatedEvent(
+  args: SubscriptionUpdatedArgs,
+): StripeFixture {
+  const event = {
+    id: `evt_${args.subscriptionId}_updated`,
+    type: "customer.subscription.updated",
+    data: {
+      object: {
+        id: args.subscriptionId,
+        customer: args.customerId,
+        status: args.status,
+        cancel_at_period_end: args.cancel_at_period_end,
+        current_period_end: args.current_period_end,
+      },
+    },
+  };
+  return {
+    event,
+    signature: (secret, ts) => buildSignature(event, secret, ts),
+  };
+}
+
+interface InvoicePaidArgs {
+  customerId: string;
+  subscriptionId: string;
+  current_period_end: number;
+}
+
+export function invoicePaidEvent(args: InvoicePaidArgs): StripeFixture {
+  const event = {
+    id: `evt_${args.subscriptionId}_invoice_paid`,
+    type: "invoice.paid",
+    data: {
+      object: {
+        customer: args.customerId,
+        subscription: args.subscriptionId,
+        lines: {
+          data: [
+            {
+              period: { end: args.current_period_end },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return {
+    event,
+    signature: (secret, ts) => buildSignature(event, secret, ts),
+  };
+}
+
+/**
+ * Generic fixture for arbitrary event types — used in the "ignored" test.
+ */
+export function customEvent(type: string): StripeFixture {
+  const event = {
+    id: `evt_custom_${type}`,
+    type,
+    data: { object: {} },
+  };
+  return {
+    event,
+    signature: (secret, ts) => buildSignature(event, secret, ts),
+  };
+}

--- a/src/core/stripe/webhook-handler.ts
+++ b/src/core/stripe/webhook-handler.ts
@@ -1,0 +1,372 @@
+/**
+ * Shared Stripe webhook handler.
+ *
+ * Verifies the `Stripe-Signature` header against the raw request body using
+ * HMAC-SHA256 (per Stripe's manual verification spec [1]), parses the event,
+ * and dispatches to per-event methods on a {@link LicenseIssuer} collaborator.
+ *
+ * Idempotency is the responsibility of the {@link LicenseIssuer}
+ * implementation. The natural idempotency key is `subscriptionId` for
+ * issue/renewal flows. A future PR can add an
+ * `event:processed:<event.id>` set if duplicate-delivery becomes a problem
+ * in production.
+ *
+ * [1] https://stripe.com/docs/webhooks#verify-manually
+ */
+
+import type { Result } from "@/utils/result";
+
+export interface LicenseIssuer {
+  issue(args: {
+    customerId: string;
+    tier: "personal" | "pro";
+    subscriptionId: string;
+  }): Promise<Result<void>>;
+  revoke(args: {
+    customerId: string;
+    subscriptionId: string;
+    reason: string;
+  }): Promise<Result<void>>;
+  recordRenewal(args: {
+    customerId: string;
+    subscriptionId: string;
+    expirySec: number;
+  }): Promise<Result<void>>;
+}
+
+/**
+ * HTTP methods this handler accepts. Used by routing contract tests in
+ * server.test.ts to enforce that the Hono server, the Vercel wrapper, and
+ * the shared handler all agree on which methods are supported.
+ */
+export const SUPPORTED_METHODS: readonly string[] = ["POST"];
+
+export interface WebhookConfig {
+  /** STRIPE_WEBHOOK_SECRET — the signing secret from the Stripe dashboard. */
+  signingSecret: string;
+  /** Replay-window tolerance in seconds. Default 300 (Stripe's recommendation). */
+  toleranceSec?: number;
+  issuer: LicenseIssuer;
+}
+
+const DEFAULT_TOLERANCE_SEC = 300;
+
+interface ParsedSignature {
+  ts: number;
+  v1: string;
+}
+
+/**
+ * Parse a Stripe-Signature header of the form `t=<ts>,v1=<sig>[,v0=<legacy>]`.
+ * v0 (legacy) signatures are intentionally ignored. Returns null on any
+ * structural problem so the caller can return 400.
+ */
+export function parseStripeSignatureHeader(
+  header: string,
+): ParsedSignature | null {
+  const parts = header.split(",");
+  let ts: number | null = null;
+  let v1: string | null = null;
+  for (const part of parts) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (key === "t") {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isFinite(parsed)) ts = parsed;
+    } else if (key === "v1") {
+      v1 = value;
+    }
+  }
+  if (ts === null || v1 === null || v1.length === 0) return null;
+  return { ts, v1 };
+}
+
+/**
+ * Constant-time compare two equal-length hex strings. Returns false when
+ * lengths differ (still constant-time within the matching prefix).
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+async function hmacSha256Hex(
+  secret: string,
+  payload: string,
+): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(payload));
+  const bytes = new Uint8Array(sig);
+  let hex = "";
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+interface VerifiedPayload {
+  event: StripeEvent;
+}
+
+type VerifyResult =
+  | { ok: true; value: VerifiedPayload }
+  | { ok: false; status: 400; error: string };
+
+async function verifyAndParse(
+  request: Request,
+  config: WebhookConfig,
+): Promise<VerifyResult> {
+  const sigHeader = request.headers.get("Stripe-Signature");
+  if (!sigHeader) {
+    return { ok: false, status: 400, error: "Missing Stripe-Signature header" };
+  }
+  const parsed = parseStripeSignatureHeader(sigHeader);
+  if (!parsed) {
+    return {
+      ok: false,
+      status: 400,
+      error: "Malformed Stripe-Signature header",
+    };
+  }
+
+  const tolerance = config.toleranceSec ?? DEFAULT_TOLERANCE_SEC;
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - parsed.ts) > tolerance) {
+    return { ok: false, status: 400, error: "Timestamp outside tolerance" };
+  }
+
+  // Read raw body BEFORE parsing — we must HMAC the exact bytes Stripe signed.
+  const rawBody = await request.text();
+  const expected = await hmacSha256Hex(
+    config.signingSecret,
+    `${parsed.ts}.${rawBody}`,
+  );
+  if (!constantTimeEqual(expected, parsed.v1)) {
+    return { ok: false, status: 400, error: "Invalid signature" };
+  }
+
+  let event: StripeEvent;
+  try {
+    event = JSON.parse(rawBody) as StripeEvent;
+  } catch {
+    return { ok: false, status: 400, error: "Invalid JSON body" };
+  }
+  return { ok: true, value: { event } };
+}
+
+interface StripeEvent {
+  id?: string;
+  type?: string;
+  data?: { object?: Record<string, unknown> };
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface DispatchOutcome {
+  status: number;
+  body: unknown;
+}
+
+const OK_RESPONSE: DispatchOutcome = { status: 200, body: { ok: true } };
+
+/**
+ * Map a Result from a {@link LicenseIssuer} call to a DispatchOutcome.
+ * Errors become 500 so Stripe retries with exponential backoff.
+ */
+function outcomeFromIssuerResult(result: Result<void>): DispatchOutcome {
+  if (!result.ok) {
+    return { status: 500, body: { ok: false, error: result.error } };
+  }
+  return OK_RESPONSE;
+}
+
+/**
+ * Build a 200 outcome that surfaces a non-fatal data issue. We return 200
+ * so Stripe stops retrying (the webhook *did* fire correctly), but record
+ * the issue in the response body for our own observability.
+ */
+function acceptedWithIssue(issue: string): DispatchOutcome {
+  return { status: 200, body: { ok: true, issue } };
+}
+
+function getString(obj: Record<string, unknown>, key: string): string | null {
+  const val = obj[key];
+  return typeof val === "string" ? val : null;
+}
+
+function extractTier(
+  subscription: Record<string, unknown>,
+): "personal" | "pro" | null {
+  const items = subscription.items as
+    | { data?: Array<{ price?: { metadata?: { tier?: unknown } } }> }
+    | undefined;
+  const tier = items?.data?.[0]?.price?.metadata?.tier;
+  return tier === "personal" || tier === "pro" ? tier : null;
+}
+
+async function handleSubscriptionCreated(
+  obj: Record<string, unknown>,
+  issuer: LicenseIssuer,
+): Promise<DispatchOutcome> {
+  const customerId = getString(obj, "customer");
+  const subscriptionId = getString(obj, "id");
+  const tier = extractTier(obj);
+  if (!customerId || !subscriptionId) {
+    return acceptedWithIssue("Missing customer or subscription id");
+  }
+  if (!tier) {
+    // Typically means the Stripe Price was not configured with `tier`
+    // metadata. We accept the webhook so Stripe stops retrying but surface
+    // the issue for our own observability.
+    return acceptedWithIssue("Missing tier metadata on price");
+  }
+  return outcomeFromIssuerResult(
+    await issuer.issue({ customerId, subscriptionId, tier }),
+  );
+}
+
+async function handleSubscriptionDeleted(
+  obj: Record<string, unknown>,
+  issuer: LicenseIssuer,
+): Promise<DispatchOutcome> {
+  const customerId = getString(obj, "customer");
+  const subscriptionId = getString(obj, "id");
+  if (!customerId || !subscriptionId) {
+    return acceptedWithIssue("Missing customer or subscription id");
+  }
+  return outcomeFromIssuerResult(
+    await issuer.revoke({
+      customerId,
+      subscriptionId,
+      reason: "subscription_deleted",
+    }),
+  );
+}
+
+async function handleSubscriptionUpdated(
+  obj: Record<string, unknown>,
+  issuer: LicenseIssuer,
+): Promise<DispatchOutcome> {
+  const customerId = getString(obj, "customer");
+  const subscriptionId = getString(obj, "id");
+  if (!customerId || !subscriptionId) {
+    return acceptedWithIssue("Missing customer or subscription id");
+  }
+
+  if (isCancellationUpdate(obj)) {
+    return outcomeFromIssuerResult(
+      await issuer.revoke({
+        customerId,
+        subscriptionId,
+        reason: "subscription_deleted",
+      }),
+    );
+  }
+
+  const expirySec = obj.current_period_end;
+  if (typeof expirySec !== "number") {
+    return acceptedWithIssue("Missing current_period_end");
+  }
+  return outcomeFromIssuerResult(
+    await issuer.recordRenewal({ customerId, subscriptionId, expirySec }),
+  );
+}
+
+function isCancellationUpdate(obj: Record<string, unknown>): boolean {
+  return (
+    obj.cancel_at_period_end === true && getString(obj, "status") === "canceled"
+  );
+}
+
+async function handleInvoicePaid(
+  obj: Record<string, unknown>,
+  issuer: LicenseIssuer,
+): Promise<DispatchOutcome> {
+  const customerId = getString(obj, "customer");
+  const subscriptionId = getString(obj, "subscription");
+  if (!customerId || !subscriptionId) {
+    return {
+      status: 200,
+      body: { ok: true, ignored: "invoice.paid without subscription" },
+    };
+  }
+  const expirySec = extractInvoicePeriodEnd(obj);
+  if (expirySec === null) {
+    return acceptedWithIssue("Missing line item period.end");
+  }
+  return outcomeFromIssuerResult(
+    await issuer.recordRenewal({ customerId, subscriptionId, expirySec }),
+  );
+}
+
+/**
+ * Invoice events carry the renewal period end inside
+ * `lines.data[0].period.end` rather than at the top level.
+ */
+function extractInvoicePeriodEnd(
+  obj: Record<string, unknown>,
+): number | null {
+  const lines = obj.lines as
+    | { data?: Array<{ period?: { end?: unknown } }> }
+    | undefined;
+  const end = lines?.data?.[0]?.period?.end;
+  return typeof end === "number" ? end : null;
+}
+
+async function dispatchEvent(
+  event: StripeEvent,
+  issuer: LicenseIssuer,
+): Promise<DispatchOutcome> {
+  const obj = event.data?.object ?? {};
+  switch (event.type) {
+    case "customer.subscription.created":
+      return handleSubscriptionCreated(obj, issuer);
+    case "customer.subscription.deleted":
+      return handleSubscriptionDeleted(obj, issuer);
+    case "customer.subscription.updated":
+      return handleSubscriptionUpdated(obj, issuer);
+    case "invoice.paid":
+      return handleInvoicePaid(obj, issuer);
+    default:
+      // Accept-and-ignore unknown types so Stripe stops retrying.
+      return {
+        status: 200,
+        body: { ok: true, ignored: event.type ?? "unknown" },
+      };
+  }
+}
+
+export async function handleStripeWebhook(
+  request: Request,
+  config: WebhookConfig,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  const verified = await verifyAndParse(request, config);
+  if (!verified.ok) {
+    return jsonResponse({ ok: false, error: verified.error }, verified.status);
+  }
+
+  const outcome = await dispatchEvent(verified.value.event, config.issuer);
+  return jsonResponse(outcome.body, outcome.status);
+}

--- a/tests/core/stripe/webhook-handler.test.ts
+++ b/tests/core/stripe/webhook-handler.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  handleStripeWebhook,
+  type LicenseIssuer,
+  type WebhookConfig,
+} from "@/core/stripe/webhook-handler";
+import {
+  subscriptionCreatedEvent,
+  subscriptionDeletedEvent,
+  subscriptionUpdatedEvent,
+  invoicePaidEvent,
+  customEvent,
+  type StripeFixture,
+} from "@/core/stripe/test-fixtures";
+import { ok, err } from "@/utils/result";
+
+const ENDPOINT = "http://localhost/api/stripe/webhook";
+const SECRET = "whsec_test_secret_value";
+const CUSTOMER_ID = "cus_test_123";
+const SUBSCRIPTION_ID = "sub_test_456";
+
+function makeIssuer(): LicenseIssuer {
+  return {
+    issue: vi.fn(async () => ok(undefined)),
+    revoke: vi.fn(async () => ok(undefined)),
+    recordRenewal: vi.fn(async () => ok(undefined)),
+  };
+}
+
+function makeConfig(issuer: LicenseIssuer): WebhookConfig {
+  return { signingSecret: SECRET, issuer };
+}
+
+function postFixture(fixture: StripeFixture, ts: number): Request {
+  return new Request(ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Stripe-Signature": fixture.signature(SECRET, ts),
+    },
+    body: JSON.stringify(fixture.event),
+  });
+}
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+describe("handleStripeWebhook", () => {
+  let issuer: LicenseIssuer;
+
+  beforeEach(() => {
+    issuer = makeIssuer();
+  });
+
+  it("rejects non-POST methods with 405", async () => {
+    const res = await handleStripeWebhook(
+      new Request(ENDPOINT, { method: "GET" }),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it("returns 400 when Stripe-Signature header is missing", async () => {
+    const res = await handleStripeWebhook(
+      new Request(ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "x" }),
+      }),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when Stripe-Signature header is malformed", async () => {
+    const res = await handleStripeWebhook(
+      new Request(ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Stripe-Signature": "garbage-not-stripe-format",
+        },
+        body: JSON.stringify({ type: "x" }),
+      }),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when timestamp is valid but signature is invalid", async () => {
+    const ts = nowSec();
+    const fixture = subscriptionCreatedEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "personal",
+    });
+    const body = JSON.stringify(fixture.event);
+    const badSig = "0".repeat(64);
+    const res = await handleStripeWebhook(
+      new Request(ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Stripe-Signature": `t=${ts},v1=${badSig}`,
+        },
+        body,
+      }),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when timestamp is older than tolerance", async () => {
+    const staleTs = nowSec() - 600; // 10 min, exceeds default 300s
+    const fixture = subscriptionCreatedEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "personal",
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, staleTs),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("dispatches customer.subscription.created to issuer.issue", async () => {
+    const fixture = subscriptionCreatedEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "pro",
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(200);
+    expect(issuer.issue).toHaveBeenCalledWith({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "pro",
+    });
+  });
+
+  it("dispatches customer.subscription.deleted to issuer.revoke", async () => {
+    const fixture = subscriptionDeletedEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(200);
+    expect(issuer.revoke).toHaveBeenCalledWith({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      reason: "subscription_deleted",
+    });
+  });
+
+  it("dispatches customer.subscription.updated normal renewal to issuer.recordRenewal", async () => {
+    const expirySec = nowSec() + 30 * 24 * 60 * 60;
+    const fixture = subscriptionUpdatedEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      status: "active",
+      cancel_at_period_end: false,
+      current_period_end: expirySec,
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(200);
+    expect(issuer.recordRenewal).toHaveBeenCalledWith({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      expirySec,
+    });
+  });
+
+  it("dispatches customer.subscription.updated with status canceled to issuer.revoke", async () => {
+    const fixture = subscriptionUpdatedEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      status: "canceled",
+      cancel_at_period_end: true,
+      current_period_end: nowSec() + 1000,
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(200);
+    expect(issuer.revoke).toHaveBeenCalledWith({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      reason: "subscription_deleted",
+    });
+  });
+
+  it("dispatches invoice.paid to issuer.recordRenewal", async () => {
+    const expirySec = nowSec() + 30 * 24 * 60 * 60;
+    const fixture = invoicePaidEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      current_period_end: expirySec,
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(200);
+    expect(issuer.recordRenewal).toHaveBeenCalledWith({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      expirySec,
+    });
+  });
+
+  it("returns 200 with ignored:<type> for unknown event types and does not call any issuer method", async () => {
+    const fixture = customEvent("charge.refunded");
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, ignored: "charge.refunded" });
+    expect(issuer.issue).not.toHaveBeenCalled();
+    expect(issuer.revoke).not.toHaveBeenCalled();
+    expect(issuer.recordRenewal).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when issuer returns Result.err so Stripe retries", async () => {
+    const failingIssuer: LicenseIssuer = {
+      ...makeIssuer(),
+      issue: vi.fn(async () => err("kv unavailable")),
+    };
+    const fixture = subscriptionCreatedEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "personal",
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(failingIssuer),
+    );
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the shared `handleStripeWebhook` handler that Stripe POSTs subscription lifecycle events to. This is **PR N** of the Phase 0 account/payments architecture work — paired with the in-flight PR L (license format) and PR M (license storage adapter).

- **Signature verification** — HMAC-SHA256 of `<ts>.<rawBody>` against the `Stripe-Signature` header per [Stripe's manual verification spec](https://stripe.com/docs/webhooks#verify-manually). Constant-time compare. 300s replay tolerance (configurable). Uses Web Crypto API — no `stripe` SDK dependency added.
- **Dispatch** — Per-event handlers fan out to a `LicenseIssuer` interface (injected, not imported) so PR M's storage adapter and a future real implementation can land before this is wired to the network.
- **Accept-and-ignore** — Unknown event types return `200 { ok: true, ignored: <type> }` so Stripe stops retrying.
- **Stripe retries on 500** — Issuer errors return `Result.err` → 500 so Stripe's exponential backoff drives retry.

Per the strategy doc:
- §6.3 (Architecture invariants): "Stripe webhook signatures verified"
- §5 (Op principle): "Stripe webhook signatures verified... idempotency keys on all operations."

## Event handling

| Stripe event | Issuer call |
|---|---|
| `customer.subscription.created` | `issue({ customerId, tier, subscriptionId })` (tier from `data.object.items.data[0].price.metadata.tier`) |
| `customer.subscription.deleted` | `revoke({ ..., reason: "subscription_deleted" })` |
| `customer.subscription.updated` | `revoke` if `cancel_at_period_end && status === "canceled"`, else `recordRenewal({ ..., expirySec: current_period_end })` |
| `invoice.paid` | `recordRenewal({ ..., expirySec: lines.data[0].period.end })` if subscription_id present |
| anything else | 200 `{ ok: true, ignored: <type> }` |

## Idempotency

Out of scope for this PR. The `LicenseIssuer` implementation is responsible for being idempotent against the keys it generates — `subscriptionId` is the natural idempotency key for issue/renewal flows. A future PR can add a Vercel-KV-backed `event:processed:<event.id>` set if duplicate-delivery shows up in production.

## /api/* wiring

**Not wired in this PR** — only the shared handler ships here. Wiring `server.ts` (Hono), `api/stripe/webhook.ts` (Vercel), and `vite.config.js` (dev proxy) is intentionally deferred to a follow-up so PR M's storage adapter and a real `LicenseIssuer` implementation can land before this is exposed to the network.

## Files NOT touched (per parallel-agent coordination)
- `src/core/license/format.ts` (PR L, #23)
- `src/core/license/storage*.ts` (PR M)
- Anything in `src/components/`, `src/pages/`, `src/stores/`

## RGR
- **RED** — wrote `tests/core/stripe/webhook-handler.test.ts` first with stub `handleStripeWebhook` returning 501; confirmed all 12 tests failed on assertions (not import errors).
- **GREEN** — implemented signature verification + dispatch; 12/12 passing.
- **REFACTOR** — extracted `parseStripeSignatureHeader`, `outcomeFromIssuerResult`, `acceptedWithIssue`, `isCancellationUpdate`, `extractInvoicePeriodEnd` helpers. Tests still pass.

## Test plan
- [x] `npm test` — 1510 passed (12 new) / 2 skipped, 0 failed
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke against real Stripe CLI (`stripe trigger customer.subscription.created`) once `/api/*` wrapper lands in follow-up
- [ ] Verify constant-time compare under load (out of scope here; standard `crypto.subtle` HMAC + char-by-char xor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)