### PR TITLE
feat(license): add LicenseStorage abstraction + in-memory adapter (PR M)

### DIFF
--- a/src/core/license/storage-vercel-kv.ts
+++ b/src/core/license/storage-vercel-kv.ts
@@ -1,0 +1,61 @@
+import { type Result } from "../../utils/result";
+import {
+  type LicenseRecord,
+  type LicenseStorage,
+} from "./storage";
+
+// TODO(phase-0): Wire a real KV client once the provider is selected.
+// `@vercel/kv` is deprecated upstream (migrating to Upstash Redis via the
+// Vercel Marketplace integration). We do not want to install a deprecated
+// dep, and we do not want to silently no-op a license store. So this file
+// compiles, satisfies the LicenseStorage interface, and throws loudly on
+// every method until the integration ships.
+//
+// When wiring:
+//   1. Install the chosen Redis client and add it to scripts/build-api.js
+//      `external` array (Vercel-provided runtime package).
+//   2. Replace the bodies below with real KV calls. Keys:
+//        license:record:<keyId>   -> JSON-encoded LicenseRecord
+//        license:revoked:<keyId>  -> reason string (presence == revoked)
+//   3. In tests/core/license/storage-vercel-kv.test.ts, replace the stub
+//      assertions with `runStorageContractTests("VercelKVLicenseStorage",
+//      () => new VercelKVLicenseStorage())` (skip when KV env unavailable).
+//
+// See docs/internal/strategy.md §6.3, §6.4, §6.5 and runbook.md
+// "deny-list" entry for the operational contract.
+//
+// import { kv } from "@vercel/kv";
+
+/**
+ * Internal sentinel: every method throws this until a real KV client is
+ * wired. Centralised so the message stays consistent and the regex in
+ * tests/core/license/storage-vercel-kv.test.ts matches a single source.
+ */
+function notWired(): never {
+  throw new Error(
+    "KV client not yet wired — install a Redis integration (Upstash via " +
+      "Vercel Marketplace) and replace VercelKVLicenseStorage method bodies.",
+  );
+}
+
+/**
+ * KV-backed implementation of {@link LicenseStorage}. Stub today; see the
+ * top-of-file TODO for the migration path.
+ */
+export class VercelKVLicenseStorage implements LicenseStorage {
+  async put(_record: LicenseRecord): Promise<Result<void>> {
+    notWired();
+  }
+
+  async get(_keyId: string): Promise<Result<LicenseRecord | null>> {
+    notWired();
+  }
+
+  async revoke(_keyId: string, _reason: string): Promise<Result<void>> {
+    notWired();
+  }
+
+  async isRevoked(_keyId: string): Promise<Result<boolean>> {
+    notWired();
+  }
+}

--- a/src/core/license/storage.ts
+++ b/src/core/license/storage.ts
@@ -1,0 +1,81 @@
+import { type Result } from "../../utils/result";
+
+/**
+ * A single issued license. The runtime license-check endpoint reads these
+ * records to decide whether a key is still valid; the deny-list (see
+ * {@link LicenseStorage.isRevoked}) is checked separately so revocation can
+ * fan out faster than a full record write.
+ *
+ * See `docs/internal/strategy.md` §6.3 (license-key model) and §6.4 (kill
+ * switches / revocation) for the surrounding design.
+ */
+export interface LicenseRecord {
+  keyId: string;
+  /** Stripe customer id (e.g. `cus_...`). Used for re-issue and audit. */
+  customerId: string;
+  tier: "free" | "personal" | "pro";
+  status: "active" | "revoked" | "expired";
+  issuedAtSec: number;
+  expirySec: number;
+  /** When the license was last touched on the server (revoke, renew). */
+  updatedAtSec: number;
+}
+
+/**
+ * Storage abstraction for license records and the revocation deny-list.
+ *
+ * Implementations must satisfy the contract encoded in
+ * `tests/core/license/storage.test.ts` (the `runStorageContractTests` suite).
+ * In particular:
+ *  - `get` returns `ok(null)` for unknown keys (not an error).
+ *  - `revoke` is one-way and idempotent.
+ *  - `revoke` never deletes the underlying record — auditability is required.
+ */
+export interface LicenseStorage {
+  /** Persist a new or updated record. Returns Result for storage errors. */
+  put(record: LicenseRecord): Promise<Result<void>>;
+
+  /**
+   * Look up by keyId. Returns `ok(null)` if not found, `err` on storage
+   * error. "Not found" is a normal control-flow signal, not an error.
+   */
+  get(keyId: string): Promise<Result<LicenseRecord | null>>;
+
+  /** Add to revocation deny-list. Idempotent. */
+  revoke(keyId: string, reason: string): Promise<Result<void>>;
+
+  /**
+   * Returns `ok(true)` if the keyId is on the deny-list, `ok(false)`
+   * otherwise (including for keyIds we have never seen).
+   */
+  isRevoked(keyId: string): Promise<Result<boolean>>;
+}
+
+/**
+ * In-memory adapter. Used by tests, the dev server, and as the reference
+ * implementation that pins the contract. Production uses
+ * `VercelKVLicenseStorage` from `./storage-vercel-kv.ts`.
+ */
+export class MemoryLicenseStorage implements LicenseStorage {
+  private readonly records = new Map<string, LicenseRecord>();
+  private readonly denyList = new Set<string>();
+
+  async put(record: LicenseRecord): Promise<Result<void>> {
+    this.records.set(record.keyId, { ...record });
+    return { ok: true, value: undefined };
+  }
+
+  async get(keyId: string): Promise<Result<LicenseRecord | null>> {
+    const record = this.records.get(keyId);
+    return { ok: true, value: record ? { ...record } : null };
+  }
+
+  async revoke(keyId: string, _reason: string): Promise<Result<void>> {
+    this.denyList.add(keyId);
+    return { ok: true, value: undefined };
+  }
+
+  async isRevoked(keyId: string): Promise<Result<boolean>> {
+    return { ok: true, value: this.denyList.has(keyId) };
+  }
+}

