### PR TITLE
feat(license): add LicenseIssuerImpl satisfying Stripe webhook contract

### DIFF
--- a/src/core/license/issuer.ts
+++ b/src/core/license/issuer.ts
@@ -1,0 +1,219 @@
+/**
+ * License issuer.
+ *
+ * Composes {@link signLicense} with a {@link LicenseStorage} to satisfy the
+ * `LicenseIssuer` contract that `src/core/stripe/webhook-handler.ts`
+ * dispatches to. The Stripe webhook is the only production caller today;
+ * an admin endpoint will reuse this for manual issue/revoke flows.
+ *
+ * Idempotency note: `issue` is intentionally not idempotent on its own. If
+ * Stripe retries `customer.subscription.created` we will mint a second
+ * token for the same subscription. Both tokens stay valid; this is
+ * acceptable for MVP and tracked as a follow-up — see
+ * `docs/internal/strategy.md` §6.3 for the design and §5 for the broader
+ * idempotency principle. A future PR can short-circuit by looking up the
+ * existing record via `LicenseStorage.listByCustomer` filtered by
+ * `subscriptionId`.
+ *
+ * `recordRenewal` is idempotent on `(customerId, subscriptionId)`: it
+ * updates the existing record's expiry, or — if a renewal arrives before
+ * the create event (Stripe race) — falls back to issuing a fresh license
+ * with the new expiry.
+ */
+
+import { signLicense, type SigningKey } from "@/core/license/sign";
+import type {
+  LicenseRecord,
+  LicenseStorage,
+} from "@/core/license/storage";
+import type { LicenseIssuer } from "@/core/stripe/webhook-handler";
+import { ok, type Result } from "@/utils/result";
+
+/** 31 days. Matches a typical Stripe billing cycle plus grace. */
+const DEFAULT_EXPIRY_SEC = 31 * 24 * 3600;
+const KEY_ID_BYTE_LENGTH = 16;
+
+export interface IssuerConfig {
+  signingKey: SigningKey;
+  storage: LicenseStorage;
+  /**
+   * Default expiry (seconds from now) for newly-issued licenses. Caller can
+   * override per call. Defaults to 31 days.
+   */
+  defaultExpirySec?: number;
+  /** Caller-injected for testability. Defaults to `Math.floor(Date.now()/1000)`. */
+  nowSec?: () => number;
+  /** Caller-injected for testability. Defaults to a 32-char hex from `crypto.getRandomValues`. */
+  generateKeyId?: () => string;
+}
+
+export interface IssueResult {
+  /** The signed wire token to deliver to the customer. */
+  token: string;
+  /** Echo of the storage record that was persisted. */
+  record: LicenseRecord;
+}
+
+interface IssueArgs {
+  customerId: string;
+  tier: "personal" | "pro";
+  subscriptionId: string;
+  /** Optional override for this issuance only. */
+  expirySec?: number;
+}
+
+/**
+ * Concrete `LicenseIssuer`. Pure composition over `signLicense` and
+ * `LicenseStorage` — no side channels (no email send, no logging) so it
+ * stays trivially testable.
+ */
+export class LicenseIssuerImpl implements LicenseIssuer {
+  private readonly signingKey: SigningKey;
+  private readonly storage: LicenseStorage;
+  private readonly defaultExpirySec: number;
+  private readonly nowSec: () => number;
+  private readonly generateKeyId: () => string;
+
+  constructor(config: IssuerConfig) {
+    this.signingKey = config.signingKey;
+    this.storage = config.storage;
+    this.defaultExpirySec = config.defaultExpirySec ?? DEFAULT_EXPIRY_SEC;
+    this.nowSec = config.nowSec ?? defaultNowSec;
+    this.generateKeyId = config.generateKeyId ?? defaultGenerateKeyId;
+  }
+
+  /**
+   * Issue a fresh license token, persist the record, and return both. The
+   * admin endpoint and `recordRenewal`'s fallback path use this directly;
+   * the Stripe webhook uses {@link issue} (which discards the token).
+   */
+  async issueWithToken(args: IssueArgs): Promise<Result<IssueResult>> {
+    return this.mintAndPersist(args);
+  }
+
+  /**
+   * Interface method called by the Stripe webhook. The token is delivered
+   * to the customer out of band (email), so the webhook only needs to know
+   * issuance succeeded.
+   */
+  async issue(args: IssueArgs): Promise<Result<void>> {
+    const result = await this.mintAndPersist(args);
+    return result.ok ? ok(undefined) : result;
+  }
+
+  /**
+   * Revoke every license currently issued to `customerId`. The
+   * subscriptionId is accepted for parity with the Stripe webhook contract
+   * but is intentionally ignored: today we don't carry an index from
+   * subscription → keyId, so we revoke at the customer level. This is
+   * conservative — a customer with multiple subscriptions cancelled for
+   * one will lose all licenses. Revisit when multi-subscription customers
+   * become a real use case (currently they don't).
+   */
+  async revoke(args: {
+    customerId: string;
+    subscriptionId: string;
+    reason: string;
+  }): Promise<Result<void>> {
+    return this.storage.revokeAllForCustomer(args.customerId, args.reason);
+  }
+
+  /**
+   * Update the matching record's expiry. If no record matches (Stripe
+   * raced the create event), fall back to issuing a fresh license with
+   * the new expiry — that keeps the (customerId, subscriptionId) →
+   * active-license invariant holding even under reordered events.
+   */
+  async recordRenewal(args: {
+    customerId: string;
+    subscriptionId: string;
+    expirySec: number;
+  }): Promise<Result<void>> {
+    const existing = await this.findActiveRecordForSubscription(
+      args.customerId,
+      args.subscriptionId,
+    );
+    if (!existing.ok) return existing;
+
+    if (existing.value === null) {
+      return this.issue({
+        customerId: args.customerId,
+        subscriptionId: args.subscriptionId,
+        // Renewals don't carry tier, so we default to personal for the
+        // fallback-issue path. Revisit when we surface tier on renewal events.
+        tier: "personal",
+        expirySec: args.expirySec,
+      });
+    }
+
+    const updated: LicenseRecord = {
+      ...existing.value,
+      expirySec: args.expirySec,
+      updatedAtSec: this.nowSec(),
+    };
+    return this.storage.put(updated);
+  }
+
+  private async mintAndPersist(
+    args: IssueArgs,
+  ): Promise<Result<IssueResult>> {
+    const issuedAtSec = this.nowSec();
+    const expirySec = args.expirySec ?? issuedAtSec + this.defaultExpirySec;
+    const keyId = this.generateKeyId();
+
+    const record: LicenseRecord = {
+      keyId,
+      customerId: args.customerId,
+      subscriptionId: args.subscriptionId,
+      tier: args.tier,
+      status: "active",
+      issuedAtSec,
+      expirySec,
+      updatedAtSec: issuedAtSec,
+    };
+
+    const stored = await this.storage.put(record);
+    if (!stored.ok) return stored;
+
+    const token = await signLicense(
+      {
+        tier: args.tier,
+        customerId: args.customerId,
+        keyId,
+        issuedAtSec,
+        expirySec,
+      },
+      this.signingKey,
+    );
+
+    return ok({ token, record });
+  }
+
+  private async findActiveRecordForSubscription(
+    customerId: string,
+    subscriptionId: string,
+  ): Promise<Result<LicenseRecord | null>> {
+    const list = await this.storage.listByCustomer(customerId);
+    if (!list.ok) return list;
+    const match = list.value.find(
+      (r) => r.subscriptionId === subscriptionId && r.status === "active",
+    );
+    return ok(match ?? null);
+  }
+}
+
+function defaultNowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * 32-char hex (16 random bytes). Matches the existing keyId convention used
+ * by `tests/core/license/sign.test.ts` and the `LicensePayload.keyId` JSDoc.
+ */
+function defaultGenerateKeyId(): string {
+  const bytes = new Uint8Array(KEY_ID_BYTE_LENGTH);
+  crypto.getRandomValues(bytes);
+  let hex = "";
+  for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
+  return hex;
+}

