### PR TITLE
feat(license): Phase 0 — HMAC-SHA256 sign + verify (stacked on #23)

### DIFF
--- a/src/core/license/crypto.ts
+++ b/src/core/license/crypto.ts
@@ -1,0 +1,53 @@
+/**
+ * Crypto primitives shared by `sign.ts` and `verify.ts`.
+ *
+ * Web Crypto API only — no Node-specific imports — so the same code runs in
+ * the browser (when verifying license claims client-side), Vercel serverless
+ * functions (Node 20+), and the Hono standalone server.
+ */
+
+/** HMAC-SHA256 of `message` under `secret`. Returns the raw signature bytes. */
+export async function hmacSha256(
+  message: string,
+  secret: string,
+): Promise<Uint8Array> {
+  const encoder = new TextEncoder();
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    cryptoKey,
+    encoder.encode(message),
+  );
+  return new Uint8Array(signature);
+}
+
+/** RFC 4648 §5 base64url encoding (no padding). Accepts a string or bytes. */
+export function base64UrlEncode(input: string | Uint8Array): string {
+  const bytes =
+    typeof input === "string" ? new TextEncoder().encode(input) : input;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * RFC 4648 §5 base64url decoding (handles missing padding).
+ * Returns "" on malformed input rather than throwing — verify.ts treats
+ * malformed tokens as invalid signatures, not errors.
+ */
+export function base64UrlDecodeToString(input: string): string {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padLen = (4 - (padded.length % 4)) % 4;
+  const b64 = padded + "=".repeat(padLen);
+  try {
+    return atob(b64);
+  } catch {
+    return "";
+  }
+}

--- a/src/core/license/sign.ts
+++ b/src/core/license/sign.ts
@@ -1,0 +1,42 @@
+/**
+ * License token signing.
+ *
+ * Wire format: `fz_<base64url(payload)>.<base64url(signature)>`
+ * - payload is the colon-joined wire string from `format.ts`
+ * - signature is HMAC-SHA256(payload) using the server signing secret
+ *
+ * Determinism: HMAC-SHA256 of the same input under the same key is byte-equal,
+ * so re-signing the same payload yields the same token. Tests rely on this.
+ *
+ * The signing secret is loaded by callers (typically from
+ * `process.env.LICENSE_SIGNING_KEY`); this module is environment-agnostic to
+ * keep it framework-portable and easy to test.
+ */
+
+import {
+  encodeLicensePayload,
+  type LicensePayload,
+} from "@/core/license/format";
+import { hmacSha256, base64UrlEncode } from "@/core/license/crypto";
+
+/** Opaque wrapper so callers don't accidentally pass a stringly-typed token. */
+export interface SigningKey {
+  /** UTF-8 string secret. Min 32 bytes recommended; not enforced here. */
+  secret: string;
+}
+
+const TOKEN_PREFIX = "fz_";
+const PART_SEPARATOR = ".";
+
+/**
+ * Sign a payload and return the wire token. Async because Web Crypto's
+ * `subtle.sign` is async — same API in browsers and Node 20+.
+ */
+export async function signLicense(
+  payload: LicensePayload,
+  key: SigningKey,
+): Promise<string> {
+  const encodedPayload = encodeLicensePayload(payload);
+  const signature = await hmacSha256(encodedPayload, key.secret);
+  return TOKEN_PREFIX + base64UrlEncode(encodedPayload) + PART_SEPARATOR + base64UrlEncode(signature);
+}

--- a/src/core/license/verify.ts
+++ b/src/core/license/verify.ts
@@ -1,0 +1,108 @@
+/**
+ * License token verification.
+ *
+ * Verifies the wire format `fz_<base64url(payload)>.<base64url(signature)>`:
+ *   1. parses the token shape
+ *   2. recomputes the HMAC and compares constant-time against the signature
+ *   3. decodes the payload (delegating to `format.ts`)
+ *   4. enforces expiry and "issuedAt not in the future" (clock-skew protection)
+ *
+ * Returns `Result<LicensePayload>` so callers handle malformed/expired/forged
+ * inputs without exception flow. The token is untrusted user input; throwing
+ * here would push the burden onto every caller.
+ *
+ * Revocation is checked separately by callers consulting `LicenseStorage` —
+ * this module only does cryptographic + temporal validity. Keeping the layers
+ * separate means we can verify a token without a DB round-trip when revocation
+ * is checked elsewhere (e.g. when both already happened and we just need to
+ * re-decode the payload).
+ */
+
+import {
+  decodeLicensePayload,
+  type LicensePayload,
+} from "@/core/license/format";
+import type { SigningKey } from "@/core/license/sign";
+import {
+  hmacSha256,
+  base64UrlEncode,
+  base64UrlDecodeToString,
+} from "@/core/license/crypto";
+import { ok, err, type Result } from "@/utils/result";
+
+const TOKEN_PREFIX = "fz_";
+
+export interface VerifyOptions {
+  /** Unix epoch seconds. Caller-injected for testability; defaults to Date.now()/1000. */
+  nowSec?: number;
+}
+
+export async function verifyLicense(
+  token: string,
+  key: SigningKey,
+  options: VerifyOptions = {},
+): Promise<Result<LicensePayload>> {
+  if (!token) return err("empty token");
+  if (!token.startsWith(TOKEN_PREFIX)) {
+    return err(`invalid token prefix (expected ${TOKEN_PREFIX})`);
+  }
+
+  const body = token.slice(TOKEN_PREFIX.length);
+  const parts = body.split(".");
+  if (parts.length !== 2) {
+    return err(`invalid token format: expected 2 parts, got ${parts.length}`);
+  }
+
+  const [encodedPayloadB64, signatureB64] = parts;
+  const encodedPayload = base64UrlDecodeToString(encodedPayloadB64);
+
+  const expectedSignature = await hmacSha256(encodedPayload, key.secret);
+  const expectedSignatureB64 = base64UrlEncode(expectedSignature);
+
+  if (!constantTimeEqual(signatureB64, expectedSignatureB64)) {
+    return err("invalid signature");
+  }
+
+  const payloadResult = decodeLicensePayload(encodedPayload);
+  if (!payloadResult.ok) return payloadResult;
+  const payload = payloadResult.value;
+
+  const nowSec = options.nowSec ?? Math.floor(Date.now() / 1000);
+
+  if (payload.issuedAtSec > nowSec) {
+    return err(
+      `token issuedAt is in the future (issuedAt=${payload.issuedAtSec}, now=${nowSec})`,
+    );
+  }
+  // Boundary inclusive: a token expiring exactly at nowSec is still valid.
+  if (payload.expirySec < nowSec) {
+    return err(
+      `token expired (expired=${payload.expirySec}, now=${nowSec})`,
+    );
+  }
+
+  return ok(payload);
+}
+
+/**
+ * Constant-time string comparison. Avoids early exit on first byte mismatch
+ * so an attacker measuring response time cannot incrementally guess the
+ * signature. Length mismatch returns false but does so after touching every
+ * byte of the shorter string, so length is not directly leakable from
+ * this function (length is, however, observable in network traffic — that's
+ * outside this module's scope).
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    let dummy = 0;
+    const len = Math.min(a.length, b.length);
+    for (let i = 0; i < len; i++) dummy |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    void dummy;
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/tests/core/license/sign.test.ts
+++ b/tests/core/license/sign.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { signLicense, type SigningKey } from "@/core/license/sign";
+import type { LicensePayload } from "@/core/license/format";
+
+const SECRET = "this-is-a-test-signing-secret-32-bytes!";
+
+const validPayload: LicensePayload = {
+  tier: "pro",
+  expirySec: 1_800_000_000,
+  customerId: "cus_NQpJjB7ehjf2QH",
+  keyId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+  issuedAtSec: 1_700_000_000,
+};
+
+const key: SigningKey = { secret: SECRET };
+
+describe("license sign — signLicense", () => {
+  it("returns a token in the form fz_<b64url>.<b64url>", async () => {
+    const token = await signLicense(validPayload, key);
+    expect(token).toMatch(/^fz_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  });
+
+  it("is deterministic for the same payload + key", async () => {
+    const a = await signLicense(validPayload, key);
+    const b = await signLicense(validPayload, key);
+    expect(a).toBe(b);
+  });
+
+  it("produces different tokens for different keys", async () => {
+    const a = await signLicense(validPayload, key);
+    const b = await signLicense(validPayload, { secret: "other-secret" });
+    expect(a).not.toBe(b);
+  });
+
+  it("produces different tokens for different payloads", async () => {
+    const a = await signLicense(validPayload, key);
+    const b = await signLicense(
+      { ...validPayload, tier: "personal" },
+      key,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("does not contain raw colons (payload is base64url-encoded)", async () => {
+    const token = await signLicense(validPayload, key);
+    // The encoded payload contains colons before encoding; after b64url
+    // encoding, no colons should appear in the wire token.
+    expect(token).not.toContain(":");
+  });
+});

--- a/tests/core/license/verify.test.ts
+++ b/tests/core/license/verify.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { signLicense, type SigningKey } from "@/core/license/sign";
+import { verifyLicense } from "@/core/license/verify";
+import type { LicensePayload } from "@/core/license/format";
+
+const SECRET = "this-is-a-test-signing-secret-32-bytes!";
+const key: SigningKey = { secret: SECRET };
+const NOW = 1_750_000_000; // mid-2025-ish, between issuedAt and expiry below
+
+const validPayload: LicensePayload = {
+  tier: "pro",
+  expirySec: 1_800_000_000,
+  customerId: "cus_NQpJjB7ehjf2QH",
+  keyId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+  issuedAtSec: 1_700_000_000,
+};
+
+describe("license verify — verifyLicense", () => {
+  it("returns ok with the original payload for a valid token", async () => {
+    const token = await signLicense(validPayload, key);
+    const result = await verifyLicense(token, key, { nowSec: NOW });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(validPayload);
+  });
+
+  it("returns err for an empty token", async () => {
+    const result = await verifyLicense("", key, { nowSec: NOW });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns err for a token without the fz_ prefix", async () => {
+    const result = await verifyLicense("notatoken.atall", key, { nowSec: NOW });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/format|prefix/i);
+  });
+
+  it("returns err for a token with the wrong number of parts", async () => {
+    const result = await verifyLicense("fz_abc", key, { nowSec: NOW });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns err when the signature doesn't match the payload (tampered payload)", async () => {
+    const goodToken = await signLicense(validPayload, key);
+    const [head, sig] = goodToken.split(".");
+    // Tamper: append a character to the encoded payload, keep original sig.
+    const tampered = `${head}X.${sig}`;
+    const result = await verifyLicense(tampered, key, { nowSec: NOW });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/signature/i);
+  });
+
+  it("returns err when the signature was made with a different key", async () => {
+    const tokenWithOtherKey = await signLicense(validPayload, {
+      secret: "different-secret-entirely",
+    });
+    const result = await verifyLicense(tokenWithOtherKey, key, { nowSec: NOW });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/signature/i);
+  });
+
+  it("returns err when the token is expired", async () => {
+    const expiredPayload: LicensePayload = {
+      ...validPayload,
+      expirySec: NOW - 1,
+    };
+    const token = await signLicense(expiredPayload, key);
+    const result = await verifyLicense(token, key, { nowSec: NOW });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/expired/i);
+  });
+
+  it("accepts a token that expires exactly at nowSec (boundary inclusive)", async () => {
+    const boundaryPayload: LicensePayload = {
+      ...validPayload,
+      expirySec: NOW,
+    };
+    const token = await signLicense(boundaryPayload, key);
+    const result = await verifyLicense(token, key, { nowSec: NOW });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns err when issuedAtSec is in the future (clock skew protection)", async () => {
+    const futurePayload: LicensePayload = {
+      ...validPayload,
+      issuedAtSec: NOW + 60 * 60, // 1 hour in the future
+    };
+    const token = await signLicense(futurePayload, key);
+    const result = await verifyLicense(token, key, { nowSec: NOW });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/issued|future/i);
+  });
+
+  it("verification uses constant-time comparison (does not short-circuit on first byte mismatch)", async () => {
+    // Property test — many bad signatures, all should err uniformly. This
+    // doesn't *prove* constant-time behavior, but it does prove we don't
+    // accidentally accept any of the easy variants (off-by-one, prefix match,
+    // length mismatch).
+    const goodToken = await signLicense(validPayload, key);
+    const [head, sig] = goodToken.split(".");
+    const variants = [
+      `${head}.${sig.slice(0, -1)}A`,                  // last char swapped
+      `${head}.A${sig.slice(1)}`,                      // first char swapped
+      `${head}.${sig.slice(0, sig.length / 2)}`,       // truncated to half
+      `${head}.${sig}${sig}`,                          // doubled
+      `${head}.`,                                      // empty sig
+    ];
+    for (const v of variants) {
+      const result = await verifyLicense(v, key, { nowSec: NOW });
+      expect(result.ok, `should reject: ${v}`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 0 brick #2 (stacked on PR #23 — license payload format).
- `signLicense(payload, key)` → `fz_<b64url(payload)>.<b64url(sig)>` token using HMAC-SHA256 (Web Crypto API).
- `verifyLicense(token, key, {nowSec?})` → `Result<LicensePayload>`. Enforces signature, expiry (boundary inclusive), and "issuedAt not in the future" (clock-skew protection).
- Constant-time signature comparison — no short-circuit on first byte mismatch.

## Why HMAC-SHA256 + Web Crypto (and not JWT or `jsonwebtoken`)
- JWT's `alg` header is a footgun (`alg=none`, alg-confusion bypasses)
- Web Crypto runs identically in browsers, Vercel Node serverless, and the Hono server — no Node-specific polyfill matrix
- HMAC is deterministic, so re-signing the same payload yields the same token (clean cache key, easy tests)

## What changed
- `src/core/license/sign.ts` (~30 lines)
- `src/core/license/verify.ts` (~100 lines including constant-time helper)
- `src/core/license/crypto.ts` (~50 lines — shared `hmacSha256`, `base64UrlEncode`, `base64UrlDecodeToString`; extracted during REFACTOR to remove duplication)
- `tests/core/license/sign.test.ts` — 5 tests
- `tests/core/license/verify.test.ts` — 10 tests including a 5-variant signature-tampering rejection sweep

## What's deliberately NOT here
- Revocation lookup — verify only does cryptographic + temporal validity. The deny-list lives in `LicenseStorage` (PR M), checked by the middleware (next PR). Separation lets us re-verify without a DB round-trip.
- HTTP wiring — there is no `/api/license/verify` endpoint yet. That ships once storage + middleware are in.

## Stacking + merge order
- Base: `main` (will surface a small conflict against PR #23's `format.ts` once #23 merges; trivial — same file, different new content)
- Recommended order: merge **#23 first**, then rebase this PR onto main and merge.

## Test plan
- [x] 5 sign tests (format match, determinism, key-sensitivity, payload-sensitivity, no raw colons)
- [x] 10 verify tests (round-trip, empty/missing-prefix/wrong-parts, tampered payload, wrong key, expired, exact-boundary expiry inclusive, issuedAt-in-future, constant-time rejection sweep)
- [x] `npm test` — 1574 passed, 2 skipped, 0 failures
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)