--- a/tests/core/license/storage-vercel-kv.test.ts
+++ b/tests/core/license/storage-vercel-kv.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { VercelKVLicenseStorage } from "../../../src/core/license/storage-vercel-kv";
+
+/**
+ * KV-backed adapter is intentionally a runtime stub until the KV provider
+ * is selected (Vercel KV is deprecated; migrating to Upstash Redis or an
+ * equivalent integration is tracked as a follow-up).
+ *
+ * The contract suite (`runStorageContractTests`) will be wired here once
+ * a real client is in place. For now we assert the stub fails loudly on
+ * use rather than silently no-op-ing — silent failure on a license store
+ * is the worst possible mode.
+ */
+describe("VercelKVLicenseStorage (stub)", () => {
+  it("throws on put until a KV client is wired", async () => {
+    const storage = new VercelKVLicenseStorage();
+    await expect(
+      storage.put({
+        keyId: "lic_x",
+        customerId: "cus_x",
+        tier: "personal",
+        status: "active",
+        issuedAtSec: 0,
+        expirySec: 0,
+        updatedAtSec: 0,
+      }),
+    ).rejects.toThrow(/KV client not yet wired/);
+  });
+});

--- a/tests/core/license/storage.test.ts
+++ b/tests/core/license/storage.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  MemoryLicenseStorage,
+  type LicenseRecord,
+  type LicenseStorage,
+} from "../../../src/core/license/storage";
+import { isOk } from "../../../src/utils/result";
+
+/**
+ * Build a sample LicenseRecord for tests. Defaults are intentionally boring
+ * so each test can override only the field it cares about.
+ */
+function makeRecord(overrides: Partial<LicenseRecord> = {}): LicenseRecord {
+  const now = 1_700_000_000;
+  return {
+    keyId: "lic_test_001",
+    customerId: "cus_test_001",
+    tier: "personal",
+    status: "active",
+    issuedAtSec: now,
+    expirySec: now + 60 * 60 * 24 * 365,
+    updatedAtSec: now,
+    ...overrides,
+  };
+}
+
+/**
+ * Shared contract suite. Re-used for any LicenseStorage implementation —
+ * runs against MemoryLicenseStorage today, will run against
+ * VercelKVLicenseStorage once KV credentials are wired in CI.
+ */
+export function runStorageContractTests(
+  name: string,
+  makeStorage: () => LicenseStorage,
+): void {
+  describe(name, () => {
+    it("put then get returns the same record", async () => {
+      const storage = makeStorage();
+      const record = makeRecord();
+
+      await storage.put(record);
+      const result = await storage.get(record.keyId);
+
+      expect(isOk(result) && result.value).toEqual(record);
+    });
+
+    it("get for unknown keyId returns ok(null), not an error", async () => {
+      const storage = makeStorage();
+
+      const result = await storage.get("lic_does_not_exist");
+
+      expect(isOk(result) && result.value).toBeNull();
+    });
+
+    it("revoke is idempotent and isRevoked stays true", async () => {
+      const storage = makeStorage();
+      const keyId = "lic_revoke_twice";
+
+      await storage.revoke(keyId, "leak");
+      const second = await storage.revoke(keyId, "leak again");
+      const revoked = await storage.isRevoked(keyId);
+
+      expect(isOk(second) && isOk(revoked) && revoked.value).toBe(true);
+    });
+
+    it("isRevoked returns false for never-revoked keyIds", async () => {
+      const storage = makeStorage();
+
+      const result = await storage.isRevoked("lic_never_seen");
+
+      expect(isOk(result) && result.value).toBe(false);
+    });
+
+    it("revoke does not delete the underlying record", async () => {
+      const storage = makeStorage();
+      const record = makeRecord({ keyId: "lic_audit_trail" });
+      await storage.put(record);
+
+      await storage.revoke(record.keyId, "audit-trail-test");
+      const fetched = await storage.get(record.keyId);
+
+      expect(isOk(fetched) && fetched.value).toEqual(record);
+    });
+
+    it("put does not clear the deny-list for a previously revoked keyId", async () => {
+      const storage = makeStorage();
+      const record = makeRecord({ keyId: "lic_one_way_revoke" });
+      await storage.revoke(record.keyId, "leak");
+
+      await storage.put(record);
+      const revoked = await storage.isRevoked(record.keyId);
+
+      expect(isOk(revoked) && revoked.value).toBe(true);
+    });
+  });
+}
+
+runStorageContractTests(
+  "MemoryLicenseStorage",
+  () => new MemoryLicenseStorage(),
+);