--- a/src/core/license/storage-vercel-kv.ts
+++ b/src/core/license/storage-vercel-kv.ts
@@ -51,7 +51,20 @@ export class VercelKVLicenseStorage implements LicenseStorage {
     notWired();
   }
 
+  async listByCustomer(
+    _customerId: string,
+  ): Promise<Result<LicenseRecord[]>> {
+    notWired();
+  }
+
   async revoke(_keyId: string, _reason: string): Promise<Result<void>> {
+    notWired();
+  }
+
+  async revokeAllForCustomer(
+    _customerId: string,
+    _reason: string,
+  ): Promise<Result<void>> {
     notWired();
   }
 

--- a/src/core/license/storage.ts
+++ b/src/core/license/storage.ts
@@ -13,6 +13,12 @@ export interface LicenseRecord {
   keyId: string;
   /** Stripe customer id (e.g. `cus_...`). Used for re-issue and audit. */
   customerId: string;
+  /**
+   * Stripe subscription id (e.g. `sub_...`). Used to map renewal/cancellation
+   * webhook events back to the issued record. Optional only because records
+   * issued before this field was added do not carry it.
+   */
+  subscriptionId?: string;
   tier: "free" | "personal" | "pro";
   status: "active" | "revoked" | "expired";
   issuedAtSec: number;
@@ -41,8 +47,30 @@ export interface LicenseStorage {
    */
   get(keyId: string): Promise<Result<LicenseRecord | null>>;
 
+  /**
+   * Return every record issued for a customer, in unspecified order. Used by
+   * the issuer to map Stripe webhook events (which arrive keyed by customerId
+   * + subscriptionId) back to the corresponding records. Returns `ok([])`
+   * when the customer has no records.
+   *
+   * Production KV implementations should back this with a customerId →
+   * keyId secondary index rather than scanning all records.
+   */
+  listByCustomer(customerId: string): Promise<Result<LicenseRecord[]>>;
+
   /** Add to revocation deny-list. Idempotent. */
   revoke(keyId: string, reason: string): Promise<Result<void>>;
+
+  /**
+   * Add every record issued for a customer to the revocation deny-list.
+   * Idempotent. Used when a customer's subscription is fully cancelled and
+   * we want to invalidate every license they hold (re-issued tokens, lost
+   * device replacements, etc.) in one operation.
+   */
+  revokeAllForCustomer(
+    customerId: string,
+    reason: string,
+  ): Promise<Result<void>>;
 
   /**
    * Returns `ok(true)` if the keyId is on the deny-list, `ok(false)`
@@ -70,8 +98,28 @@ export class MemoryLicenseStorage implements LicenseStorage {
     return { ok: true, value: record ? { ...record } : null };
   }
 
+  async listByCustomer(
+    customerId: string,
+  ): Promise<Result<LicenseRecord[]>> {
+    const matches: LicenseRecord[] = [];
+    for (const record of this.records.values()) {
+      if (record.customerId === customerId) matches.push({ ...record });
+    }
+    return { ok: true, value: matches };
+  }
+
   async revoke(keyId: string, _reason: string): Promise<Result<void>> {
     this.denyList.add(keyId);
+    return { ok: true, value: undefined };
+  }
+
+  async revokeAllForCustomer(
+    customerId: string,
+    _reason: string,
+  ): Promise<Result<void>> {
+    for (const record of this.records.values()) {
+      if (record.customerId === customerId) this.denyList.add(record.keyId);
+    }
     return { ok: true, value: undefined };
   }
 

--- a/tests/core/license/issuer.test.ts
+++ b/tests/core/license/issuer.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { LicenseIssuerImpl } from "@/core/license/issuer";
+import { MemoryLicenseStorage } from "@/core/license/storage";
+import { verifyLicense } from "@/core/license/verify";
+import type { SigningKey } from "@/core/license/sign";
+import { isOk } from "@/utils/result";
+
+const SECRET = "this-is-a-test-signing-secret-32-bytes!";
+const KEY: SigningKey = { secret: SECRET };
+const NOW = 1_750_000_000;
+
+/**
+ * Build an issuer wired with deterministic time + keyId generation so each
+ * test asserts on a known shape rather than chasing random output.
+ */
+function makeIssuer(
+  overrides: {
+    nowSec?: () => number;
+    generateKeyId?: () => string;
+    defaultExpirySec?: number;
+  } = {},
+): { issuer: LicenseIssuerImpl; storage: MemoryLicenseStorage } {
+  const storage = new MemoryLicenseStorage();
+  const issuer = new LicenseIssuerImpl({
+    signingKey: KEY,
+    storage,
+    nowSec: overrides.nowSec ?? (() => NOW),
+    generateKeyId:
+      overrides.generateKeyId ?? (() => "deterministic_key_id_0001"),
+    defaultExpirySec: overrides.defaultExpirySec,
+  });
+  return { issuer, storage };
+}
+
+describe("LicenseIssuerImpl — issueWithToken", () => {
+  it("returns a token that verifyLicense decodes successfully", async () => {
+    const { issuer } = makeIssuer();
+
+    const result = await issuer.issueWithToken({
+      customerId: "cus_001",
+      tier: "personal",
+      subscriptionId: "sub_001",
+    });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const verified = await verifyLicense(result.value.token, KEY, {
+      nowSec: NOW,
+    });
+    expect(verified.ok).toBe(true);
+  });
+
+  it("persists the issued record with status=active", async () => {
+    const { issuer, storage } = makeIssuer();
+
+    const issued = await issuer.issueWithToken({
+      customerId: "cus_002",
+      tier: "pro",
+      subscriptionId: "sub_002",
+    });
+    expect(isOk(issued)).toBe(true);
+    if (!isOk(issued)) return;
+
+    const fetched = await storage.get(issued.value.record.keyId);
+    expect(isOk(fetched) && fetched.value?.status).toBe("active");
+  });
+
+  it("returns a token whose payload echoes the input args", async () => {
+    const { issuer } = makeIssuer();
+
+    const issued = await issuer.issueWithToken({
+      customerId: "cus_003",
+      tier: "pro",
+      subscriptionId: "sub_003",
+    });
+    expect(isOk(issued)).toBe(true);
+    if (!isOk(issued)) return;
+
+    const verified = await verifyLicense(issued.value.token, KEY, {
+      nowSec: NOW,
+    });
+    expect(verified.ok).toBe(true);
+    if (!verified.ok) return;
+    expect({
+      tier: verified.value.tier,
+      customerId: verified.value.customerId,
+    }).toEqual({ tier: "pro", customerId: "cus_003" });
+  });
+
+  it("generates a fresh keyId per call", async () => {
+    const ids = [
+      "kid_a_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "kid_b_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    ];
+    let i = 0;
+    const { issuer } = makeIssuer({ generateKeyId: () => ids[i++] });
+
+    const a = await issuer.issueWithToken({
+      customerId: "cus_004",
+      tier: "personal",
+      subscriptionId: "sub_004a",
+    });
+    const b = await issuer.issueWithToken({
+      customerId: "cus_004",
+      tier: "personal",
+      subscriptionId: "sub_004b",
+    });
+
+    expect(
+      isOk(a) && isOk(b) && a.value.record.keyId !== b.value.record.keyId,
+    ).toBe(true);
+  });
+
+  it("defaults expirySec to nowSec + 31 days when not provided", async () => {
+    const { issuer } = makeIssuer();
+    const expected = NOW + 31 * 24 * 3600;
+
+    const issued = await issuer.issueWithToken({
+      customerId: "cus_005",
+      tier: "personal",
+      subscriptionId: "sub_005",
+    });
+
+    expect(isOk(issued) && issued.value.record.expirySec).toBe(expected);
+  });
+});
+
+describe("LicenseIssuerImpl — issue (interface method)", () => {
+  it("succeeds and the resulting record is recoverable from storage", async () => {
+    const { issuer, storage } = makeIssuer({
+      generateKeyId: () => "interface_method_key_id_xxxxxxxx",
+    });
+
+    const result = await issuer.issue({
+      customerId: "cus_006",
+      tier: "personal",
+      subscriptionId: "sub_006",
+    });
+    expect(isOk(result)).toBe(true);
+
+    const fetched = await storage.get("interface_method_key_id_xxxxxxxx");
+    expect(isOk(fetched) && fetched.value?.customerId).toBe("cus_006");
+  });
+});
+
+describe("LicenseIssuerImpl — revoke", () => {
+  it("marks ALL records for a customer as revoked", async () => {
+    const ids = [
+      "kid_revoke_a_aaaaaaaaaaaaaaaaaaaaa",
+      "kid_revoke_b_bbbbbbbbbbbbbbbbbbbbb",
+    ];
+    let i = 0;
+    const { issuer, storage } = makeIssuer({ generateKeyId: () => ids[i++] });
+
+    await issuer.issue({
+      customerId: "cus_revoke",
+      tier: "personal",
+      subscriptionId: "sub_revoke_a",
+    });
+    await issuer.issue({
+      customerId: "cus_revoke",
+      tier: "personal",
+      subscriptionId: "sub_revoke_b",
+    });
+
+    const revoked = await issuer.revoke({
+      customerId: "cus_revoke",
+      subscriptionId: "sub_revoke_a",
+      reason: "subscription_deleted",
+    });
+    expect(isOk(revoked)).toBe(true);
+
+    const aRevoked = await storage.isRevoked(ids[0]);
+    const bRevoked = await storage.isRevoked(ids[1]);
+    expect(
+      isOk(aRevoked) && aRevoked.value && isOk(bRevoked) && bRevoked.value,
+    ).toBe(true);
+  });
+});
+
+describe("LicenseIssuerImpl — recordRenewal", () => {
+  it("updates expirySec on a matching record", async () => {
+    const keyId = "kid_renewal_match_xxxxxxxxxxxxxxx";
+    const { issuer, storage } = makeIssuer({ generateKeyId: () => keyId });
+
+    await issuer.issue({
+      customerId: "cus_renew",
+      tier: "personal",
+      subscriptionId: "sub_renew",
+    });
+
+    const newExpiry = NOW + 90 * 24 * 3600;
+    await issuer.recordRenewal({
+      customerId: "cus_renew",
+      subscriptionId: "sub_renew",
+      expirySec: newExpiry,
+    });
+
+    const fetched = await storage.get(keyId);
+    expect(isOk(fetched) && fetched.value?.expirySec).toBe(newExpiry);
+  });
+
+  it("falls back to issue when no matching record exists", async () => {
+    const fallbackKeyId = "kid_renewal_fallback_xxxxxxxxxxxx";
+    const { issuer, storage } = makeIssuer({
+      generateKeyId: () => fallbackKeyId,
+    });
+
+    const newExpiry = NOW + 90 * 24 * 3600;
+    const result = await issuer.recordRenewal({
+      customerId: "cus_no_record",
+      subscriptionId: "sub_no_record",
+      expirySec: newExpiry,
+    });
+    expect(isOk(result)).toBe(true);
+
+    const fetched = await storage.get(fallbackKeyId);
+    expect(isOk(fetched) && fetched.value?.expirySec).toBe(newExpiry);
+  });
+});

--- a/tests/core/license/middleware.test.ts
+++ b/tests/core/license/middleware.test.ts
@@ -46,6 +46,11 @@ class FailingRevocationStorage implements LicenseStorage {
   put = this.inner.put.bind(this.inner);
   get = this.inner.get.bind(this.inner);
   revoke = this.inner.revoke.bind(this.inner);
+  // PR R extended LicenseStorage with these for the issuer's renewal /
+  // revoke flows. The middleware path doesn't exercise them, so we delegate
+  // to the in-memory inner so the type contract is satisfied.
+  listByCustomer = this.inner.listByCustomer.bind(this.inner);
+  revokeAllForCustomer = this.inner.revokeAllForCustomer.bind(this.inner);
   async isRevoked(_keyId: string): Promise<Result<boolean>> {
     return err("kv unavailable");
   }

--- a/tests/core/license/storage.test.ts
+++ b/tests/core/license/storage.test.ts
@@ -92,6 +92,61 @@ export function runStorageContractTests(
 
       expect(isOk(revoked) && revoked.value).toBe(true);
     });
+
+    it("listByCustomer returns every record issued for that customer", async () => {
+      const storage = makeStorage();
+      await storage.put(
+        makeRecord({ keyId: "lic_list_a", customerId: "cus_list" }),
+      );
+      await storage.put(
+        makeRecord({ keyId: "lic_list_b", customerId: "cus_list" }),
+      );
+      await storage.put(
+        makeRecord({ keyId: "lic_list_c", customerId: "cus_other" }),
+      );
+
+      const result = await storage.listByCustomer("cus_list");
+
+      expect(isOk(result) && result.value.map((r) => r.keyId).sort()).toEqual([
+        "lic_list_a",
+        "lic_list_b",
+      ]);
+    });
+
+    it("listByCustomer returns ok([]) for an unknown customer", async () => {
+      const storage = makeStorage();
+
+      const result = await storage.listByCustomer("cus_never_seen");
+
+      expect(isOk(result) && result.value).toEqual([]);
+    });
+
+    it("revokeAllForCustomer revokes every record for that customer", async () => {
+      const storage = makeStorage();
+      await storage.put(
+        makeRecord({ keyId: "lic_revall_a", customerId: "cus_revall" }),
+      );
+      await storage.put(
+        makeRecord({ keyId: "lic_revall_b", customerId: "cus_revall" }),
+      );
+      await storage.put(
+        makeRecord({ keyId: "lic_revall_c", customerId: "cus_other" }),
+      );
+
+      await storage.revokeAllForCustomer("cus_revall", "subscription_deleted");
+
+      const aRevoked = await storage.isRevoked("lic_revall_a");
+      const bRevoked = await storage.isRevoked("lic_revall_b");
+      const cRevoked = await storage.isRevoked("lic_revall_c");
+      expect(
+        isOk(aRevoked) &&
+          aRevoked.value &&
+          isOk(bRevoked) &&
+          bRevoked.value &&
+          isOk(cRevoked) &&
+          !cRevoked.value,
+      ).toBe(true);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Concrete `LicenseIssuer` (`src/core/license/issuer.ts`) that composes
`signLicense` with a `LicenseStorage` to satisfy the contract dispatched
by `src/core/stripe/webhook-handler.ts`. This is the missing glue
between Stripe webhook events and our HMAC-signed license tokens.

See `docs/internal/strategy.md` §6.3 (license-key model — anonymous
purchase, HMAC-signed) and §5 (idempotency principle).

## Behavior

- **`issueWithToken`** — generate fresh keyId, persist `LicenseRecord`
  (`status=active`), sign token, return both. Used by the admin
  endpoint and `recordRenewal`'s fallback path.
- **`issue`** (interface method) — wraps `issueWithToken` and discards
  the token; the Stripe webhook needs only an ack since the token is
  delivered out of band by email.
- **`revoke`** — delegates to `storage.revokeAllForCustomer`. MVP is
  customer-level (a cancellation revokes every license that customer
  holds); follow-up will add a subscription→keyId index for
  per-subscription granularity.
- **`recordRenewal`** — idempotent on `(customerId, subscriptionId)`.
  Updates the matching record's `expirySec`, or — if Stripe sends the
  renewal before the create event — falls back to `issue()` so the
  invariant holds even under reordered events.

`nowSec` and `generateKeyId` are constructor-injected for deterministic
testing; production uses `Math.floor(Date.now()/1000)` and a 32-char
hex from `crypto.getRandomValues`.

## Storage extension (justified by issuer needs)

Extended `LicenseStorage` because the issuer cannot map Stripe events
back to records without it:

- `LicenseRecord.subscriptionId` (optional) — used by `recordRenewal`
  to find the right record to update.
- `LicenseStorage.listByCustomer(customerId)` — backs the renewal
  lookup. Production KV adapters should index this server-side rather
  than scanning all records.
- `LicenseStorage.revokeAllForCustomer(customerId, reason)` — atomic
  fan-out revoke; cleanly separated from the existing per-key
  `revoke()`.

`MemoryLicenseStorage` implements both new methods; the
`VercelKVLicenseStorage` stub gains matching `notWired()` bodies so the
interface stays satisfied.

## Idempotency follow-up

`issue` is intentionally NOT idempotent on its own — if Stripe retries
`customer.subscription.created` we will mint a second token for the
same subscription. Both tokens stay valid; not catastrophic. A future
PR can short-circuit by looking up an existing record via
`listByCustomer` filtered by `subscriptionId` (this is also why the
new `LicenseRecord.subscriptionId` field lands here).

## Three-entry-point rule

This PR adds no HTTP surface — `LicenseIssuerImpl` is wired by future
PRs (Stripe webhook endpoint, admin issue endpoint).

## Test plan

- [x] `npm test` — 1605 passing (added 9 issuer tests + 3 storage
      contract tests for the new methods)
- [x] `npx tsc --noEmit` — clean
- [x] One logical assertion per test
- [x] `runStorageContractTests` covers `listByCustomer` (happy path +
      empty), `revokeAllForCustomer` (revokes only matching customer)
- [x] Issuer tests: `issueWithToken` produces verifyLicense-decodable
      token, persists active record, fresh keyId per call, default
      31-day expiry, `issue` interface method, `revoke` revokes all
      customer records, `recordRenewal` updates expiry on match,
      `recordRenewal` falls back to issue when no match

🤖 Generated with [Claude Code](https://claude.com/claude-code)