### PR TITLE
feat(license): add authorizeLicense middleware (Bearer + verify + revocation)

### DIFF
--- a/src/core/license/middleware.ts
+++ b/src/core/license/middleware.ts
@@ -1,0 +1,84 @@
+/**
+ * License authorization middleware (framework-agnostic).
+ *
+ * Wraps the cryptographic verification (`verifyLicense`) and the revocation
+ * check (`LicenseStorage.isRevoked`) into a single call that the API layer
+ * (Hono / Vercel serverless / Vite dev proxy) can invoke uniformly.
+ *
+ * Why this is a pure function and not an Express/Hono middleware:
+ *  - Three different runtimes consume it (see CLAUDE.md "three-entry-point
+ *    rule"). Each runtime turns a `Result` into its own response shape.
+ *  - Returning `Result` keeps the test surface tiny — no need to fake a
+ *    `next()` or a response object.
+ *
+ * Failure mode: if the revocation lookup itself errors (e.g. KV outage), we
+ * fail closed and surface a "storage" error rather than auto-allowing or
+ * auto-denying silently. See `docs/internal/strategy.md` §6.3 (license-key
+ * model) and §6.4 (kill switches / revocation).
+ */
+
+import { verifyLicense } from "@/core/license/verify";
+import type { LicensePayload } from "@/core/license/format";
+import type { SigningKey } from "@/core/license/sign";
+import type { LicenseStorage } from "@/core/license/storage";
+import { ok, err, type Result } from "@/utils/result";
+
+export interface LicenseAuthContext {
+  /** The verified payload, with revocation already checked. */
+  license: LicensePayload;
+}
+
+export interface LicenseAuthOptions {
+  signingKey: SigningKey;
+  storage: LicenseStorage;
+  /** Caller-injected for tests. Defaults to Date.now()/1000. */
+  nowSec?: number;
+}
+
+const BEARER_SCHEME = "Bearer ";
+
+/**
+ * Reads `Authorization: Bearer <token>` from the request, verifies the token,
+ * checks the deny-list, and returns the license payload OR a structured error.
+ * Pure function — does NOT short-circuit by writing to the response itself,
+ * because callers (Hono / Vercel) handle the response shape.
+ */
+export async function authorizeLicense(
+  request: Request,
+  options: LicenseAuthOptions,
+): Promise<Result<LicenseAuthContext>> {
+  const tokenResult = parseBearerToken(request.headers.get("Authorization"));
+  if (!tokenResult.ok) return tokenResult;
+
+  const verifyResult = await verifyLicense(tokenResult.value, options.signingKey, {
+    nowSec: options.nowSec,
+  });
+  if (!verifyResult.ok) return verifyResult;
+  const payload = verifyResult.value;
+
+  const revokedResult = await options.storage.isRevoked(payload.keyId);
+  if (!revokedResult.ok) {
+    return err(`license storage error: ${revokedResult.error}`);
+  }
+  if (revokedResult.value) {
+    return err("license revoked");
+  }
+
+  return ok({ license: payload });
+}
+
+/**
+ * Extract the bearer token from an Authorization header value.
+ *
+ * The scheme check is case-sensitive (`Bearer`, not `bearer`). RFC 7235 says
+ * scheme tokens are case-insensitive, but every production caller of this
+ * function controls both ends — being strict here surfaces client bugs early
+ * rather than masking them.
+ */
+function parseBearerToken(headerValue: string | null): Result<string> {
+  if (!headerValue) return err("missing Authorization header");
+  if (!headerValue.startsWith(BEARER_SCHEME)) {
+    return err("invalid Authorization scheme (expected Bearer)");
+  }
+  return ok(headerValue.slice(BEARER_SCHEME.length));
+}