### PR DESCRIPTION
## Summary
- Adds the storage layer that the Phase 0 license-check endpoints and deny-list runbook will use. Interface is the contract; implementations swap behind it.
- `MemoryLicenseStorage` is the reference adapter and pins the contract via a re-usable `runStorageContractTests` suite.
- `VercelKVLicenseStorage` is a loud-throwing stub. `@vercel/kv` is deprecated upstream (Vercel is migrating users to Upstash Redis via the Marketplace), so we deferred installing the dep rather than ship a deprecated package. The stub is wired so a future PR can swap in the chosen Redis client without touching call sites.

## Files
- `src/core/license/storage.ts` — `LicenseRecord`, `LicenseStorage`, `MemoryLicenseStorage`
- `src/core/license/storage-vercel-kv.ts` — `VercelKVLicenseStorage` stub with TODO + migration notes
- `tests/core/license/storage.test.ts` — exported `runStorageContractTests(name, makeStorage)` helper + 6 invariants run against `MemoryLicenseStorage`
- `tests/core/license/storage-vercel-kv.test.ts` — confirms the stub throws loudly rather than silently no-op-ing

## Encoded invariants (one logical assertion each)
1. `put` then `get` returns the same record
2. `get` for unknown keyId returns `ok(null)`, NOT an error
3. `revoke` is idempotent; `isRevoked` stays `true`
4. `isRevoked` returns `false` for never-revoked keyIds (default state)
5. `revoke` does NOT delete the underlying record (auditability — strategy §6.7)
6. `put` on a previously revoked keyId does NOT clear the deny-list (revoke is one-way)

## References
- `docs/internal/strategy.md` §6.3 (license-key model), §6.4 (kill switches / revocation), §6.5 (rollback paths)
- `docs/internal/runbook.md` "deny-list" entry — this PR builds the storage abstraction the runbook already assumes

## Decision: Option B (stub) over Option A (install `@vercel/kv`)
`@vercel/kv@3.0.0` is marked deprecated by Vercel: "Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis." Installing a deprecated package as a runtime dep would lock us into a migration we'd have to do anyway. The stub keeps the contract honest and surface area minimal until the Redis integration is selected.

**Follow-up action item:** select Redis provider (Upstash via Vercel Marketplace), install client, replace stub bodies, add to `scripts/build-api.js` `external` array, and re-enable `runStorageContractTests` against the KV adapter.

## Test plan
- [x] `npm test` — 1505 passed, 2 skipped (zero regressions)
- [x] `npx tsc --noEmit` — clean
- [x] Storage contract suite runs against `MemoryLicenseStorage`
- [x] KV stub throws loudly (no silent no-op on a license store)

## Files NOT touched (per coordination)
- `src/core/license/format.ts` (PR L #23)
- `src/core/stripe/**` (PR N — Stripe webhook agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)