--- a/tests/core/license/middleware.test.ts
+++ b/tests/core/license/middleware.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { authorizeLicense } from "@/core/license/middleware";
+import { signLicense, type SigningKey } from "@/core/license/sign";
+import {
+  MemoryLicenseStorage,
+  type LicenseStorage,
+} from "@/core/license/storage";
+import type { LicensePayload } from "@/core/license/format";
+import { err, ok, type Result } from "@/utils/result";
+
+const SECRET = "this-is-a-test-signing-secret-32-bytes!";
+const key: SigningKey = { secret: SECRET };
+const NOW = 1_750_000_000;
+
+const validPayload: LicensePayload = {
+  tier: "pro",
+  expirySec: 1_800_000_000,
+  customerId: "cus_NQpJjB7ehjf2QH",
+  keyId: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+  issuedAtSec: 1_700_000_000,
+};
+
+/** Build a fresh Request carrying an Authorization header. */
+function makeRequest(authorizationHeader?: string): Request {
+  const headers = new Headers();
+  if (authorizationHeader !== undefined) {
+    headers.set("Authorization", authorizationHeader);
+  }
+  return new Request("https://feedzero.app/api/example", { headers });
+}
+
+/** Sign a payload using the real signer so we exercise the verify path. */
+async function signTestToken(
+  payload: LicensePayload,
+  signingKey: SigningKey,
+): Promise<string> {
+  return signLicense(payload, signingKey);
+}
+
+/**
+ * Storage that always errors from `isRevoked`. Used to assert that storage
+ * outages surface as a failure rather than silently allowing access.
+ */
+class FailingRevocationStorage implements LicenseStorage {
+  private readonly inner = new MemoryLicenseStorage();
+  put = this.inner.put.bind(this.inner);
+  get = this.inner.get.bind(this.inner);
+  revoke = this.inner.revoke.bind(this.inner);
+  async isRevoked(_keyId: string): Promise<Result<boolean>> {
+    return err("kv unavailable");
+  }
+}
+
+describe("license middleware — authorizeLicense", () => {
+  it("returns err when the Authorization header is missing", async () => {
+    const storage = new MemoryLicenseStorage();
+    const request = makeRequest(undefined);
+    const result = await authorizeLicense(request, {
+      signingKey: key,
+      storage,
+      nowSec: NOW,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/missing/i);
+  });
+
+  it("returns err when the Authorization scheme is not Bearer", async () => {
+    const storage = new MemoryLicenseStorage();
+    const request = makeRequest("Basic dXNlcjpwYXNz");
+    const result = await authorizeLicense(request, {
+      signingKey: key,
+      storage,
+      nowSec: NOW,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/scheme/i);
+  });
+
+  it("returns err with 'signature' when the bearer token is tampered", async () => {
+    const storage = new MemoryLicenseStorage();
+    const goodToken = await signTestToken(validPayload, key);
+    const [head, sig] = goodToken.split(".");
+    const tampered = `${head}X.${sig}`;
+    const request = makeRequest(`Bearer ${tampered}`);
+    const result = await authorizeLicense(request, {
+      signingKey: key,
+      storage,
+      nowSec: NOW,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/signature/i);
+  });
+
+  it("returns err with 'expired' when the bearer token is past its expiry", async () => {
+    const storage = new MemoryLicenseStorage();
+    const expiredPayload: LicensePayload = {
+      ...validPayload,
+      expirySec: NOW - 10,
+    };
+    const token = await signTestToken(expiredPayload, key);
+    const request = makeRequest(`Bearer ${token}`);
+    const result = await authorizeLicense(request, {
+      signingKey: key,
+      storage,
+      nowSec: NOW,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/expired/i);
+  });
+
+  it("returns err with 'revoked' when the keyId is on the deny-list", async () => {
+    const storage = new MemoryLicenseStorage();
+    await storage.revoke(validPayload.keyId, "test revocation");
+    const token = await signTestToken(validPayload, key);
+    const request = makeRequest(`Bearer ${token}`);
+    const result = await authorizeLicense(request, {
+      signingKey: key,
+      storage,
+      nowSec: NOW,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/revoked/i);
+  });
+
+  it("returns err with 'storage' when the revocation lookup itself fails (fail-closed)", async () => {
+    const storage = new FailingRevocationStorage();
+    const token = await signTestToken(validPayload, key);
+    const request = makeRequest(`Bearer ${token}`);
+    const result = await authorizeLicense(request, {
+      signingKey: key,
+      storage,
+      nowSec: NOW,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/storage/i);
+  });
+
+  it("returns ok with the verified payload for a valid, un-revoked token", async () => {
+    const storage = new MemoryLicenseStorage();
+    const token = await signTestToken(validPayload, key);
+    const request = makeRequest(`Bearer ${token}`);
+    const result = await authorizeLicense(request, {
+      signingKey: key,
+      storage,
+      nowSec: NOW,
+    });
+    expect(result).toEqual(ok({ license: validPayload }));
+  });
+});


### PR DESCRIPTION
## Summary

Adds `authorizeLicense(request, options)` — a pure, framework-agnostic helper that the API layer (Hono / Vercel serverless / Vite dev proxy) wraps to authorize license-bearing requests.

**Flow** (per `docs/internal/strategy.md` §6.3 license-key model + §6.4 kill switches):
1. Read `Authorization: Bearer <token>` header
2. Run `verifyLicense` (cryptographic + temporal validity)
3. Consult `LicenseStorage.isRevoked(payload.keyId)` for the deny-list
4. Return `Result<LicenseAuthContext>` — each runtime shapes its own response

**Fail-closed on storage outages.** If `isRevoked` itself errors (e.g. KV unavailable) we surface `license storage error: ...` rather than silently allowing access. A loud failure beats a quiet bypass when revocation is the kill switch.

**Contract.** Honours the existing interfaces without modifying them:
- `verifyLicense(token, key, {nowSec?})` — propagates its `Result` errors verbatim (signature/expired/etc.)
- `LicenseStorage.isRevoked(keyId)` — `ok(true|false)` for known/unknown keys, `err` only on storage outage

**Bearer parsing extracted** into `parseBearerToken()` per the refactor guidance — strict case-sensitive `Bearer ` scheme so client bugs surface early.

## Test plan
- [x] 7 new tests in `tests/core/license/middleware.test.ts` — one logical assertion each
- [x] Covers: missing header, wrong scheme, tampered signature, expired token, revoked keyId, storage outage (fail-closed), happy path
- [x] Real `signLicense` + `verifyLicense` exercised end-to-end (no mocking the verify path)
- [x] `npm test` — 1600 passed (was 1593, +7), 2 skipped, 0 failed
- [x] `npx tsc --noEmit` — clean

## Out of scope
- No `/api/*` wiring (next PR)
- No changes to `src/core/license/*` other than the new file
- No changes to `src/core/stripe/**` (PR R territory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)