### PR TITLE
chore(skills): install Phase −1 + Phase 0 agent skills

### DIFF
--- a/.agents/skills/codeql/SKILL.md
+++ b/.agents/skills/codeql/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: codeql
+description: >-
+  Scans a codebase for security vulnerabilities using CodeQL's interprocedural data flow and
+  taint tracking analysis. Triggers on "run codeql", "codeql scan", "codeql analysis", "build
+  codeql database", or "find vulnerabilities with codeql". Supports "run all" (security-and-quality
+  + security-experimental suites) and "important only" (high-precision security findings) scan
+  modes. Also handles creating data extension models and processing CodeQL SARIF output.
+allowed-tools: Bash Read Write Edit Glob Grep AskUserQuestion TaskCreate TaskList TaskUpdate TaskGet TodoRead TodoWrite
+---
+
+# CodeQL Analysis
+
+Supported languages: Python, JavaScript/TypeScript, Go, Java/Kotlin, C/C++, C#, Ruby, Swift.
+
+**Skill resources:** Reference files and templates are located at `{baseDir}/references/` and `{baseDir}/workflows/`.
+
+## Essential Principles
+
+1. **Database quality is non-negotiable.** A database that builds is not automatically good. Always run quality assessment (file counts, baseline LoC, extractor errors) and compare against expected source files. A cached build produces zero useful extraction.
+
+2. **Data extensions catch what CodeQL misses.** Even projects using standard frameworks (Django, Spring, Express) have custom wrappers around database calls, request parsing, or shell execution. Skipping the create-data-extensions workflow means missing vulnerabilities in project-specific code paths.
+
+3. **Explicit suite references prevent silent query dropping.** Never pass pack names directly to `codeql database analyze` — each pack's `defaultSuiteFile` applies hidden filters that can produce zero results. Always generate a custom `.qls` suite file.
+
+4. **Zero findings needs investigation, not celebration.** Zero results can indicate poor database quality, missing models, wrong query packs, or silent suite filtering. Investigate before reporting clean.
+
+5. **macOS Apple Silicon requires workarounds for compiled languages.** Exit code 137 is `arm64e`/`arm64` mismatch, not a build failure. Try Homebrew arm64 tools or Rosetta before falling back to `build-mode=none`.
+
+6. **Follow workflows step by step.** Once a workflow is selected, execute it step by step without skipping phases. Each phase gates the next — skipping quality assessment or data extensions leads to incomplete analysis.
+
+## Output Directory
+
+All generated files (database, build logs, diagnostics, extensions, results) are stored in a single output directory.
+
+- **If the user specifies an output directory** in their prompt, use it as `OUTPUT_DIR`.
+- **If not specified**, default to `./static_analysis_codeql_1`. If that already exists, increment to `_2`, `_3`, etc.
+
+In both cases, **always create the directory** with `mkdir -p` before writing any files.
+
+```bash
+# Resolve output directory
+if [ -n "$USER_SPECIFIED_DIR" ]; then
+  OUTPUT_DIR="$USER_SPECIFIED_DIR"
+else
+  BASE="static_analysis_codeql"
+  N=1
+  while [ -e "${BASE}_${N}" ]; do
+    N=$((N + 1))
+  done
+  OUTPUT_DIR="${BASE}_${N}"
+fi
+mkdir -p "$OUTPUT_DIR"
+```
+
+The output directory is resolved **once** at the start before any workflow executes. All workflows receive `$OUTPUT_DIR` and store their artifacts there:
+
+```
+$OUTPUT_DIR/
+├── rulesets.txt                 # Selected query packs (logged after Step 3)
+├── codeql.db/                   # CodeQL database (dir containing codeql-database.yml)
+├── build.log                    # Build log
+├── codeql-config.yml            # Exclusion config (interpreted languages)
+├── diagnostics/                 # Diagnostic queries and CSVs
+├── extensions/                  # Data extension YAMLs
+├── raw/                         # Unfiltered analysis output
+│   ├── results.sarif
+│   └── <mode>.qls
+└── results/                     # Final results (filtered for important-only, copied for run-all)
+    └── results.sarif
+```
+
+### Database Discovery
+
+A CodeQL database is identified by the presence of a `codeql-database.yml` marker file inside its directory. When searching for existing databases, **always collect all matches** — there may be multiple databases from previous runs or for different languages.
+
+**Discovery command:**
+
+```bash
+# Find ALL CodeQL databases (top-level and one subdirectory deep)
+find . -maxdepth 3 -name "codeql-database.yml" -not -path "*/\.*" 2>/dev/null \
+  | while read -r yml; do dirname "$yml"; done
+```
+
+- **Inside `$OUTPUT_DIR`:** `find "$OUTPUT_DIR" -maxdepth 2 -name "codeql-database.yml"`
+- **Project-wide (for auto-detection):** `find . -maxdepth 3 -name "codeql-database.yml"` — covers databases at the project top level (`./db-name/`) and one subdirectory deep (`./subdir/db-name/`). Does not search deeper.
+
+Never assume a database is named `codeql.db` — discover it by its marker file.
+
+**When multiple databases are found:**
+
+For each discovered database, collect metadata to help the user choose:
+
+```bash
+# For each database, extract language and creation time
+for db in $FOUND_DBS; do
+  CODEQL_LANG=$(codeql resolve database --format=json -- "$db" 2>/dev/null | jq -r '.languages[0]')
+  CREATED=$(grep '^creationMetadata:' -A5 "$db/codeql-database.yml" 2>/dev/null | grep 'creationTime' | awk '{print $2}')
+  echo "$db — language: $CODEQL_LANG, created: $CREATED"
+done
+```
+
+Then use `AskUserQuestion` to let the user select which database to use, or to build a new one. **Skip `AskUserQuestion` if the user explicitly stated which database to use or to build a new one in their prompt.**
+
+## Quick Start
+
+For the common case ("scan this codebase for vulnerabilities"):
+
+```bash
+# 1. Verify CodeQL is installed
+if ! command -v codeql >/dev/null 2>&1; then
+  echo "NOT INSTALLED: codeql binary not found on PATH"
+else
+  codeql --version || echo "ERROR: codeql found but --version failed (check installation)"
+fi
+
+# 2. Resolve output directory
+BASE="static_analysis_codeql"; N=1
+while [ -e "${BASE}_${N}" ]; do N=$((N + 1)); done
+OUTPUT_DIR="${BASE}_${N}"; mkdir -p "$OUTPUT_DIR"
+```
+
+Then execute the full pipeline: **build database → create data extensions → run analysis** using the workflows below.
+
+## When to Use
+
+- Scanning a codebase for security vulnerabilities with deep data flow analysis
+- Building a CodeQL database from source code (with build capability for compiled languages)
+- Finding complex vulnerabilities that require interprocedural taint tracking or AST/CFG analysis
+- Performing comprehensive security audits with multiple query packs
+
+## When NOT to Use
+
+- **Writing custom queries** - Use a dedicated query development skill
+- **CI/CD integration** - Use GitHub Actions documentation directly
+- **Quick pattern searches** - Use Semgrep or grep for speed
+- **No build capability** for compiled languages - Consider Semgrep instead
+- **Single-file or lightweight analysis** - Semgrep is faster for simple pattern matching
+
+## Rationalizations to Reject
+
+These shortcuts lead to missed findings. Do not accept them:
+
+- **"security-extended is enough"** - It is the baseline. Always check if Trail of Bits packs and Community Packs are available for the language. They catch categories `security-extended` misses entirely.
+- **"security-and-quality is the broadest suite"** - `security-and-quality` excludes all `experimental/` query paths. For run-all mode, import both `security-and-quality` and `security-experimental`. The delta is 1–52 queries depending on the language.
+- **"The database built, so it's good"** - A database that builds does not mean it extracted well. Always run quality assessment and check file counts against expected source files.
+- **"Data extensions aren't needed for standard frameworks"** - Even Django/Spring apps have custom wrappers that CodeQL does not model. Skipping extensions means missing vulnerabilities.
+- **"build-mode=none is fine for compiled languages"** - It produces severely incomplete analysis. Only use as an absolute last resort. On macOS, try the arm64 toolchain workaround or Rosetta first.
+- **"The build fails on macOS, just use build-mode=none"** - Exit code 137 is caused by `arm64e`/`arm64` mismatch, not a fundamental build failure. See [macos-arm64e-workaround.md](references/macos-arm64e-workaround.md).
+- **"No findings means the code is secure"** - Zero findings can indicate poor database quality, missing models, or wrong query packs. Investigate before reporting clean results.
+- **"I'll just run the default suite"** / **"I'll just pass the pack names directly"** - Each pack's `defaultSuiteFile` applies hidden filters and can produce zero results. Always use an explicit suite reference.
+- **"I'll put files in the current directory"** - All generated files must go in `$OUTPUT_DIR`. Scattering files in the working directory makes cleanup impossible and risks overwriting previous runs.
+- **"Just use the first database I find"** - Multiple databases may exist for different languages or from previous runs. When more than one is found, present all options to the user. Only skip the prompt when the user already specified which database to use.
+- **"The user said 'scan', that means they want me to pick a database"** - "Scan" is not database selection. If multiple databases exist and the user didn't name one, ask.
+
+---
+
+## Workflow Selection
+
+This skill has three workflows. **Once a workflow is selected, execute it step by step without skipping phases.**
+
+| Workflow | Purpose |
+|----------|---------|
+| [build-database](workflows/build-database.md) | Create CodeQL database using build methods in sequence |
+| [create-data-extensions](workflows/create-data-extensions.md) | Detect or generate data extension models for project APIs |
+| [run-analysis](workflows/run-analysis.md) | Select rulesets, execute queries, process results |
+
+### Auto-Detection Logic
+
+**If user explicitly specifies** what to do (e.g., "build a database", "run analysis on ./my-db"), execute that workflow directly. **Do NOT call `AskUserQuestion` for database selection if the user's prompt already makes their intent clear** — e.g., "build a new database", "analyze the codeql database in static_analysis_codeql_2", "run a full scan from scratch".
+
+**Default pipeline for "test", "scan", "analyze", or similar:** Discover existing databases first, then decide.
+
+```bash
+# Find ALL CodeQL databases by looking for codeql-database.yml marker file
+# Search top-level dirs and one subdirectory deep
+FOUND_DBS=()
+while IFS= read -r yml; do
+  db_dir=$(dirname "$yml")
+  codeql resolve database -- "$db_dir" >/dev/null 2>&1 && FOUND_DBS+=("$db_dir")
+done < <(find . -maxdepth 3 -name "codeql-database.yml" -not -path "*/\.*" 2>/dev/null)
+
+echo "Found ${#FOUND_DBS[@]} existing database(s)"
+```
+
+| Condition | Action |
+|-----------|--------|
+| No databases found | Resolve new `$OUTPUT_DIR`, execute build → extensions → analysis (full pipeline) |
+| One database found | Use `AskUserQuestion`: reuse it or build new? |
+| Multiple databases found | Use `AskUserQuestion`: list all with metadata, let user pick one or build new |
+| User explicitly stated intent | Skip `AskUserQuestion`, act on their instructions directly |
+
+### Database Selection Prompt
+
+When existing databases are found **and the user did not explicitly specify which to use**, present via `AskUserQuestion`:
+
+```
+header: "Existing CodeQL Databases"
+question: "I found existing CodeQL database(s). What would you like to do?"
+options:
+  - label: "<db_path_1> (language: python, created: 2026-02-24)"
+    description: "Reuse this database"
+  - label: "<db_path_2> (language: cpp, created: 2026-02-23)"
+    description: "Reuse this database"
+  - label: "Build a new database"
+    description: "Create a fresh database in a new output directory"
+```
+
+After selection:
+- **If user picks an existing database:** Set `$OUTPUT_DIR` to its parent directory (or the directory containing it), set `$DB_NAME` to the selected path, then proceed to extensions → analysis.
+- **If user picks "Build new":** Resolve a new `$OUTPUT_DIR`, execute build → extensions → analysis.
+
+### General Decision Prompt
+
+If the user's intent is ambiguous (neither database selection nor workflow is clear), ask:
+
+```
+I can help with CodeQL analysis. What would you like to do?
+
+1. **Full scan (Recommended)** - Build database, create extensions, then run analysis
+2. **Build database** - Create a new CodeQL database from this codebase
+3. **Create data extensions** - Generate custom source/sink models for project APIs
+4. **Run analysis** - Run security queries on existing database
+
+[If databases found: "I found N existing database(s): <list paths with language>"]
+[Show output directory: "Output will be stored in <OUTPUT_DIR>"]
+```
+
+---
+
+## Reference Index
+
+| File | Content |
+|------|---------|
+| **Workflows** | |
+| [workflows/build-database.md](workflows/build-database.md) | Database creation with build method sequence |
+| [workflows/create-data-extensions.md](workflows/create-data-extensions.md) | Data extension generation pipeline |
+| [workflows/run-analysis.md](workflows/run-analysis.md) | Query execution and result processing |
+| **References** | |
+| [references/macos-arm64e-workaround.md](references/macos-arm64e-workaround.md) | Apple Silicon build tracing workarounds |
+| [references/build-fixes.md](references/build-fixes.md) | Build failure fix catalog |
+| [references/quality-assessment.md](references/quality-assessment.md) | Database quality metrics and improvements |
+| [references/extension-yaml-format.md](references/extension-yaml-format.md) | Data extension YAML column definitions and examples |
+| [references/sarif-processing.md](references/sarif-processing.md) | jq commands for SARIF output processing |
+| [references/diagnostic-query-templates.md](references/diagnostic-query-templates.md) | QL queries for source/sink enumeration |
+| [references/important-only-suite.md](references/important-only-suite.md) | Important-only suite template and generation |
+| [references/run-all-suite.md](references/run-all-suite.md) | Run-all suite template |
+| [references/ruleset-catalog.md](references/ruleset-catalog.md) | Available query packs by language |
+| [references/threat-models.md](references/threat-models.md) | Threat model configuration |
+| [references/language-details.md](references/language-details.md) | Language-specific build and extraction details |
+| [references/performance-tuning.md](references/performance-tuning.md) | Memory, threading, and timeout configuration |
+
+---
+
+## Success Criteria
+
+A complete CodeQL analysis run should satisfy:
+
+- [ ] Output directory resolved (user-specified or auto-incremented default)
+- [ ] All generated files stored inside `$OUTPUT_DIR`
+- [ ] Database built (discovered via `codeql-database.yml` marker) with quality assessment passed (baseline LoC > 0, errors < 5%)
+- [ ] Data extensions evaluated — either created in `$OUTPUT_DIR/extensions/` or explicitly skipped with justification
+- [ ] Analysis run with explicit suite reference (not default pack suite)
+- [ ] All installed query packs (official + Trail of Bits + Community) used or explicitly excluded
+- [ ] Selected query packs logged to `$OUTPUT_DIR/rulesets.txt`
+- [ ] Unfiltered results preserved in `$OUTPUT_DIR/raw/results.sarif`
+- [ ] Final results in `$OUTPUT_DIR/results/results.sarif` (filtered for important-only, copied for run-all)
+- [ ] Zero-finding results investigated (database quality, model coverage, suite selection)
+- [ ] Build log preserved at `$OUTPUT_DIR/build.log` with all commands, fixes, and quality assessments

--- a/.agents/skills/codeql/references/build-fixes.md
+++ b/.agents/skills/codeql/references/build-fixes.md
@@ -1,0 +1,90 @@
+# Build Fixes
+
+Fixes to apply when a CodeQL database build method fails. Try these in order, then retry the current build method. **Log each fix attempt.**
+
+## 1. Clean existing state
+
+```bash
+log_step "Applying fix: clean existing state"
+rm -rf "$DB_NAME"
+log_result "Removed $DB_NAME"
+```
+
+## 2. Clean build cache
+
+```bash
+log_step "Applying fix: clean build cache"
+CLEANED=""
+make clean 2>/dev/null && CLEANED="$CLEANED make"
+rm -rf build CMakeCache.txt CMakeFiles 2>/dev/null && CLEANED="$CLEANED cmake-artifacts"
+./gradlew clean 2>/dev/null && CLEANED="$CLEANED gradle"
+mvn clean 2>/dev/null && CLEANED="$CLEANED maven"
+cargo clean 2>/dev/null && CLEANED="$CLEANED cargo"
+log_result "Cleaned: $CLEANED"
+```
+
+## 3. Install missing dependencies
+
+> **Note:** The commands below install the *target project's* dependencies so CodeQL can trace the build. Use whatever package manager the target project expects (`pip`, `npm`, `go mod`, etc.) — these are not the skill's own tooling preferences.
+
+```bash
+log_step "Applying fix: install dependencies"
+
+# Python — use target project's package manager (pip/uv/poetry)
+if [ -f requirements.txt ]; then
+  log_cmd "pip install -r requirements.txt"
+  pip install -r requirements.txt 2>&1 | tee -a "$LOG_FILE"
+fi
+if [ -f setup.py ] || [ -f pyproject.toml ]; then
+  log_cmd "pip install -e ."
+  pip install -e . 2>&1 | tee -a "$LOG_FILE"
+fi
+
+# Node - log installed packages
+if [ -f package.json ]; then
+  log_cmd "npm install"
+  npm install 2>&1 | tee -a "$LOG_FILE"
+fi
+
+# Go
+if [ -f go.mod ]; then
+  log_cmd "go mod download"
+  go mod download 2>&1 | tee -a "$LOG_FILE"
+fi
+
+# Java - log downloaded dependencies
+if [ -f build.gradle ] || [ -f build.gradle.kts ]; then
+  log_cmd "./gradlew dependencies --refresh-dependencies"
+  ./gradlew dependencies --refresh-dependencies 2>&1 | tee -a "$LOG_FILE"
+fi
+if [ -f pom.xml ]; then
+  log_cmd "mvn dependency:resolve"
+  mvn dependency:resolve 2>&1 | tee -a "$LOG_FILE"
+fi
+
+# Rust
+if [ -f Cargo.toml ]; then
+  log_cmd "cargo fetch"
+  cargo fetch 2>&1 | tee -a "$LOG_FILE"
+fi
+
+log_result "Dependencies installed - see above for details"
+```
+
+## 4. Handle private registries
+
+If dependencies require authentication, ask user:
+```
+AskUserQuestion: "Build requires private registry access. Options:"
+  1. "I'll configure auth and retry"
+  2. "Skip these dependencies"
+  3. "Show me what's needed"
+```
+
+```bash
+# Log authentication setup if performed
+log_step "Private registry authentication configured"
+log_result "Registry: <REGISTRY_URL>, Method: <AUTH_METHOD>"
+```
+
+**After fixes:** Retry current build method. If still fails, move to next method.

--- a/.agents/skills/codeql/references/diagnostic-query-templates.md
+++ b/.agents/skills/codeql/references/diagnostic-query-templates.md
@@ -1,0 +1,339 @@
+# Diagnostic Query Templates
+
+Language-specific QL queries for enumerating sources and sinks recognized by CodeQL. Used during the data extensions creation process.
+
+## Source Enumeration Query
+
+All languages use the class `RemoteFlowSource`. The import differs per language.
+
+### Import Reference
+
+| Language | Imports | Class |
+|----------|---------|-------|
+| Python | `import python` + `import semmle.python.dataflow.new.RemoteFlowSources` | `RemoteFlowSource` |
+| JavaScript | `import javascript` | `RemoteFlowSource` |
+| Java | `import java` + `import semmle.code.java.dataflow.FlowSources` | `RemoteFlowSource` |
+| Go | `import go` | `RemoteFlowSource` |
+| C/C++ | `import cpp` + `import semmle.code.cpp.security.FlowSources` | `RemoteFlowSource` |
+| C# | `import csharp` + `import semmle.code.csharp.security.dataflow.flowsources.Remote` | `RemoteFlowSource` |
+| Ruby | `import ruby` + `import codeql.ruby.dataflow.RemoteFlowSources` | `RemoteFlowSource` |
+
+### Template (Python — swap imports per table above)
+
+```ql
+/**
+ * @name List recognized dataflow sources
+ * @description Enumerates all locations CodeQL recognizes as dataflow sources
+ * @kind problem
+ * @id custom/list-sources
+ */
+import python
+import semmle.python.dataflow.new.RemoteFlowSources
+
+from RemoteFlowSource src
+select src,
+  src.getSourceType()
+    + " | " + src.getLocation().getFile().getRelativePath()
+    + ":" + src.getLocation().getStartLine().toString()
+```
+
+**Note:** `getSourceType()` is available on Python, Java, and C#. For Go, JavaScript, Ruby, and C++ replace the select with:
+```ql
+select src,
+  src.getLocation().getFile().getRelativePath()
+    + ":" + src.getLocation().getStartLine().toString()
+```
+
+---
+
+## Sink Enumeration Queries
+
+The Concepts API differs significantly across languages. Use the correct template.
+
+### Concept Class Reference
+
+| Concept | Python | JavaScript | Go | Ruby |
+|---------|--------|------------|-----|------|
+| SQL | `SqlExecution.getSql()` | `DatabaseAccess.getAQueryArgument()` | `SQL::QueryString` (is-a Node) | `SqlExecution.getSql()` |
+| Command exec | `SystemCommandExecution.getCommand()` | `SystemCommandExecution.getACommandArgument()` | `SystemCommandExecution.getCommandName()` | `SystemCommandExecution.getAnArgument()` |
+| File access | `FileSystemAccess.getAPathArgument()` | `FileSystemAccess.getAPathArgument()` | `FileSystemAccess.getAPathArgument()` | `FileSystemAccess.getAPathArgument()` |
+| HTTP client | `Http::Client::Request.getAUrlPart()` | — | — | — |
+| Decoding | `Decoding.getAnInput()` | — | — | — |
+| XML parsing | — | — | — | `XmlParserCall.getAnInput()` |
+
+### Python
+
+```ql
+/**
+ * @name List recognized dataflow sinks
+ * @description Enumerates security-relevant sinks CodeQL recognizes
+ * @kind problem
+ * @id custom/list-sinks
+ */
+import python
+import semmle.python.Concepts
+
+from DataFlow::Node sink, string kind
+where
+  exists(SqlExecution e | sink = e.getSql() and kind = "sql-execution")
+  or
+  exists(SystemCommandExecution e |
+    sink = e.getCommand() and kind = "command-execution"
+  )
+  or
+  exists(FileSystemAccess e |
+    sink = e.getAPathArgument() and kind = "file-access"
+  )
+  or
+  exists(Http::Client::Request r |
+    sink = r.getAUrlPart() and kind = "http-request"
+  )
+  or
+  exists(Decoding d | sink = d.getAnInput() and kind = "decoding")
+  or
+  exists(CodeExecution e | sink = e.getCode() and kind = "code-execution")
+select sink,
+  kind
+    + " | " + sink.getLocation().getFile().getRelativePath()
+    + ":" + sink.getLocation().getStartLine().toString()
+```
+
+### JavaScript / TypeScript
+
+```ql
+/**
+ * @name List recognized dataflow sinks
+ * @description Enumerates security-relevant sinks CodeQL recognizes
+ * @kind problem
+ * @id custom/list-sinks-js
+ */
+import javascript
+
+from DataFlow::Node sink, string kind
+where
+  exists(DatabaseAccess e |
+    sink = e.getAQueryArgument() and kind = "database-access"
+  )
+  or
+  exists(SystemCommandExecution e |
+    sink = e.getACommandArgument() and kind = "command-execution"
+  )
+  or
+  exists(FileSystemAccess e |
+    sink = e.getAPathArgument() and kind = "file-access"
+  )
+select sink,
+  kind
+    + " | " + sink.getLocation().getFile().getRelativePath()
+    + ":" + sink.getLocation().getStartLine().toString()
+```
+
+### Go
+
+```ql
+/**
+ * @name List recognized dataflow sinks
+ * @description Enumerates security-relevant sinks CodeQL recognizes
+ * @kind problem
+ * @id custom/list-sinks-go
+ */
+import go
+import semmle.go.frameworks.SQL
+
+from DataFlow::Node sink, string kind
+where
+  sink instanceof SQL::QueryString and kind = "sql-query"
+  or
+  exists(SystemCommandExecution e |
+    sink = e.getCommandName() and kind = "command-execution"
+  )
+  or
+  exists(FileSystemAccess e |
+    sink = e.getAPathArgument() and kind = "file-access"
+  )
+select sink,
+  kind
+    + " | " + sink.getLocation().getFile().getRelativePath()
+    + ":" + sink.getLocation().getStartLine().toString()
+```
+
+### Ruby
+
+```ql
+/**
+ * @name List recognized dataflow sinks
+ * @description Enumerates security-relevant sinks CodeQL recognizes
+ * @kind problem
+ * @id custom/list-sinks-ruby
+ */
+import ruby
+import codeql.ruby.Concepts
+
+from DataFlow::Node sink, string kind
+where
+  exists(SqlExecution e | sink = e.getSql() and kind = "sql-execution")
+  or
+  exists(SystemCommandExecution e |
+    sink = e.getAnArgument() and kind = "command-execution"
+  )
+  or
+  exists(FileSystemAccess e |
+    sink = e.getAPathArgument() and kind = "file-access"
+  )
+  or
+  exists(CodeExecution e | sink = e.getCode() and kind = "code-execution")
+select sink,
+  kind
+    + " | " + sink.getLocation().getFile().getRelativePath()
+    + ":" + sink.getLocation().getStartLine().toString()
+```
+
+### Java
+
+Java lacks a unified Concepts module. Use language-specific sink classes. The diagnostics query needs its own `qlpack.yml` with a `codeql/java-all` dependency — create it alongside the `.ql` files:
+
+```yaml
+# $DIAG_DIR/qlpack.yml
+name: custom/diagnostics
+version: 0.0.1
+dependencies:
+  codeql/java-all: "*"
+```
+
+Then run `codeql pack install` in the diagnostics directory before executing queries.
+
+```ql
+/**
+ * @name List recognized dataflow sinks
+ * @description Enumerates security-relevant sinks CodeQL recognizes
+ * @kind problem
+ * @id custom/list-sinks
+ */
+import java
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.security.QueryInjection
+import semmle.code.java.security.CommandLineQuery
+import semmle.code.java.security.TaintedPathQuery
+import semmle.code.java.security.XSS
+import semmle.code.java.security.RequestForgery
+import semmle.code.java.security.Xxe
+
+from DataFlow::Node sink, string kind
+where
+  sink instanceof QueryInjectionSink and kind = "sql-injection"
+  or
+  sink instanceof CommandInjectionSink and kind = "command-injection"
+  or
+  sink instanceof TaintedPathSink and kind = "path-injection"
+  or
+  sink instanceof XssSink and kind = "xss"
+  or
+  sink instanceof RequestForgerySink and kind = "ssrf"
+  or
+  sink instanceof XxeSink and kind = "xxe"
+select sink,
+  kind
+    + " | " + sink.getLocation().getFile().getRelativePath()
+    + ":" + sink.getLocation().getStartLine().toString()
+```
+
+### C / C++
+
+C++ uses a similar per-vulnerability-class pattern. Requires a `qlpack.yml` with `codeql/cpp-all` dependency (same approach as Java):
+
+```yaml
+# $DIAG_DIR/qlpack.yml
+name: custom/diagnostics
+version: 0.0.1
+dependencies:
+  codeql/cpp-all: "*"
+```
+
+Then run `codeql pack install` in the diagnostics directory before executing queries.
+
+```ql
+/**
+ * @name List recognized dataflow sinks
+ * @description Enumerates security-relevant sinks CodeQL recognizes
+ * @kind problem
+ * @id custom/list-sinks-cpp
+ */
+import cpp
+import semmle.code.cpp.dataflow.DataFlow
+import semmle.code.cpp.security.CommandExecution
+import semmle.code.cpp.security.FileAccess
+import semmle.code.cpp.security.BufferWrite
+
+from DataFlow::Node sink, string kind
+where
+  exists(FunctionCall call |
+    sink.asExpr() = call.getAnArgument() and
+    call.getTarget().hasGlobalOrStdName("system") and
+    kind = "command-injection"
+  )
+  or
+  exists(FunctionCall call |
+    sink.asExpr() = call.getAnArgument() and
+    call.getTarget().hasGlobalOrStdName(["fopen", "open", "freopen"]) and
+    kind = "file-access"
+  )
+  or
+  exists(FunctionCall call |
+    sink.asExpr() = call.getAnArgument() and
+    call.getTarget().hasGlobalOrStdName(["sprintf", "strcpy", "strcat", "gets"]) and
+    kind = "buffer-write"
+  )
+  or
+  exists(FunctionCall call |
+    sink.asExpr() = call.getAnArgument() and
+    call.getTarget().hasGlobalOrStdName(["execl", "execle", "execlp", "execv", "execvp", "execvpe", "popen"]) and
+    kind = "command-execution"
+  )
+select sink,
+  kind
+    + " | " + sink.getLocation().getFile().getRelativePath()
+    + ":" + sink.getLocation().getStartLine().toString()
+```
+
+### C\#
+
+C# uses per-vulnerability sink classes. Requires a `qlpack.yml` with `codeql/csharp-all` dependency:
+
+```yaml
+# $DIAG_DIR/qlpack.yml
+name: custom/diagnostics
+version: 0.0.1
+dependencies:
+  codeql/csharp-all: "*"
+```
+
+Then run `codeql pack install` in the diagnostics directory before executing queries.
+
+```ql
+/**
+ * @name List recognized dataflow sinks
+ * @description Enumerates security-relevant sinks CodeQL recognizes
+ * @kind problem
+ * @id custom/list-sinks-csharp
+ */
+import csharp
+import semmle.code.csharp.dataflow.DataFlow
+import semmle.code.csharp.security.dataflow.SqlInjectionQuery
+import semmle.code.csharp.security.dataflow.CommandInjectionQuery
+import semmle.code.csharp.security.dataflow.TaintedPathQuery
+import semmle.code.csharp.security.dataflow.XSSQuery
+
+from DataFlow::Node sink, string kind
+where
+  sink instanceof SqlInjection::Sink and kind = "sql-injection"
+  or
+  sink instanceof CommandInjection::Sink and kind = "command-injection"
+  or
+  sink instanceof TaintedPath::Sink and kind = "path-injection"
+  or
+  sink instanceof XSS::Sink and kind = "xss"
+select sink,
+  kind
+    + " | " + sink.getLocation().getFile().getRelativePath()
+    + ":" + sink.getLocation().getStartLine().toString()
+```

--- a/.agents/skills/codeql/references/extension-yaml-format.md
+++ b/.agents/skills/codeql/references/extension-yaml-format.md
@@ -1,0 +1,209 @@
+# Data Extension YAML Format
+
+YAML format for CodeQL data extension files. Used by the create-data-extensions workflow to model project-specific sources, sinks, and flow summaries.
+
+## Structure
+
+All extension files follow this structure:
+
+```yaml
+extensions:
+  - addsTo:
+      pack: codeql/<language>-all  # Target library pack
+      extensible: <model-type>      # sourceModel, sinkModel, summaryModel, neutralModel
+    data:
+      - [<columns>]
+```
+
+## Source Models
+
+Columns: `[package, type, subtypes, name, signature, ext, output, kind, provenance]`
+
+| Column | Description | Example |
+|--------|-------------|---------|
+| package | Module/package path | `myapp.auth` |
+| type | Class or module name | `AuthManager` |
+| subtypes | Include subclasses | `True` (Java: capitalized) / `true` (Python/JS/Go) |
+| name | Method name | `get_token` |
+| signature | Method signature (optional) | `""` (Python/JS), `"(String,int)"` (Java) |
+| ext | Extension (optional) | `""` |
+| output | What is tainted | `ReturnValue`, `Parameter[0]` (Java) / `Argument[0]` (Python/JS/Go) |
+| kind | Source category | `remote`, `local`, `file`, `environment`, `database` |
+| provenance | How model was created | `manual` |
+
+**Java-specific format differences:**
+- **subtypes**: Use `True` / `False` (capitalized, Python-style), not `true` / `false`
+- **output for parameters**: Use `Parameter[N]` (not `Argument[N]`) to mark method parameters as sources
+- **signature**: Required for disambiguation — use Java type syntax: `"(String)"`, `"(String,int)"`
+- **Parameter ranges**: Use `Parameter[0..2]` to mark multiple consecutive parameters
+
+Example (Python):
+
+```yaml
+# $OUTPUT_DIR/extensions/sources.yml
+extensions:
+  - addsTo:
+      pack: codeql/python-all
+      extensible: sourceModel
+    data:
+      - ["myapp.http", "Request", true, "get_param", "", "", "ReturnValue", "remote", "manual"]
+      - ["myapp.http", "Request", true, "get_header", "", "", "ReturnValue", "remote", "manual"]
+```
+
+Example (Java — note `True`, `Parameter[N]`, and signature):
+
+```yaml
+# $OUTPUT_DIR/extensions/sources.yml
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sourceModel
+    data:
+      - ["com.myapp.controller", "ApiController", True, "search", "(String)", "", "Parameter[0]", "remote", "manual"]
+      - ["com.myapp.service", "FileService", True, "upload", "(String,String)", "", "Parameter[0..1]", "remote", "manual"]
+```
+
+## Sink Models
+
+Columns: `[package, type, subtypes, name, signature, ext, input, kind, provenance]`
+
+Note: column 7 is `input` (which argument receives tainted data), not `output`.
+
+| Kind | Vulnerability |
+|------|---------------|
+| `sql-injection` | SQL injection |
+| `command-injection` | Command injection |
+| `path-injection` | Path traversal |
+| `xss` | Cross-site scripting |
+| `code-injection` | Code injection |
+| `ssrf` | Server-side request forgery |
+| `unsafe-deserialization` | Insecure deserialization |
+
+Example (Python):
+
+```yaml
+# $OUTPUT_DIR/extensions/sinks.yml
+extensions:
+  - addsTo:
+      pack: codeql/python-all
+      extensible: sinkModel
+    data:
+      - ["myapp.db", "Connection", true, "raw_query", "", "", "Argument[0]", "sql-injection", "manual"]
+      - ["myapp.shell", "Runner", false, "execute", "", "", "Argument[0]", "command-injection", "manual"]
+```
+
+Example (Java — note `True` and `Argument[N]` for sink input):
+
+```yaml
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["com.myapp.db", "QueryRunner", True, "execute", "(String)", "", "Argument[0]", "sql-injection", "manual"]
+```
+
+## Summary Models
+
+Columns: `[package, type, subtypes, name, signature, ext, input, output, kind, provenance]`
+
+| Kind | Description |
+|------|-------------|
+| `taint` | Data flows through, still tainted |
+| `value` | Data flows through, exact value preserved |
+
+Example:
+
+```yaml
+# $OUTPUT_DIR/extensions/summaries.yml
+extensions:
+  # Pass-through: taint propagates
+  - addsTo:
+      pack: codeql/python-all
+      extensible: summaryModel
+    data:
+      - ["myapp.cache", "Cache", true, "get", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
+      - ["myapp.utils", "JSON", false, "parse", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
+
+```
+
+## Neutral Models
+
+Columns: `[package, type, name, signature, kind, provenance]` (6 columns, NOT the 10-column `summaryModel` format).
+
+Use `neutralModel` to explicitly block taint propagation through known-safe functions.
+
+Example:
+
+```yaml
+  - addsTo:
+      pack: codeql/python-all
+      extensible: neutralModel
+    data:
+      - ["myapp.security", "Sanitizer", "escape_html", "", "summary", "manual"]
+```
+
+**`neutralModel` vs no model:** If a function has no model at all, CodeQL may still infer flow through it. Use `neutralModel` to explicitly block taint propagation through known-safe functions.
+
+## Language-Specific Notes
+
+**Python:** Use dotted module paths for `package` (e.g., `myapp.db`).
+
+**JavaScript:** `package` is often `""` for project-local code. Use the import path for npm packages.
+
+**Go:** Use full import paths (e.g., `myapp/internal/db`). `type` is often `""` for package-level functions.
+
+**Java:** Use fully qualified package names (e.g., `com.myapp.db`).
+
+**C/C++:** Use `""` for package, put the namespace in `type`.
+
+## Deploying Extensions
+
+**Known limitation:** `--additional-packs` and `--model-packs` flags do not work with pre-compiled query packs (bundled CodeQL distributions that cache `java-all` inside `.codeql/libraries/`). Extensions placed in a standalone model pack directory will be resolved by `codeql resolve qlpacks` but silently ignored during `codeql database analyze`.
+
+**Workaround — copy extensions into the library pack's `ext/` directory:**
+
+> **Warning:** Files copied into the `ext/` directory live inside CodeQL's managed pack cache. They will be **lost** when packs are updated via `codeql pack download` or version upgrades. After any pack update, re-run this deployment step to restore the extensions.
+
+```bash
+# Find the java-all ext directory used by the query pack
+JAVA_ALL_EXT=$(find "$(codeql resolve qlpacks 2>/dev/null | grep 'java-queries' | awk '{print $NF}' | tr -d '()')" \
+  -path '*/.codeql/libraries/codeql/java-all/*/ext' -type d 2>/dev/null | head -1)
+
+if [ -n "$JAVA_ALL_EXT" ]; then
+  PROJECT_NAME=$(basename "$(pwd)")
+  cp "$OUTPUT_DIR/extensions/sources.yml" "$JAVA_ALL_EXT/${PROJECT_NAME}.sources.model.yml"
+  [ -f "$OUTPUT_DIR/extensions/sinks.yml" ] && cp "$OUTPUT_DIR/extensions/sinks.yml" "$JAVA_ALL_EXT/${PROJECT_NAME}.sinks.model.yml"
+  [ -f "$OUTPUT_DIR/extensions/summaries.yml" ] && cp "$OUTPUT_DIR/extensions/summaries.yml" "$JAVA_ALL_EXT/${PROJECT_NAME}.summaries.model.yml"
+
+  # Verify deployment — confirm files landed correctly
+  DEPLOYED=$(ls "$JAVA_ALL_EXT/${PROJECT_NAME}".*.model.yml 2>/dev/null | wc -l)
+  if [ "$DEPLOYED" -gt 0 ]; then
+    echo "Extensions deployed to $JAVA_ALL_EXT ($DEPLOYED files):"
+    ls -la "$JAVA_ALL_EXT/${PROJECT_NAME}".*.model.yml
+  else
+    echo "ERROR: Files were copied but verification failed. Check path: $JAVA_ALL_EXT"
+  fi
+else
+  echo "WARNING: Could not find java-all ext directory. Extensions may not load."
+  echo "Attempted path lookup from: codeql resolve qlpacks | grep java-queries"
+  echo "Run 'codeql resolve qlpacks' manually to debug."
+fi
+```
+
+**For Python/JS/Go:** The same limitation may apply. Locate the `<lang>-all` pack's `ext/` directory and copy extensions there.
+
+**Alternative (if query packs are NOT pre-compiled):** Use `--additional-packs=./codeql-extensions` with a proper model pack `qlpack.yml`:
+
+```yaml
+# $OUTPUT_DIR/extensions/qlpack.yml
+name: custom/<project>-extensions
+version: 0.0.1
+library: true
+extensionTargets:
+  codeql/<lang>-all: "*"
+dataExtensions:
+  - sources.yml
+  - sinks.yml
+  - summaries.yml
+```

--- a/.agents/skills/codeql/references/important-only-suite.md
+++ b/.agents/skills/codeql/references/important-only-suite.md
@@ -1,0 +1,153 @@
+# Important-Only Query Suite
+
+In important-only mode, generate a custom `.qls` query suite file at runtime. This applies the same precision/severity filtering to **all** packs (official + third-party).
+
+## Why a Custom Suite
+
+The built-in `security-extended` suite only applies to the official `codeql/<lang>-queries` pack. Third-party packs (Trail of Bits, Community Packs) run unfiltered when passed directly to `codeql database analyze`. A custom `.qls` suite loads queries from all packs and applies a single set of `include`/`exclude` filters uniformly.
+
+## Metadata Criteria
+
+Two-phase filtering: the **suite** selects candidate queries (broad), then a **post-analysis jq filter** removes low-severity medium-precision results from the SARIF output.
+
+### Phase 1: Suite selection (which queries run)
+
+Queries are included if they match **any** of these blocks (OR logic across blocks, AND logic within):
+
+| Block | kind | precision | problem.severity | tags |
+|-------|------|-----------|-----------------|------|
+| 1 | `problem`, `path-problem` | `high`, `very-high` | *(any)* | must contain `security` |
+| 2 | `problem`, `path-problem` | `medium` | *(any)* | must contain `security` |
+
+### Phase 2: Post-analysis filter (which results are reported)
+
+After `codeql database analyze` completes, filter the SARIF output:
+
+| precision | security-severity | Action |
+|-----------|-------------------|--------|
+| high / very-high | *(any)* | **Keep** |
+| medium | >= 6.0 | **Keep** |
+| medium | < 6.0 or missing | **Drop** |
+
+This ensures medium-precision queries with meaningful security impact (e.g., `cpp/path-injection` at 7.5, `cpp/world-writable-file-creation` at 7.8) are included, while noisy low-severity medium-precision findings are filtered out.
+
+Excluded: deprecated queries, model editor/generator queries. Experimental queries are **included**.
+
+**Key difference from `security-extended`:** The `security-extended` suite includes medium-precision queries at any severity. Important-only mode adds a security-severity threshold to reduce noise from medium-precision queries that flag low-impact issues.
+
+## Suite Template
+
+Generate this file as `important-only.qls` in the results directory before running analysis:
+
+```yaml
+- description: Important-only — security vulnerabilities, medium-high confidence
+# Official queries
+- queries: .
+  from: codeql/<CODEQL_LANG>-queries
+# Third-party packs (include only if installed, one entry per pack)
+# - queries: .
+#   from: trailofbits/<CODEQL_LANG>-queries
+# - queries: .
+#   from: GitHubSecurityLab/CodeQL-Community-Packs-<CODEQL_LANG>
+# Filtering: security only, high/very-high precision (any severity),
+# medium precision (any severity — low-severity filtered post-analysis by security-severity score).
+# Experimental queries included.
+- include:
+    kind:
+      - problem
+      - path-problem
+    precision:
+      - high
+      - very-high
+    tags contain:
+      - security
+- include:
+    kind:
+      - problem
+      - path-problem
+    precision:
+      - medium
+    tags contain:
+      - security
+- exclude:
+    deprecated: //
+- exclude:
+    tags contain:
+      - modeleditor
+      - modelgenerator
+```
+
+> **Post-analysis step required:** After running the analysis, apply the post-analysis jq filter (defined in the run-analysis workflow Step 5) to remove medium-precision results with `security-severity` < 6.0.
+
+## Generation Script
+
+The agent should generate the suite file dynamically based on installed packs:
+
+```bash
+RAW_DIR="$OUTPUT_DIR/raw"
+SUITE_FILE="$RAW_DIR/important-only.qls"
+
+# NOTE: CODEQL_LANG must be set before running this script (e.g., CODEQL_LANG=cpp)
+# NOTE: INSTALLED_THIRD_PARTY_PACKS must be a space-separated list of pack names
+
+# Use a heredoc WITHOUT quotes so ${CODEQL_LANG} expands
+cat > "$SUITE_FILE" << HEADER
+- description: Important-only — security vulnerabilities, medium-high confidence
+- queries: .
+  from: codeql/${CODEQL_LANG}-queries
+HEADER
+
+# Add each installed third-party pack
+for PACK in $INSTALLED_THIRD_PARTY_PACKS; do
+  cat >> "$SUITE_FILE" << PACK_ENTRY
+- queries: .
+  from: ${PACK}
+PACK_ENTRY
+done
+
+# Append the filtering rules (quoted heredoc — no variable expansion needed)
+cat >> "$SUITE_FILE" << 'FILTERS'
+- include:
+    kind:
+      - problem
+      - path-problem
+    precision:
+      - high
+      - very-high
+    tags contain:
+      - security
+- include:
+    kind:
+      - problem
+      - path-problem
+    precision:
+      - medium
+    tags contain:
+      - security
+- exclude:
+    deprecated: //
+- exclude:
+    tags contain:
+      - modeleditor
+      - modelgenerator
+FILTERS
+
+# Verify the suite resolves correctly
+: "${CODEQL_LANG:?ERROR: CODEQL_LANG must be set before generating suite}"
+: "${SUITE_FILE:?ERROR: SUITE_FILE must be set}"
+
+if ! codeql resolve queries "$SUITE_FILE" | head -20; then
+  echo "ERROR: Suite file failed to resolve. Check CODEQL_LANG=$CODEQL_LANG and installed packs."
+fi
+echo "Suite generated: $SUITE_FILE"
+```
+
+## How Filtering Works on Third-Party Queries
+
+CodeQL query suite filters match on query metadata (`@precision`, `@problem.severity`, `@tags`). Third-party queries that:
+
+- **Have proper metadata**: Filtered normally (kept if they match the include criteria)
+- **Lack `@precision`**: Excluded by `include` blocks (they require precision to match). This is correct — if a query doesn't declare its precision, we cannot assess its confidence.
+- **Lack `@tags security`**: Excluded. Non-security queries are not relevant to important-only mode.
+
+This is a stricter-than-necessary filter for third-party packs, but it ensures only well-annotated security queries run in important-only mode. The post-analysis jq filter then further narrows medium-precision results to those with `security-severity` >= 6.0.

--- a/.agents/skills/codeql/references/language-details.md
+++ b/.agents/skills/codeql/references/language-details.md
@@ -1,0 +1,207 @@
+# Language-Specific Guidance
+
+## No Build Required
+
+### Python
+
+```bash
+codeql database create codeql.db --language=python --source-root=.
+```
+
+**Framework Support:**
+- Django, Flask, FastAPI: Built-in models
+- Tornado, Pyramid: Partial support
+- Custom frameworks: May need data extensions
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Missing Django models | Ensure `settings.py` is at expected location |
+| Virtual env included | Use `paths-ignore` in config |
+| Type stubs missing | Install `types-*` packages before extraction |
+
+### JavaScript/TypeScript
+
+```bash
+codeql database create codeql.db --language=javascript --source-root=.
+```
+
+**Framework Support:**
+- React, Vue, Angular: Built-in models
+- Express, Koa, Fastify: HTTP source/sink models
+- Next.js, Nuxt: Partial SSR support
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| node_modules bloat | Already excluded by default |
+| TypeScript not parsed | Ensure `tsconfig.json` is valid |
+| Monorepo issues | Use `--source-root` for specific package |
+
+### Go
+
+```bash
+codeql database create codeql.db --language=go --source-root=.
+```
+
+**Framework Support:**
+- net/http, Gin, Echo, Chi: Built-in models
+- gRPC: Partial support
+- Custom routers: May need data extensions
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Missing dependencies | Run `go mod download` first |
+| Vendor directory | CodeQL handles automatically |
+| CGO code | Requires `--command='go build'` with CGO enabled |
+
+### Ruby
+
+```bash
+codeql database create codeql.db --language=ruby --source-root=.
+```
+
+**Framework Support:**
+- Rails: Full support (controllers, models, views)
+- Sinatra: Built-in support
+- Hanami: Partial support
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Bundler issues | Run `bundle install` first |
+| Rails engines | May need multiple database passes |
+
+## Build Required
+
+### C/C++
+
+```bash
+# Make
+codeql database create codeql.db --language=cpp --command='make -j8'
+
+# CMake
+codeql database create codeql.db --language=cpp \
+  --source-root=/path/to/src \
+  --command='cmake --build build'
+
+# Ninja
+codeql database create codeql.db --language=cpp \
+  --command='ninja -C build'
+```
+
+**Build System Tips:**
+| Build System | Command |
+|--------------|---------|
+| Make | `make clean && make -j$(nproc)` |
+| CMake | `cmake -B build && cmake --build build` |
+| Meson | `meson setup build && ninja -C build` |
+| Bazel | `bazel build //...` |
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Partial extraction | Ensure `make clean` before CodeQL build |
+| Header-only libraries | Use `--extractor-option cpp_trap_headers=true` |
+| Cross-compilation | Set `CODEQL_EXTRACTOR_CPP_TARGET_ARCH` |
+
+### Java/Kotlin
+
+```bash
+# Gradle
+codeql database create codeql.db --language=java --command='./gradlew build -x test'
+
+# Maven
+codeql database create codeql.db --language=java --command='mvn compile -DskipTests'
+```
+
+**Framework Support:**
+- Spring Boot: Full support
+- Jakarta EE: Built-in models
+- Android: Requires Android SDK
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Missing dependencies | Run `./gradlew dependencies` first |
+| Kotlin mixed projects | Use `--language=java` (covers both) |
+| Annotation processors | Ensure they run during CodeQL build |
+
+### Rust
+
+```bash
+codeql database create codeql.db --language=rust --command='cargo build'
+```
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Proc macros | May require special handling |
+| Workspace projects | Use `--source-root` for specific crate |
+| Build script failures | Ensure native dependencies are available |
+
+### C#
+
+```bash
+# .NET Core
+codeql database create codeql.db --language=csharp --command='dotnet build'
+
+# MSBuild
+codeql database create codeql.db --language=csharp --command='msbuild /t:rebuild'
+```
+
+**Framework Support:**
+- ASP.NET Core: Full support
+- Entity Framework: Database query models
+- Blazor: Partial support
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| NuGet restore | Run `dotnet restore` first |
+| Multiple solutions | Specify solution file in command |
+
+### Swift
+
+```bash
+# Xcode project
+codeql database create codeql.db --language=swift \
+  --command='xcodebuild -project MyApp.xcodeproj -scheme MyApp build'
+
+# Swift Package Manager
+codeql database create codeql.db --language=swift --command='swift build'
+```
+
+**Requirements:**
+- macOS only
+- Xcode Command Line Tools
+
+**Common Issues:**
+| Issue | Fix |
+|-------|-----|
+| Code signing | Add `CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO` |
+| Simulator target | Add `-sdk iphonesimulator` |
+
+## Extractor Options
+
+Set via environment variables: `CODEQL_EXTRACTOR_<LANG>_OPTION_<NAME>=<VALUE>`
+
+### C/C++ Options
+
+| Option | Description |
+|--------|-------------|
+| `trap_headers=true` | Include header file analysis |
+| `target_arch=x86_64` | Target architecture |
+
+### Java Options
+
+| Option | Description |
+|--------|-------------|
+| `jdk_version=17` | JDK version for analysis |
+
+### Python Options
+
+| Option | Description |
+|--------|-------------|
+| `python_executable=/path/to/python` | Specific Python interpreter |

--- a/.agents/skills/codeql/references/macos-arm64e-workaround.md
+++ b/.agents/skills/codeql/references/macos-arm64e-workaround.md
@@ -1,0 +1,179 @@
+# macOS arm64e Workaround
+
+Methods for building CodeQL databases on macOS Apple Silicon when the `arm64e`/`arm64` architecture mismatch causes SIGKILL (exit code 137) during build tracing.
+
+**Use when `IS_MACOS_ARM64E=true`** (detected in build-database workflow Step 2a). These replace Methods 1 and 2 on affected systems.
+
+The strategy is to use Homebrew-installed tools (plain `arm64`, not `arm64e`) so `libtrace.dylib` can be injected successfully. Try sub-methods in order:
+
+## Sub-method 2m-a: Homebrew clang/gcc with multi-step tracing
+
+Trace only the compiler invocations individually, avoiding system tools (`/usr/bin/ar`, `/bin/mkdir`) that would be killed. This requires a multi-step build: init → trace each compiler call → finalize.
+
+```bash
+log_step "METHOD 2m-a: macOS arm64 — Homebrew compiler with multi-step tracing"
+
+# 1. Find Homebrew C/C++ compiler (arm64, not arm64e)
+BREW_CC=""
+# Prefer Homebrew clang
+if [ -x "/opt/homebrew/opt/llvm/bin/clang" ]; then
+  BREW_CC="/opt/homebrew/opt/llvm/bin/clang"
+# Try Homebrew GCC (e.g. gcc-14, gcc-13)
+elif command -v gcc-14 >/dev/null 2>&1; then
+  BREW_CC="$(command -v gcc-14)"
+elif command -v gcc-13 >/dev/null 2>&1; then
+  BREW_CC="$(command -v gcc-13)"
+fi
+
+if [ -z "$BREW_CC" ]; then
+  log_result "No Homebrew C/C++ compiler found — skipping 2m-a"
+  # Fall through to 2m-b
+else
+  # Verify it's arm64 (not arm64e)
+  BREW_CC_ARCH=$(lipo -archs "$BREW_CC" 2>/dev/null)
+  if [[ "$BREW_CC_ARCH" == *"arm64e"* ]]; then
+    log_result "Homebrew compiler is arm64e — skipping 2m-a"
+  else
+    log_step "Using Homebrew compiler: $BREW_CC (arch: $BREW_CC_ARCH)"
+
+    # 2. Run the build normally (without tracing) to create build dirs and artifacts
+    #    Use Homebrew make (gmake) if available, otherwise system make outside tracer
+    if command -v gmake >/dev/null 2>&1; then
+      MAKE_CMD="gmake"
+    else
+      MAKE_CMD="make"
+    fi
+    $MAKE_CMD clean 2>/dev/null || true
+    $MAKE_CMD CC="$BREW_CC" 2>&1 | tee -a "$LOG_FILE"
+
+    # 3. Extract compiler commands from the Makefile / build system
+    #    Use make's dry-run mode to get the exact compiler invocations
+    $MAKE_CMD clean 2>/dev/null || true
+    COMPILE_CMDS=$($MAKE_CMD CC="$BREW_CC" --dry-run 2>/dev/null \
+      | grep -E "^\s*$BREW_CC\b.*\s-c\s" \
+      | sed 's/^[[:space:]]*//')
+
+    if [ -z "$COMPILE_CMDS" ]; then
+      log_result "Could not extract compile commands from dry-run — skipping 2m-a"
+    else
+      # 4. Init database
+      codeql database init $DB_NAME --language=cpp --source-root=. --overwrite 2>&1 \
+        | tee -a "$LOG_FILE"
+
+      # 5. Ensure build directories exist (outside tracer — avoids arm64e mkdir)
+      $MAKE_CMD clean 2>/dev/null || true
+      #    Parse -o flags to find output dirs, or just create common dirs
+      echo "$COMPILE_CMDS" | sed -n 's/.*-o[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*/\1/p' | xargs -I{} dirname {} \
+        | sort -u | xargs mkdir -p 2>/dev/null || true
+
+      # 6. Trace each compiler invocation individually
+      TRACE_OK=true
+      while IFS= read -r cmd; do
+        [ -z "$cmd" ] && continue
+        log_cmd "codeql database trace-command $DB_NAME -- $cmd"
+        if ! codeql database trace-command $DB_NAME -- $cmd 2>&1 | tee -a "$LOG_FILE"; then
+          log_result "FAILED on: $cmd"
+          TRACE_OK=false
+          break
+        fi
+      done <<< "$COMPILE_CMDS"
+
+      if $TRACE_OK; then
+        # 7. Finalize
+        codeql database finalize $DB_NAME 2>&1 | tee -a "$LOG_FILE"
+        if codeql resolve database -- "$DB_NAME" >/dev/null 2>&1; then
+          log_result "SUCCESS (macOS arm64 multi-step)"
+          # Done — skip to Step 4
+        else
+          log_result "FAILED (finalize failed)"
+        fi
+      fi
+    fi
+  fi
+fi
+```
+
+## Sub-method 2m-b: Rosetta x86_64 emulation
+
+Force the entire CodeQL pipeline to run under Rosetta, which uses the `x86_64` slice of both `libtrace.dylib` and system tools — no `arm64e` mismatch.
+
+```bash
+log_step "METHOD 2m-b: macOS arm64 — Rosetta x86_64 emulation"
+
+# Check if Rosetta is available
+if ! arch -x86_64 /usr/bin/true 2>/dev/null; then
+  log_result "Rosetta not available — skipping 2m-b"
+else
+  BUILD_CMD="<BUILD_CMD>"  # e.g. "make clean && make -j4"
+  CMD="arch -x86_64 codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=. --command='$BUILD_CMD' --overwrite"
+  log_cmd "$CMD"
+
+  arch -x86_64 codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=. \
+    --command="$BUILD_CMD" --overwrite 2>&1 | tee -a "$LOG_FILE"
+
+  if codeql resolve database -- "$DB_NAME" >/dev/null 2>&1; then
+    log_result "SUCCESS (Rosetta x86_64)"
+  else
+    log_result "FAILED (Rosetta)"
+  fi
+fi
+```
+
+## Sub-method 2m-c: System compiler (direct attempt)
+
+As a verification step, try the standard autobuild with the system compiler. This will likely fail with exit code 137 on affected systems, but confirms the arm64e issue is the cause.
+
+> **This sub-method is optional.** Skip it if arm64e incompatibility was already confirmed in Step 2a.
+
+```bash
+log_step "METHOD 2m-c: System compiler (expected to fail on arm64e)"
+CMD="codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=. --overwrite"
+log_cmd "$CMD"
+
+$CMD 2>&1 | tee -a "$LOG_FILE"
+
+EXIT_CODE=$?
+if [ $EXIT_CODE -eq 137 ] || [ $EXIT_CODE -eq 134 ]; then
+  log_result "FAILED: exit code $EXIT_CODE confirms arm64e/libtrace incompatibility"
+elif codeql resolve database -- "$DB_NAME" >/dev/null 2>&1; then
+  log_result "SUCCESS (unexpected — system compiler worked)"
+else
+  log_result "FAILED (exit code: $EXIT_CODE)"
+fi
+```
+
+## Sub-method 2m-d: Ask user
+
+If all macOS workarounds fail, present options:
+
+```
+AskUserQuestion:
+  header: "macOS Build"
+  question: "Build tracing failed due to macOS arm64e incompatibility. How to proceed?"
+  multiSelect: false
+  options:
+    - label: "Use build-mode=none (Recommended)"
+      description: "Source-level analysis only. Misses some interprocedural data flow but catches most C/C++ vulnerabilities (format strings, buffer overflows, unsafe functions)."
+    - label: "Install arm64 tools and retry"
+      description: "Run: brew install llvm make — then retry with Homebrew toolchain"
+    - label: "Install Rosetta and retry"
+      description: "Run: softwareupdate --install-rosetta — then retry under x86_64 emulation"
+    - label: "Abort"
+      description: "Stop database creation"
+```
+
+**If "Use build-mode=none":** Proceed to Method 4.
+
+**If "Install arm64 tools and retry":**
+```bash
+log_step "Installing Homebrew arm64 toolchain"
+brew install llvm make 2>&1 | tee -a "$LOG_FILE"
+# Retry Sub-method 2m-a
+```
+
+**If "Install Rosetta and retry":**
+```bash
+log_step "Installing Rosetta"
+softwareupdate --install-rosetta --agree-to-license 2>&1 | tee -a "$LOG_FILE"
+# Retry Sub-method 2m-b
+```

--- a/.agents/skills/codeql/references/performance-tuning.md
+++ b/.agents/skills/codeql/references/performance-tuning.md
@@ -1,0 +1,111 @@
+# Performance Tuning
+
+## Memory Configuration
+
+### CODEQL_RAM Environment Variable
+
+Control maximum heap memory (in MB):
+
+```bash
+# 48GB for large codebases
+CODEQL_RAM=48000 codeql database analyze codeql.db ...
+
+# 16GB for medium codebases
+CODEQL_RAM=16000 codeql database analyze codeql.db ...
+```
+
+**Guidelines:**
+| Codebase Size | Recommended RAM |
+|---------------|-----------------|
+| Small (<100K LOC) | 4-8 GB |
+| Medium (100K-1M LOC) | 8-16 GB |
+| Large (1M+ LOC) | 32-64 GB |
+
+## Thread Configuration
+
+### Analysis Threads
+
+```bash
+# Use all available cores
+codeql database analyze codeql.db --threads=0 ...
+
+# Use specific number
+codeql database analyze codeql.db --threads=8 ...
+```
+
+**Note:** `--threads=0` uses all available cores. For shared machines, use explicit count.
+
+## Query-Level Timeouts
+
+Prevent individual queries from running indefinitely:
+
+```bash
+# Set per-query timeout (in milliseconds)
+codeql database analyze codeql.db --timeout=600000 ...
+```
+
+A 10-minute timeout (`600000`) catches runaway queries without killing legitimate complex analysis. Taint-tracking queries on large codebases may need longer.
+
+## Evaluator Diagnostics
+
+When analysis is slow, use `--evaluator-log` to identify which queries consume the most time:
+
+```bash
+codeql database analyze codeql.db \
+  --evaluator-log=evaluator.log \
+  --format=sarif-latest \
+  --output=results.sarif \
+  -- codeql/python-queries:codeql-suites/python-security-extended.qls
+
+# Summarize the log
+codeql generate log-summary evaluator.log --format=text
+```
+
+The summary shows per-query timing and tuple counts. Queries producing millions of tuples are likely the bottleneck.
+
+## Disk Space
+
+| Phase | Typical Size | Notes |
+|-------|-------------|-------|
+| Database creation | 2-10x source size | Compiled languages are larger due to build tracing |
+| Analysis cache | 1-5 GB | Stored in database directory |
+| SARIF output | 1-50 MB | Depends on finding count |
+
+Check available space before starting:
+
+```bash
+df -h .
+du -sh codeql_*.db 2>/dev/null
+```
+
+## Caching Behavior
+
+CodeQL caches query evaluation results inside the database directory. Subsequent runs of the same queries skip re-evaluation.
+
+| Scenario | Cache Effect |
+|----------|-------------|
+| Re-run same packs | Fast — uses cached results |
+| Add new query pack | Only new queries evaluate |
+| `codeql database cleanup` | Clears cache — forces full re-evaluation |
+| `--rerun` flag | Ignores cache for this run |
+
+**When to clear cache:**
+- After deploying new data extensions (cache may hold stale results)
+- When investigating unexpected zero-finding results
+- Before benchmark comparisons (ensures consistent timing)
+
+```bash
+# Clear evaluation cache
+codeql database cleanup codeql_1.db
+```
+
+## Troubleshooting Performance
+
+| Symptom | Likely Cause | Solution |
+|---------|--------------|----------|
+| OOM during analysis | Not enough RAM | Increase `CODEQL_RAM` |
+| Slow database creation | Complex build | Use `--threads`, simplify build |
+| Slow query execution | Large codebase | Reduce query scope, add RAM |
+| Database too large | Too many files | Use exclusion config (`codeql-config.yml` with `paths-ignore`) |
+| Single query hangs | Runaway evaluation | Use `--timeout` and check `--evaluator-log` |
+| Repeated runs still slow | Cache not used | Check you're using same database path |

--- a/.agents/skills/codeql/references/quality-assessment.md
+++ b/.agents/skills/codeql/references/quality-assessment.md
@@ -1,0 +1,172 @@
+# Quality Assessment
+
+How to assess and improve CodeQL database quality after a successful build.
+
+## Collect Metrics
+
+```bash
+log_step "Assessing database quality"
+
+# 1. Baseline lines of code and file list (most reliable metric)
+codeql database print-baseline -- "$DB_NAME"
+BASELINE_LOC=$(python3 -c "
+import json
+with open('$DB_NAME/baseline-info.json') as f:
+    d = json.load(f)
+for lang, info in d['languages'].items():
+    print(f'{lang}: {info[\"linesOfCode\"]} LoC, {len(info[\"files\"])} files')
+")
+echo "$BASELINE_LOC"
+log_result "Baseline: $BASELINE_LOC"
+
+# 2. Source archive file count
+SRC_FILE_COUNT=$(unzip -Z1 "$DB_NAME/src.zip" 2>/dev/null | wc -l)
+echo "Files in source archive: $SRC_FILE_COUNT"
+
+# 3. Extraction errors from extractor diagnostics
+EXTRACTOR_ERRORS=$(find "$DB_NAME/diagnostic/extractors" -name '*.jsonl' \
+  -exec cat {} + 2>/dev/null | grep -c '^{' 2>/dev/null || true)
+EXTRACTOR_ERRORS=${EXTRACTOR_ERRORS:-0}
+echo "Extractor errors: $EXTRACTOR_ERRORS"
+
+# 4. Export diagnostics summary (experimental but useful)
+DIAG_TEXT=$(codeql database export-diagnostics --format=text -- "$DB_NAME" 2>/dev/null || true)
+if [ -n "$DIAG_TEXT" ]; then
+  echo "Diagnostics: $DIAG_TEXT"
+fi
+
+# 5. Check database is finalized
+FINALIZED=$(grep '^finalised:' "$DB_NAME/codeql-database.yml" 2>/dev/null \
+  | awk '{print $2}')
+echo "Finalized: $FINALIZED"
+```
+
+## Compare Against Expected Source
+
+Estimate the expected source file count from the working directory and compare.
+
+> **Compiled languages (C/C++, Java, C#):** The source archive (`src.zip`) includes system headers and SDK files alongside project source files. For C/C++, this can inflate the archive count 10-20x (e.g., 111 archive files for 5 project source files). Compare against **project-relative files only** by filtering the archive listing.
+
+```bash
+# Count source files in the project (adjust extensions per language)
+EXPECTED=$(fd -t f -e c -e cpp -e h -e hpp -e java -e kt -e py -e js -e ts \
+  --exclude 'codeql_*.db' --exclude node_modules --exclude vendor --exclude .git . \
+  2>/dev/null | wc -l)
+echo "Expected source files: $EXPECTED"
+
+# Count PROJECT files in source archive (exclude system/SDK paths)
+PROJECT_SRC_COUNT=$(unzip -Z1 "$DB_NAME/src.zip" 2>/dev/null \
+  | grep -v -E '^(Library/|usr/|System/|opt/|Applications/)' | wc -l)
+echo "Project files in source archive: $PROJECT_SRC_COUNT"
+echo "Total files in source archive: $SRC_FILE_COUNT (includes system headers for compiled langs)"
+
+# Baseline LOC from database metadata (most reliable single metric)
+DB_LOC=$(grep '^baselineLinesOfCode:' "$DB_NAME/codeql-database.yml" \
+  | awk '{print $2}')
+echo "Baseline LoC: $DB_LOC"
+
+# Error ratio — use project file count for compiled langs, total for interpreted
+if [ "$PROJECT_SRC_COUNT" -gt 0 ]; then
+  ERROR_RATIO=$(python3 -c "print(f'{$EXTRACTOR_ERRORS/$PROJECT_SRC_COUNT*100:.1f}%')")
+else
+  ERROR_RATIO="N/A (no files)"
+fi
+echo "Error ratio: $ERROR_RATIO ($EXTRACTOR_ERRORS errors / $PROJECT_SRC_COUNT project files)"
+```
+
+## Log Assessment
+
+```bash
+log_step "Quality assessment results"
+log_result "Baseline LoC: $DB_LOC"
+log_result "Project source files: $PROJECT_SRC_COUNT (expected: ~$EXPECTED)"
+log_result "Total archive files: $SRC_FILE_COUNT (includes system headers for compiled langs)"
+log_result "Extractor errors: $EXTRACTOR_ERRORS (ratio: $ERROR_RATIO)"
+log_result "Finalized: $FINALIZED"
+
+# Sample extracted project files (exclude system paths)
+unzip -Z1 "$DB_NAME/src.zip" 2>/dev/null \
+  | grep -v -E '^(Library/|usr/|System/|opt/|Applications/)' \
+  | head -20 >> "$LOG_FILE"
+```
+
+## Quality Criteria
+
+| Metric | Source | Good | Poor |
+|--------|--------|------|------|
+| Baseline LoC | `print-baseline` / `baseline-info.json` | > 0, proportional to project size | 0 or far below expected |
+| Project source files | `src.zip` (filtered) | Close to expected source file count | 0 or < 50% of expected |
+| Extractor errors | `diagnostic/extractors/*.jsonl` | 0 or < 5% of project files | > 5% of project files |
+| Finalized | `codeql-database.yml` | `true` | `false` (incomplete build) |
+| Key directories | `src.zip` listing | Application code directories present | Missing `src/main`, `lib/`, `app/` etc. |
+| "No source code seen" | build log | Absent | Present (cached build — compiled languages) |
+
+**Interpreting archive file counts for compiled languages:** C/C++ databases include system headers (e.g., `<stdio.h>`, SDK headers) in `src.zip`. A project with 5 source files may have 100+ files in the archive. Always filter to project-relative paths when comparing against expected counts. Use `baselineLinesOfCode` as the primary quality indicator.
+
+**Interpreting baseline LoC:** A small number of extractor errors is normal and does not significantly impact analysis. However, if `baselineLinesOfCode` is 0 or the source archive contains no files, the database is empty — likely a cached build (compiled languages) or wrong `--source-root`.
+
+---
+
+## Improve Quality (if poor)
+
+Try these improvements, re-assess after each. **Log all improvements:**
+
+### 1. Adjust source root
+
+```bash
+log_step "Quality improvement: adjust source root"
+NEW_ROOT="./src"  # or detected subdirectory
+# For interpreted: add --codescanning-config=codeql-config.yml
+# For compiled: omit config flag
+log_cmd "codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=$NEW_ROOT --overwrite"
+codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=$NEW_ROOT --overwrite
+log_result "Changed source-root to: $NEW_ROOT"
+```
+
+### 2. Fix "no source code seen" (cached build - compiled languages only)
+
+```bash
+log_step "Quality improvement: force rebuild (cached build detected)"
+log_cmd "make clean && rebuild"
+make clean && codeql database create $DB_NAME --language=$CODEQL_LANG --overwrite
+log_result "Forced clean rebuild"
+```
+
+### 3. Install type stubs / dependencies
+
+> **Note:** These install into the *target project's* environment to improve CodeQL extraction quality.
+
+```bash
+log_step "Quality improvement: install type stubs/additional deps"
+
+# Python type stubs — install into target project's environment
+STUBS_INSTALLED=""
+for stub in types-requests types-PyYAML types-redis; do
+  if pip install "$stub" 2>/dev/null; then
+    STUBS_INSTALLED="$STUBS_INSTALLED $stub"
+  fi
+done
+log_result "Installed type stubs:$STUBS_INSTALLED"
+
+# Additional project dependencies
+log_cmd "pip install -e ."
+pip install -e . 2>&1 | tee -a "$LOG_FILE"
+```
+
+### 4. Adjust extractor options
+
+```bash
+log_step "Quality improvement: adjust extractor options"
+
+# C/C++: Include headers
+export CODEQL_EXTRACTOR_CPP_OPTION_TRAP_HEADERS=true
+log_result "Set CODEQL_EXTRACTOR_CPP_OPTION_TRAP_HEADERS=true"
+
+# Java: Specific JDK version
+export CODEQL_EXTRACTOR_JAVA_OPTION_JDK_VERSION=17
+log_result "Set CODEQL_EXTRACTOR_JAVA_OPTION_JDK_VERSION=17"
+
+# Then rebuild with current method
+```
+
+**After each improvement:** Re-assess quality. If no improvement possible, move to next build method.

--- a/.agents/skills/codeql/references/ruleset-catalog.md
+++ b/.agents/skills/codeql/references/ruleset-catalog.md
@@ -1,0 +1,65 @@
+# Ruleset Catalog
+
+## Official CodeQL Suites
+
+| Suite | False Positives | Use Case |
+|-------|-----------------|----------|
+| `security-extended` | Low | **Default** - Security audits |
+| `security-and-quality` | Medium | Comprehensive review (stable security + code quality) |
+| `security-experimental` | Higher | Research, vulnerability hunting (stable security + experimental security) |
+
+> **Suite hierarchy:** `security-and-quality` and `security-experimental` are complementary. `security-and-quality` excludes `experimental/` query paths. `security-experimental` includes them but excludes code quality queries. For maximum coverage (run-all mode), import both.
+
+**Usage:** `codeql/<lang>-queries:codeql-suites/<lang>-security-extended.qls`
+
+**Languages:** `cpp`, `csharp`, `go`, `java`, `javascript`, `python`, `ruby`, `swift`
+
+---
+
+## Trail of Bits Packs
+
+| Pack | Language | Focus |
+|------|----------|-------|
+| `trailofbits/cpp-queries` | C/C++ | Memory safety, integer overflows |
+| `trailofbits/go-queries` | Go | Concurrency, error handling |
+| `trailofbits/java-queries` | Java | Security, code quality |
+
+**Install:**
+```bash
+codeql pack download trailofbits/cpp-queries
+codeql pack download trailofbits/go-queries
+codeql pack download trailofbits/java-queries
+```
+
+---
+
+## CodeQL Community Packs
+
+| Pack | Language |
+|------|----------|
+| `GitHubSecurityLab/CodeQL-Community-Packs-JavaScript` | JavaScript/TypeScript |
+| `GitHubSecurityLab/CodeQL-Community-Packs-Python` | Python |
+| `GitHubSecurityLab/CodeQL-Community-Packs-Go` | Go |
+| `GitHubSecurityLab/CodeQL-Community-Packs-Java` | Java |
+| `GitHubSecurityLab/CodeQL-Community-Packs-CPP` | C/C++ |
+| `GitHubSecurityLab/CodeQL-Community-Packs-CSharp` | C# |
+| `GitHubSecurityLab/CodeQL-Community-Packs-Ruby` | Ruby |
+
+**Install:**
+```bash
+codeql pack download GitHubSecurityLab/CodeQL-Community-Packs-<Lang>
+```
+
+**Source:** [github.com/GitHubSecurityLab/CodeQL-Community-Packs](https://github.com/GitHubSecurityLab/CodeQL-Community-Packs)
+
+---
+
+## Verify Installation
+
+```bash
+# List all installed packs
+codeql resolve qlpacks
+
+# Check specific packs
+codeql resolve qlpacks | grep -E "(trailofbits|GitHubSecurityLab)"
+```

--- a/.agents/skills/codeql/references/run-all-suite.md
+++ b/.agents/skills/codeql/references/run-all-suite.md
@@ -1,0 +1,100 @@
+# Run-All Query Suite
+
+In run-all mode, generate a custom `.qls` query suite file at runtime. This ensures all queries from all installed packs actually execute, avoiding the silent filtering caused by each pack's `defaultSuiteFile`.
+
+## Why a Custom Suite
+
+When you pass a pack name directly to `codeql database analyze` (e.g., `-- codeql/cpp-queries`), CodeQL uses the pack's `defaultSuiteFile` field from `qlpack.yml`. For official packs, this is typically `codeql-suites/<lang>-code-scanning.qls`, which applies strict precision and severity filters. This silently drops many queries and can produce zero results for small codebases.
+
+The run-all suite explicitly imports both `security-and-quality` and `security-experimental` from official packs, plus third-party packs with minimal filtering.
+
+> **Why both suites?** `security-and-quality` = stable security + code quality (excludes `experimental/` paths). `security-experimental` = stable security + experimental security (re-includes `experimental/` paths tagged `security`). They are complementary — importing both is safe since CodeQL deduplicates shared queries automatically.
+
+## Suite Template
+
+Generate this file as `run-all.qls` in the results directory before running analysis:
+
+```yaml
+- description: Run-all — all security, experimental, and quality queries from all installed packs
+# Official queries: import BOTH suites (they are complementary, not hierarchical)
+# security-and-quality = stable security + code quality (excludes experimental/ paths)
+# security-experimental = stable security + experimental security (re-includes experimental/ with security tag)
+- import: codeql-suites/<CODEQL_LANG>-security-and-quality.qls
+  from: codeql/<CODEQL_LANG>-queries
+- import: codeql-suites/<CODEQL_LANG>-security-experimental.qls
+  from: codeql/<CODEQL_LANG>-queries
+# Third-party packs (include only if installed, one entry per pack)
+# - queries: .
+#   from: trailofbits/<CODEQL_LANG>-queries
+# - queries: .
+#   from: GitHubSecurityLab/CodeQL-Community-Packs-<CODEQL_LANG>
+# Minimal filtering — only select alert-type queries
+- include:
+    kind:
+      - problem
+      - path-problem
+- exclude:
+    deprecated: //
+- exclude:
+    tags contain:
+      - modeleditor
+      - modelgenerator
+```
+
+## Generation Script
+
+```bash
+RAW_DIR="$OUTPUT_DIR/raw"
+SUITE_FILE="$RAW_DIR/run-all.qls"
+
+# NOTE: CODEQL_LANG must be set before running this script (e.g., CODEQL_LANG=cpp)
+# NOTE: INSTALLED_THIRD_PARTY_PACKS must be a space-separated list of pack names
+
+cat > "$SUITE_FILE" << HEADER
+- description: Run-all — all security, experimental, and quality queries from all installed packs
+- import: codeql-suites/${CODEQL_LANG}-security-and-quality.qls
+  from: codeql/${CODEQL_LANG}-queries
+- import: codeql-suites/${CODEQL_LANG}-security-experimental.qls
+  from: codeql/${CODEQL_LANG}-queries
+HEADER
+
+# Add each installed third-party pack
+for PACK in $INSTALLED_THIRD_PARTY_PACKS; do
+  cat >> "$SUITE_FILE" << PACK_ENTRY
+- queries: .
+  from: ${PACK}
+PACK_ENTRY
+done
+
+# Append minimal filtering rules (quoted heredoc — no expansion needed)
+cat >> "$SUITE_FILE" << 'FILTERS'
+- include:
+    kind:
+      - problem
+      - path-problem
+- exclude:
+    deprecated: //
+- exclude:
+    tags contain:
+      - modeleditor
+      - modelgenerator
+FILTERS
+
+# Verify the suite resolves correctly
+: "${CODEQL_LANG:?ERROR: CODEQL_LANG must be set before generating suite}"
+: "${SUITE_FILE:?ERROR: SUITE_FILE must be set}"
+
+if ! codeql resolve queries "$SUITE_FILE" | wc -l; then
+  echo "ERROR: Suite file failed to resolve. Check CODEQL_LANG=$CODEQL_LANG and installed packs."
+fi
+echo "Suite generated: $SUITE_FILE"
+```
+
+## How This Differs From Important-Only
+
+| Aspect | Run all | Important only |
+|--------|---------|----------------|
+| Official pack suites | `security-and-quality` + `security-experimental` (stable security + code quality + experimental security) | All queries loaded, filtered by precision |
+| Third-party packs | All `problem`/`path-problem` queries | Only `security`-tagged queries with precision metadata |
+| Precision filter | None | high/very-high always; medium only if security-severity >= 6.0 |
+| Post-analysis filter | None | Drops medium-precision results with security-severity < 6.0 |

--- a/.agents/skills/codeql/references/sarif-processing.md
+++ b/.agents/skills/codeql/references/sarif-processing.md
@@ -1,0 +1,79 @@
+# SARIF Processing
+
+jq commands for processing CodeQL SARIF output. Used in the run-analysis workflow Step 5.
+
+> **SARIF structure note:** `security-severity` and `level` are stored on rule definitions (`.runs[].tool.driver.rules[]`), NOT on individual result objects. Results reference rules by `ruleIndex`. The jq commands below join results with their rule metadata.
+>
+> **Portability note:** These jq patterns assume CodeQL SARIF output where `ruleIndex` is populated. For SARIF from other tools (e.g., Semgrep), use `ruleId`-based lookups instead.
+
+> **Directory convention:** Unfiltered output lives in `$RAW_DIR` (`$OUTPUT_DIR/raw`). Final results live in `$RESULTS_DIR` (`$OUTPUT_DIR/results`). The summary commands below operate on `$RESULTS_DIR/results.sarif` (the final output).
+
+## Count Findings
+
+```bash
+jq '.runs[].results | length' "$RESULTS_DIR/results.sarif"
+```
+
+## Summary by SARIF Level
+
+```bash
+jq -r '
+  .runs[] |
+  . as $run |
+  .results[] |
+  ($run.tool.driver.rules[.ruleIndex].defaultConfiguration.level // "unknown")
+' "$RESULTS_DIR/results.sarif" \
+  | sort | uniq -c | sort -rn
+```
+
+## Summary by Security Severity (most useful for triage)
+
+```bash
+jq -r '
+  .runs[] |
+  . as $run |
+  .results[] |
+  ($run.tool.driver.rules[.ruleIndex].properties["security-severity"] // "none") + " | " +
+  .ruleId + " | " +
+  (.locations[0].physicalLocation.artifactLocation.uri // "?") + ":" +
+  ((.locations[0].physicalLocation.region.startLine // 0) | tostring) + " | " +
+  (.message.text // "no message" | .[0:80])
+' "$RESULTS_DIR/results.sarif" | sort -rn | head -20
+```
+
+## Summary by Rule
+
+```bash
+jq -r '.runs[].results[] | .ruleId' "$RESULTS_DIR/results.sarif" \
+  | sort | uniq -c | sort -rn
+```
+
+## Important-Only Post-Filter
+
+If scan mode is "important only", filter out medium-precision results with `security-severity` < 6.0 from the report. The suite includes all medium-precision security queries to let CodeQL evaluate them, but low-severity medium-precision findings are noise.
+
+The filter reads from `$RAW_DIR/results.sarif` (unfiltered) and writes to `$RESULTS_DIR/results.sarif` (final). The raw file is preserved unmodified.
+
+```bash
+# Filter important-only results: drop medium-precision findings with security-severity < 6.0
+# Medium-precision queries without a security-severity score default to 0.0 (excluded).
+# Non-medium queries are always kept regardless of security-severity.
+# Reads from raw/, writes to results/ — preserving the unfiltered original.
+RAW_DIR="$OUTPUT_DIR/raw"
+RESULTS_DIR="$OUTPUT_DIR/results"
+jq '
+  .runs[] |= (
+    . as $run |
+    .results = [
+      .results[] |
+      ($run.tool.driver.rules[.ruleIndex].properties.precision // "unknown") as $prec |
+      ($run.tool.driver.rules[.ruleIndex].properties["security-severity"] // null) as $raw_sev |
+      (if $prec == "medium" then ($raw_sev // "0" | tonumber) else 10 end) as $sev |
+      select(
+        ($prec == "high") or ($prec == "very-high") or ($prec == "unknown") or
+        ($prec == "medium" and $sev >= 6.0)
+      )
+    ]
+  )
+' "$RAW_DIR/results.sarif" > "$RESULTS_DIR/results.sarif"
+```

--- a/.agents/skills/codeql/references/threat-models.md
+++ b/.agents/skills/codeql/references/threat-models.md
@@ -1,0 +1,51 @@
+# Threat Models Reference
+
+Control which source categories are active during CodeQL analysis. By default, only `remote` sources are tracked.
+
+## Available Models
+
+| Model | Sources Included | When to Enable | False Positive Impact |
+|-------|------------------|----------------|----------------------|
+| `remote` | HTTP requests, network input | Always (default). Covers web services, APIs, network-facing code. | Low — these are the most common attack vectors. |
+| `local` | Command line args, local files | CLI tools, batch processors, desktop apps where local users are untrusted. | Medium — generates noise for web-only services where CLI args are developer-controlled. |
+| `environment` | Environment variables | Apps that read config from env vars at runtime (12-factor apps, containers). Skip for apps that only read env at startup into validated config objects. | Medium — many env reads are startup-only config, not runtime-tainted data. |
+| `database` | Database query results | Second-order injection scenarios: stored XSS, data from shared databases where other writers are untrusted. | High — most apps trust their own database. Only enable when auditing for stored/second-order attacks. |
+| `file` | File contents | File upload processors, log parsers, config file readers that accept user-provided files. | Medium — triggers on all file reads including trusted config files. |
+
+## Default Behavior
+
+With no `--threat-model` flag, CodeQL uses `remote` only (the `default` group). This is correct for most web applications and APIs. Expanding beyond `remote` is useful when the application's trust boundary extends to local inputs.
+
+## Usage
+
+Enable additional threat models with the `--threat-model` flag (singular, NOT `--threat-models`):
+
+```bash
+# Web service (default — remote only, no flag needed)
+codeql database analyze codeql.db \
+  -- results/suite.qls
+
+# CLI tool — local users can provide malicious input
+codeql database analyze codeql.db \
+  --threat-model local \
+  -- results/suite.qls
+
+# Container app reading env vars from untrusted orchestrator
+codeql database analyze codeql.db \
+  --threat-model local --threat-model environment \
+  -- results/suite.qls
+
+# Full coverage — audit mode for all input vectors
+codeql database analyze codeql.db \
+  --threat-model all \
+  -- results/suite.qls
+
+# Enable all except database (to reduce noise)
+codeql database analyze codeql.db \
+  --threat-model all --threat-model '!database' \
+  -- results/suite.qls
+```
+
+The `--threat-model` flag can be repeated. Each invocation adds (or removes with `!` prefix) a threat model group. The `remote` group is always enabled by default — use `--threat-model '!default'` to disable it (rare). The `all` group enables everything, and `!<name>` disables a specific model.
+
+Multiple models can be combined. Each additional model expands the set of sources CodeQL considers tainted, increasing coverage but potentially increasing false positives. Start with the narrowest set that matches the application's actual threat model, then expand if needed.

--- a/.agents/skills/codeql/workflows/build-database.md
+++ b/.agents/skills/codeql/workflows/build-database.md
@@ -1,0 +1,280 @@
+# Build Database Workflow
+
+Create high-quality CodeQL databases by trying build methods in sequence until one produces good results.
+
+## Task System
+
+Create these tasks on workflow start:
+
+```
+TaskCreate: "Detect language and configure" (Step 1)
+TaskCreate: "Build database" (Step 2) - blockedBy: Step 1
+TaskCreate: "Apply fixes if needed" (Step 3) - blockedBy: Step 2
+TaskCreate: "Assess quality" (Step 4) - blockedBy: Step 3
+TaskCreate: "Improve quality if needed" (Step 5) - blockedBy: Step 4
+TaskCreate: "Generate final report" (Step 6) - blockedBy: Step 5
+```
+
+---
+
+## Overview
+
+Database creation differs by language type:
+
+### Interpreted Languages (Python, JavaScript, Go, Ruby)
+- **No build required** — CodeQL extracts source directly
+- **Exclusion config supported** — Use `--codescanning-config` to skip irrelevant files
+
+### Compiled Languages (C/C++, Java, C#, Rust, Swift)
+- **Build required** — CodeQL must trace the compilation
+- **Exclusion config NOT supported** — All compiled code must be traced
+- Try build methods in order until one succeeds:
+  1. **Autobuild** — CodeQL auto-detects and runs the build
+  2. **Custom Command** — Explicit build command for the detected build system
+  2m. **macOS arm64 Toolchain** — Homebrew compiler + multi-step tracing (Apple Silicon workaround)
+  3. **Multi-step** — Fine-grained control with init → trace-command → finalize
+  4. **No-build fallback** — `--build-mode=none` (partial analysis, last resort)
+
+> **macOS Apple Silicon:** On arm64 Macs, system tools (`/usr/bin/make`, `/usr/bin/clang`, `/usr/bin/ar`) are `arm64e` but CodeQL's `libtrace.dylib` only has `arm64`. macOS kills `arm64e` processes with a non-`arm64e` injected dylib (SIGKILL, exit 137). Step 2a detects this and routes to Method 2m.
+
+---
+
+## Output Directory
+
+This workflow receives `$OUTPUT_DIR` from the parent skill (resolved once at invocation). All files go inside it.
+
+```bash
+DB_NAME="$OUTPUT_DIR/codeql.db"
+```
+
+---
+
+## Build Log
+
+Maintain a log file throughout. Initialize at start:
+
+```bash
+LOG_FILE="$OUTPUT_DIR/build.log"
+echo "=== CodeQL Database Build Log ===" > "$LOG_FILE"
+echo "Started: $(date -Iseconds)" >> "$LOG_FILE"
+echo "Output dir: $OUTPUT_DIR" >> "$LOG_FILE"
+echo "Database: $DB_NAME" >> "$LOG_FILE"
+```
+
+Log helper:
+```bash
+log_step()   { echo "[$(date -Iseconds)] $1" >> "$LOG_FILE"; }
+log_cmd()    { echo "[$(date -Iseconds)] COMMAND: $1" >> "$LOG_FILE"; }
+log_result() { echo "[$(date -Iseconds)] RESULT: $1" >> "$LOG_FILE"; echo "" >> "$LOG_FILE"; }
+```
+
+**What to log:** Detected language/build system, each build attempt with exact command, fix attempts and outcomes, quality assessment results, final successful command.
+
+---
+
+## Step 1: Detect Language and Configure
+
+**Entry:** CodeQL CLI installed and on PATH (`codeql --version` succeeds)
+**Exit:** `CODEQL_LANG` variable set to a valid CodeQL language identifier; exclusion config created (interpreted) or skipped (compiled)
+
+### 1a. Detect Language
+
+```bash
+fd -t f -e py -e js -e ts -e go -e rb -e java -e c -e cpp -e h -e hpp -e rs -e cs | \
+  sed 's/.*\.//' | sort | uniq -c | sort -rn | head -5
+ls -la Makefile CMakeLists.txt build.gradle pom.xml Cargo.toml *.sln 2>/dev/null || true
+```
+
+| Language | `--language=` | Type |
+|----------|---------------|------|
+| Python | `python` | Interpreted |
+| JavaScript/TypeScript | `javascript` | Interpreted |
+| Go | `go` | Interpreted |
+| Ruby | `ruby` | Interpreted |
+| Java/Kotlin | `java` | Compiled |
+| C/C++ | `cpp` | Compiled |
+| C# | `csharp` | Compiled |
+| Rust | `rust` | Compiled |
+| Swift | `swift` | Compiled (macOS) |
+
+### 1b. Create Exclusion Config (Interpreted Languages Only)
+
+> **Skip for compiled languages** — exclusion config is not supported when build tracing is required.
+
+Scan for irrelevant directories and create `$OUTPUT_DIR/codeql-config.yml` with `paths-ignore` entries for `node_modules`, `vendor`, `venv`, third-party code, and generated/minified files.
+
+---
+
+## Step 2: Build Database
+
+**Entry:** Step 1 complete (`CODEQL_LANG` set, `DB_NAME` assigned, log file initialized)
+**Exit:** `codeql resolve database -- "$DB_NAME"` succeeds (database exists and is valid)
+
+### For Interpreted Languages
+
+```bash
+log_step "Building database for interpreted language: <LANG>"
+CMD="codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=. --codescanning-config=$OUTPUT_DIR/codeql-config.yml --overwrite"
+log_cmd "$CMD"
+$CMD 2>&1 | tee -a "$LOG_FILE"
+```
+
+**Skip to Step 4 after success.**
+
+---
+
+### For Compiled Languages
+
+#### Step 2a: macOS arm64e Detection (C/C++ primarily)
+
+```bash
+IS_MACOS_ARM64E=false
+if [[ "$(uname -s)" == "Darwin" ]] && [[ "$(uname -m)" == "arm64" ]]; then
+  LIBTRACE=$(find "$(dirname "$(command -v codeql)")" -name libtrace.dylib 2>/dev/null | head -1)
+  if [ -n "$LIBTRACE" ]; then
+    LIBTRACE_ARCHS=$(lipo -archs "$LIBTRACE" 2>/dev/null)
+    if [[ "$LIBTRACE_ARCHS" != *"arm64e"* ]]; then
+      MAKE_ARCHS=$(lipo -archs /usr/bin/make 2>/dev/null)
+      [[ "$MAKE_ARCHS" == *"arm64e"* ]] && IS_MACOS_ARM64E=true
+    fi
+  fi
+fi
+```
+
+**If `IS_MACOS_ARM64E=true`:** Skip Methods 1 and 2 — go directly to Method 2m.
+
+---
+
+Try build methods in sequence until one succeeds:
+
+#### Method 1: Autobuild
+
+> **Skip if `IS_MACOS_ARM64E=true`.**
+
+```bash
+log_step "METHOD 1: Autobuild"
+CMD="codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=. --overwrite"
+log_cmd "$CMD"
+$CMD 2>&1 | tee -a "$LOG_FILE"
+```
+
+#### Method 2: Custom Command
+
+> **Skip if `IS_MACOS_ARM64E=true`.**
+
+Detect build system and use explicit command:
+
+| Build System | Detection | Command |
+|--------------|-----------|---------|
+| Make | `Makefile` | `make clean && make -j$(nproc)` |
+| CMake | `CMakeLists.txt` | `cmake -B build && cmake --build build` |
+| Gradle | `build.gradle` | `./gradlew clean build -x test` |
+| Maven | `pom.xml` | `mvn clean compile -DskipTests` |
+| Cargo | `Cargo.toml` | `cargo clean && cargo build` |
+| .NET | `*.sln` | `dotnet clean && dotnet build` |
+
+Also check for project-specific build scripts (`build.sh`, `compile.sh`) and README instructions.
+
+```bash
+log_step "METHOD 2: Custom command"
+CMD="codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=. --command='$BUILD_CMD' --overwrite"
+log_cmd "$CMD"
+$CMD 2>&1 | tee -a "$LOG_FILE"
+```
+
+#### Method 2m: macOS arm64 Toolchain (Apple Silicon workaround)
+
+> **Use when `IS_MACOS_ARM64E=true`.** Replaces Methods 1 and 2 on affected systems.
+
+See [macos-arm64e-workaround.md](../references/macos-arm64e-workaround.md) for the full sub-method sequence (2m-a through 2m-d): Homebrew compiler with multi-step tracing → Rosetta x86_64 → system compiler verification → ask user.
+
+#### Method 3: Multi-step Build
+
+For complex builds needing fine-grained control:
+
+> **On macOS with `IS_MACOS_ARM64E=true`:** Only trace arm64 Homebrew binaries. Do NOT trace system tools.
+
+```bash
+log_step "METHOD 3: Multi-step build"
+codeql database init $DB_NAME --language=$CODEQL_LANG --source-root=. --overwrite
+codeql database trace-command $DB_NAME -- <build step 1>
+codeql database trace-command $DB_NAME -- <build step 2>
+codeql database finalize $DB_NAME
+```
+
+#### Method 4: No-Build Fallback (Last Resort)
+
+> **WARNING:** Creates a database without build tracing. Only source-level patterns detected.
+
+```bash
+log_step "METHOD 4: No-build fallback (partial analysis)"
+CMD="codeql database create $DB_NAME --language=$CODEQL_LANG --source-root=. --build-mode=none --overwrite"
+log_cmd "$CMD"
+$CMD 2>&1 | tee -a "$LOG_FILE"
+```
+
+---
+
+## Step 3: Apply Fixes (if build failed)
+
+**Entry:** Step 2 build method failed (non-zero exit or `codeql resolve database` fails)
+**Exit:** Fix applied and current build method retried; either succeeds (go to Step 4) or all fixes exhausted (try next build method in Step 2)
+
+Try fixes in order, then retry current build method. See [build-fixes.md](../references/build-fixes.md) for the full fix catalog: clean state, clean build cache, install dependencies, handle private registries.
+
+---
+
+## Steps 4-5: Assess and Improve Quality
+
+**Entry:** Database exists and `codeql resolve database` succeeds
+**Exit (Step 4):** Quality metrics collected (baseline LoC, file counts, extractor errors, finalization status)
+**Exit (Step 5):** Quality is GOOD (baseline LoC > 0, errors < 5%, project files present) OR user accepts current state
+
+Run quality checks and compare against expected source files. See [quality-assessment.md](../references/quality-assessment.md) for metric collection, quality criteria table, and improvement steps.
+
+---
+
+## Exit Conditions
+
+**Success:** Quality assessment shows GOOD or user accepts current state.
+
+**Failure (all methods exhausted):**
+```
+AskUserQuestion: "All build methods failed. Options:"
+  1. "Accept current state" (if any database exists)
+  2. "I'll fix the build manually and retry"
+  3. "Abort"
+```
+
+---
+
+## Final Report
+
+```bash
+echo "=== Build Complete ===" >> "$LOG_FILE"
+echo "Finished: $(date -Iseconds)" >> "$LOG_FILE"
+echo "Final database: $DB_NAME" >> "$LOG_FILE"
+echo "Successful method: <METHOD>" >> "$LOG_FILE"
+codeql resolve database -- "$DB_NAME" >> "$LOG_FILE" 2>&1
+```
+
+Report to user:
+```
+## Database Build Complete
+
+**Output directory:** $OUTPUT_DIR
+**Database:** $DB_NAME
+**Language:** <LANG>
+**Build method:** autobuild | custom | multi-step
+**Files extracted:** <COUNT>
+
+### Quality:
+- Errors: <N>
+- Coverage: <good/partial/poor>
+
+### Build Log:
+See `$OUTPUT_DIR/build.log` for complete details.
+
+**Final command used:** <EXACT_COMMAND>
+**Ready for analysis.**
+```

--- a/.agents/skills/codeql/workflows/create-data-extensions.md
+++ b/.agents/skills/codeql/workflows/create-data-extensions.md
@@ -1,0 +1,261 @@
+# Create Data Extensions Workflow
+
+Generate data extension YAML files to improve CodeQL's data flow coverage for project-specific APIs. Runs after database build and before analysis.
+
+## Task System
+
+Create these tasks on workflow start:
+
+```
+TaskCreate: "Check for existing data extensions" (Step 1)
+TaskCreate: "Query known sources and sinks" (Step 2) - blockedBy: Step 1
+TaskCreate: "Identify missing sources and sinks" (Step 3) - blockedBy: Step 2
+TaskCreate: "Create data extension files" (Step 4) - blockedBy: Step 3
+TaskCreate: "Validate with re-analysis" (Step 5) - blockedBy: Step 4
+```
+
+### Early Exit Points
+
+| After Step | Condition | Action |
+|------------|-----------|--------|
+| Step 1 | Extensions already exist | Return found packs/files to run-analysis workflow, finish |
+| Step 3 | No missing models identified | Report coverage is adequate, finish |
+
+---
+
+## Steps
+
+### Step 1: Check for Existing Data Extensions
+
+**Entry:** CodeQL database exists (`codeql resolve database` succeeds)
+**Exit:** Either existing extensions found (report and finish) OR no extensions found (proceed to Step 2)
+
+Search the project for existing data extensions and model packs.
+
+```bash
+# 1. In-repo model packs (exclude output dirs and legacy database dirs)
+fd '(qlpack|codeql-pack)\.yml$' . --exclude 'static_analysis_codeql_*' --exclude 'codeql_*.db' | while read -r f; do
+  if grep -q 'dataExtensions' "$f"; then
+    echo "MODEL PACK: $(dirname "$f") - $(grep '^name:' "$f")"
+  fi
+done
+
+# 2. Standalone data extension files
+rg -l '^extensions:' --glob '*.yml' --glob '!static_analysis_codeql_*/**' --glob '!codeql_*.db/**' | head -20
+
+# 3. Installed model packs
+codeql resolve qlpacks 2>/dev/null | grep -iE 'model|extension'
+```
+
+**If any found:** Report to user and finish. These will be picked up by the run-analysis workflow.
+
+**If none found:** Proceed to Step 2.
+
+---
+
+### Step 2: Query Known Sources and Sinks
+
+**Entry:** Step 1 found no existing extensions; database and language identified
+**Exit:** `sources.csv` and `sinks.csv` exist in `$DIAG_DIR` with enumerated source/sink locations
+
+Run custom QL queries against the database to enumerate all sources and sinks CodeQL currently recognizes.
+
+#### 2a: Select Database and Language
+
+A CodeQL database is a directory containing a `codeql-database.yml` marker file. `$DB_NAME` may already be set by the parent skill. If not, discover inside `$OUTPUT_DIR`.
+
+```bash
+if [ -z "$DB_NAME" ]; then
+  FOUND_DBS=()
+  while IFS= read -r yml; do
+    FOUND_DBS+=("$(dirname "$yml")")
+  done < <(find "$OUTPUT_DIR" -maxdepth 2 -name "codeql-database.yml" 2>/dev/null)
+
+  if [ ${#FOUND_DBS[@]} -eq 0 ]; then
+    echo "ERROR: No CodeQL database found in $OUTPUT_DIR"; exit 1
+  elif [ ${#FOUND_DBS[@]} -eq 1 ]; then
+    DB_NAME="${FOUND_DBS[0]}"
+  else
+    # Multiple databases — use AskUserQuestion to select
+    # SKIP if user already specified which database in their prompt
+  fi
+fi
+
+CODEQL_LANG=$(codeql resolve database --format=json -- "$DB_NAME" | jq -r '.languages[0]')
+DIAG_DIR="$OUTPUT_DIR/diagnostics"
+mkdir -p "$DIAG_DIR"
+```
+
+#### 2b: Write Source Enumeration Query
+
+Use the `Write` tool to create `$DIAG_DIR/list-sources.ql` using the source template from [diagnostic-query-templates.md](../references/diagnostic-query-templates.md#source-enumeration-query). Pick the correct import block for `$CODEQL_LANG`.
+
+#### 2c: Write Sink Enumeration Query
+
+Use the `Write` tool to create `$DIAG_DIR/list-sinks.ql` using the language-specific sink template from [diagnostic-query-templates.md](../references/diagnostic-query-templates.md#sink-enumeration-queries).
+
+**For Java:** Also create `$DIAG_DIR/qlpack.yml` with a `codeql/java-all` dependency and run `codeql pack install` before executing queries.
+
+#### 2d: Run Queries
+
+```bash
+codeql query run --database="$DB_NAME" --output="$DIAG_DIR/sources.bqrs" -- "$DIAG_DIR/list-sources.ql"
+codeql bqrs decode --format=csv --output="$DIAG_DIR/sources.csv" -- "$DIAG_DIR/sources.bqrs"
+
+codeql query run --database="$DB_NAME" --output="$DIAG_DIR/sinks.bqrs" -- "$DIAG_DIR/list-sinks.ql"
+codeql bqrs decode --format=csv --output="$DIAG_DIR/sinks.csv" -- "$DIAG_DIR/sinks.bqrs"
+```
+
+#### 2e: Summarize Results
+
+Read both CSV files and present a summary showing source types and sink kinds with counts.
+
+---
+
+### Step 3: Identify Missing Sources and Sinks
+
+**Entry:** Step 2 complete (`sources.csv` and `sinks.csv` available)
+**Exit:** Either no gaps found (report adequate coverage and finish) OR user confirms which gaps to model (proceed to Step 4)
+
+Cross-reference the project's API surface against CodeQL's known models.
+
+#### 3a: Map the Project's API Surface
+
+Read source code to identify security-relevant patterns:
+
+| Pattern | What To Find | Likely Model Type |
+|---------|-------------|-------------------|
+| HTTP/request handlers | Custom request parsing | `sourceModel` (kind: `remote`) |
+| Database layers | Custom ORM, raw query wrappers | `sinkModel` (kind: `sql-injection`) |
+| Command execution | Shell wrappers, process spawners | `sinkModel` (kind: `command-injection`) |
+| File operations | Custom file read/write | `sinkModel` (kind: `path-injection`) |
+| Template rendering | HTML output, response builders | `sinkModel` (kind: `xss`) |
+| Deserialization | Custom deserializers | `sinkModel` (kind: `unsafe-deserialization`) |
+| HTTP clients | URL construction | `sinkModel` (kind: `ssrf`) |
+| Sanitizers | Input validation, escaping | `neutralModel` |
+| Pass-through wrappers | Logging, caching, encoding | `summaryModel` (kind: `taint`) |
+
+Use `Grep` to search for these patterns in source code (adapt per language).
+
+#### 3b: Cross-Reference Against Known Sources and Sinks
+
+For each API pattern found, check if it appears in `sources.csv` or `sinks.csv` from Step 2.
+
+**An API is "missing" if:**
+- It handles user input but does not appear in `sources.csv`
+- It performs a dangerous operation but does not appear in `sinks.csv`
+- It wraps tainted data but has no summary model
+
+#### 3c: Report Gaps
+
+Present findings and use `AskUserQuestion`:
+
+```
+header: "Extensions"
+question: "Create data extension files for the identified gaps?"
+options:
+  - label: "Create all (Recommended)"
+    description: "Generate extensions for all identified gaps"
+  - label: "Select individually"
+    description: "Choose which gaps to model"
+  - label: "Skip"
+    description: "No extensions needed, proceed to analysis"
+```
+
+---
+
+### Step 4: Create Data Extension Files
+
+**Entry:** Step 3 identified gaps and user confirmed which to model
+**Exit:** YAML extension files created in `$OUTPUT_DIR/extensions/` and deployed to `<lang>-all` ext/ directory
+
+Generate YAML data extension files for the gaps confirmed by the user.
+
+#### File Structure
+
+Create files in `$OUTPUT_DIR/extensions/`:
+
+```
+$OUTPUT_DIR/extensions/
+  sources.yml       # sourceModel entries
+  sinks.yml         # sinkModel entries
+  summaries.yml     # summaryModel and neutralModel entries
+```
+
+#### YAML Format and Deployment
+
+See [extension-yaml-format.md](../references/extension-yaml-format.md) for column definitions, per-language examples (Python, Java, JS, Go, C/C++), and the deployment workaround for pre-compiled query packs.
+
+Use the `Write` tool to create each file. Only create files that have entries — skip empty categories.
+
+---
+
+### Step 5: Validate with Re-Analysis
+
+**Entry:** Step 4 complete (extension files deployed)
+**Exit:** Finding delta measured (with-extensions count >= baseline count); extensions validated as loading correctly
+
+Run a full security analysis with and without extensions to measure the finding delta.
+
+#### 5a: Run Baseline Analysis (without extensions)
+
+Validation artifacts go in `$DIAG_DIR` (not `results/`) since these are intermediate comparisons, not the final analysis output.
+
+```bash
+codeql database analyze "$DB_NAME" \
+  --format=sarif-latest --output="$DIAG_DIR/baseline.sarif" --threads=0 \
+  -- codeql/<lang>-queries:codeql-suites/<lang>-security-extended.qls
+```
+
+#### 5b: Run Analysis with Extensions
+
+```bash
+codeql database cleanup "$DB_NAME"
+codeql database analyze "$DB_NAME" \
+  --format=sarif-latest --output="$DIAG_DIR/with-extensions.sarif" --threads=0 --rerun \
+  -- codeql/<lang>-queries:codeql-suites/<lang>-security-extended.qls
+```
+
+Use `-vvv` flag to verify extensions are being loaded.
+
+#### 5c: Compare Findings
+
+```bash
+BASELINE=$(python3 -c "import json; print(sum(len(r.get('results',[])) for r in json.load(open('$DIAG_DIR/baseline.sarif')).get('runs',[])))")
+WITH_EXT=$(python3 -c "import json; print(sum(len(r.get('results',[])) for r in json.load(open('$DIAG_DIR/with-extensions.sarif')).get('runs',[])))")
+echo "Findings: $BASELINE → $WITH_EXT (+$((WITH_EXT - BASELINE)))"
+```
+
+**If counts did not increase:** Check extension loading (`-vvv`), pre-compiled pack workaround, Java `True`/`False` capitalization, column value accuracy.
+
+---
+
+## Final Output
+
+```
+## Data Extensions Created
+
+**Output directory:** $OUTPUT_DIR
+**Database:** $DB_NAME
+**Language:** <LANG>
+
+### Files Created:
+- $OUTPUT_DIR/extensions/sources.yml — <N> source models
+- $OUTPUT_DIR/extensions/sinks.yml — <N> sink models
+- $OUTPUT_DIR/extensions/summaries.yml — <N> summary/neutral models
+
+### Model Coverage:
+- Sources: <BEFORE> → <AFTER> (+<DELTA>)
+- Sinks: <BEFORE> → <AFTER> (+<DELTA>)
+
+### Usage:
+Extensions deployed to `<lang>-all` ext/ directory (auto-loaded).
+Source files in `$OUTPUT_DIR/extensions/` for version control.
+Run the run-analysis workflow to use them.
+```
+
+## References
+
+- [Threat models reference](../references/threat-models.md) — control which source categories are active during analysis
+- [CodeQL data extensions](https://codeql.github.com/docs/codeql-cli/using-custom-queries-with-the-codeql-cli/#using-extension-packs)
+- [Customizing library models](https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-python/)

--- a/.agents/skills/codeql/workflows/run-analysis.md
+++ b/.agents/skills/codeql/workflows/run-analysis.md
@@ -1,0 +1,302 @@
+# Run Analysis Workflow
+
+Execute CodeQL security queries on an existing database with ruleset selection and result formatting.
+
+## Scan Modes
+
+Two modes control analysis scope. Both use all installed packs — the difference is filtering.
+
+| Mode | Description | Suite Reference |
+|------|-------------|-----------------|
+| **Run all** | All queries from all installed packs via `security-and-quality` + `security-experimental` suites | [run-all-suite.md](../references/run-all-suite.md) |
+| **Important only** | Security queries filtered by precision and security-severity threshold | [important-only-suite.md](../references/important-only-suite.md) |
+
+> **WARNING:** Do NOT pass pack names directly to `codeql database analyze` (e.g., `-- codeql/cpp-queries`). Each pack's `defaultSuiteFile` silently applies strict filters and can produce zero results. Always use an explicit suite reference.
+
+---
+
+## Task System
+
+Create these tasks on workflow start:
+
+```
+TaskCreate: "Select database and detect language" (Step 1)
+TaskCreate: "Select scan mode, check additional packs" (Step 2) - blockedBy: Step 1
+TaskCreate: "Select query packs, model packs, and threat models" (Step 3) - blockedBy: Step 2
+TaskCreate: "Execute analysis" (Step 4) - blockedBy: Step 3
+TaskCreate: "Process and report results" (Step 5) - blockedBy: Step 4
+```
+
+### Gates
+
+| Task | Gate Type | Cannot Proceed Until |
+|------|-----------|---------------------|
+| Step 2a | **SOFT GATE** | User selects scan mode. Skip only if user said "run all" or "important only" verbatim. |
+| Step 3a | **HARD GATE** | User confirms query pack selection. Always ask — no auto-skip. |
+| Step 3c | **HARD GATE** | User selects threat model. Always ask — no auto-skip. |
+
+**Auto-skip rules are per-gate.** Each gate documents its own skip condition. Choosing "full scan" or "run all" satisfies the scan mode gate (2a) but does not satisfy pack confirmation (3a) or threat model selection (3c).
+
+---
+
+## Steps
+
+### Step 1: Select Database and Detect Language
+
+**Entry:** `$OUTPUT_DIR` is set (from parent skill). `$DB_NAME` may already be set if the parent skill resolved database selection.
+**Exit:** `DB_NAME` and `CODEQL_LANG` variables set; database resolves successfully.
+
+**If `$DB_NAME` is already set** (parent skill handled database selection): validate it and proceed.
+
+**If `$DB_NAME` is not set:** discover databases by looking for `codeql-database.yml` marker files. Search inside `$OUTPUT_DIR` first, then fall back to the project root (top-level and one subdirectory deep).
+
+```bash
+# Skip discovery if DB_NAME was already resolved by parent skill
+if [ -z "$DB_NAME" ]; then
+  # Discover databases inside OUTPUT_DIR
+  FOUND_DBS=()
+  while IFS= read -r yml; do
+    FOUND_DBS+=("$(dirname "$yml")")
+  done < <(find "$OUTPUT_DIR" -maxdepth 2 -name "codeql-database.yml" 2>/dev/null)
+
+  # Fallback: search project root (top-level and one subdir deep)
+  if [ ${#FOUND_DBS[@]} -eq 0 ]; then
+    while IFS= read -r yml; do
+      FOUND_DBS+=("$(dirname "$yml")")
+    done < <(find . -maxdepth 3 -name "codeql-database.yml" -not -path "*/\.*" 2>/dev/null)
+  fi
+
+  if [ ${#FOUND_DBS[@]} -eq 0 ]; then
+    echo "ERROR: No CodeQL database found in $OUTPUT_DIR or project root"
+    exit 1
+  elif [ ${#FOUND_DBS[@]} -eq 1 ]; then
+    DB_NAME="${FOUND_DBS[0]}"
+  else
+    # Multiple databases found — present to user
+    # Use AskUserQuestion with each DB's path and language
+    # SKIP if user already specified which database in their prompt
+  fi
+fi
+
+CODEQL_LANG=$(codeql resolve database --format=json -- "$DB_NAME" | jq -r '.languages[0]')
+echo "Using: $DB_NAME (language: $CODEQL_LANG)"
+```
+
+**When multiple databases are found**, use `AskUserQuestion` to let user select — list each database with its path and language. **Skip `AskUserQuestion` if the user already specified which database to use in their prompt.**
+
+If multi-language database, ask which language to analyze.
+
+---
+
+### Step 2: Select Scan Mode, Check Additional Packs
+
+**Entry:** Step 1 complete (`DB_NAME` and `CODEQL_LANG` set)
+**Exit:** Scan mode selected; all available packs (official, ToB, community) checked for installation status; model packs detected
+
+#### 2a: Select Scan Mode
+
+**Skip only if user said "run all" or "important only" in their prompt.** "Full scan", "scan", or "analyze" do NOT count — ask.
+
+```
+header: "Scan Mode"
+question: "Which scan mode should be used?"
+options:
+  - label: "Run all (Recommended)"
+    description: "Maximum coverage — all queries from all installed packs"
+  - label: "Important only"
+    description: "Security vulnerabilities only — medium-high precision, security-severity threshold"
+```
+
+#### 2b: Query Packs
+
+For each pack available for the detected language (see [ruleset-catalog.md](../references/ruleset-catalog.md)):
+
+| Language | Trail of Bits | Community Pack |
+|----------|---------------|----------------|
+| C/C++ | `trailofbits/cpp-queries` | `GitHubSecurityLab/CodeQL-Community-Packs-CPP` |
+| Go | `trailofbits/go-queries` | `GitHubSecurityLab/CodeQL-Community-Packs-Go` |
+| Java | `trailofbits/java-queries` | `GitHubSecurityLab/CodeQL-Community-Packs-Java` |
+| JavaScript | — | `GitHubSecurityLab/CodeQL-Community-Packs-JavaScript` |
+| Python | — | `GitHubSecurityLab/CodeQL-Community-Packs-Python` |
+| C# | — | `GitHubSecurityLab/CodeQL-Community-Packs-CSharp` |
+| Ruby | — | `GitHubSecurityLab/CodeQL-Community-Packs-Ruby` |
+
+Check if installed (`codeql resolve qlpacks | grep -i "<PACK_NAME>"`). If not, ask user to install or ignore.
+
+#### 2c: Detect Model Packs
+
+Search three locations for data extension model packs:
+1. **In-repo model packs** — `qlpack.yml`/`codeql-pack.yml` with `dataExtensions`
+2. **In-repo standalone data extensions** — `.yml` files with `extensions:` key
+3. **Installed model packs** — resolved by CodeQL
+
+Record all detected packs for Step 3.
+
+---
+
+### Step 3: Select Query Packs and Model Packs
+
+**Entry:** Step 2 complete (scan mode, pack availability, and model packs all determined)
+**Exit:** User confirmed query packs, model packs, and threat model selection; all flags built (`THREAT_MODEL_FLAG`, `MODEL_PACK_FLAGS`, `ADDITIONAL_PACK_FLAGS`)
+
+> **CHECKPOINT** — Present available packs to user for confirmation.
+> **Always ask. Do not auto-skip.**
+
+#### 3a: Confirm Query Packs
+
+**Important-only mode:** Inform user all installed packs included with filtering. Proceed to 3b.
+
+**Run-all mode:** Use `AskUserQuestion` to confirm "Use all" or "Select individually". Always ask — the user needs to see which packs will run.
+
+#### 3b: Select Model Packs (if any detected)
+
+**Skip if no model packs detected in Step 2c.**
+
+Use `AskUserQuestion`: "Use all (Recommended)" / "Select individually" / "Skip".
+
+**Notes:**
+- In-repo standalone extensions (`.yml`) are auto-discovered — pass source directory via `--additional-packs`
+- In-repo model packs (with `qlpack.yml`) need parent directory via `--additional-packs`
+- Installed model packs use `--model-packs`
+
+#### 3c: Select Threat Models
+
+Threat models control which input sources CodeQL treats as tainted. See [threat-models.md](../references/threat-models.md).
+
+**Always ask.** Do not default to "remote only" without user confirmation. Use `AskUserQuestion`:
+
+```
+header: "Threat Models"
+question: "Which input sources should CodeQL treat as tainted?"
+options:
+  - label: "Remote only (Recommended)"
+    description: "Default — HTTP requests, network input"
+  - label: "Remote + Local"
+    description: "Add CLI args, local files"
+  - label: "All sources"
+    description: "Remote, local, environment, database, file"
+  - label: "Custom"
+    description: "Select specific threat models individually"
+```
+
+Build the flag: `THREAT_MODEL_FLAG=""` (remote only needs no flag), `--threat-model local`, etc.
+
+---
+
+### Step 4: Execute Analysis
+
+**Entry:** Step 3 complete (all flags and pack selections finalized)
+**Exit:** `$RAW_DIR/results.sarif` exists and contains valid SARIF output
+
+#### Log selected query packs
+
+Write the selected query packs, model packs, and threat models to `$OUTPUT_DIR/rulesets.txt`:
+
+```bash
+cat > "$OUTPUT_DIR/rulesets.txt" << RULESETS
+# CodeQL Analysis — Selected Query Packs
+# Generated: $(date -Iseconds)
+# Scan mode: <run-all|important-only>
+# Database: $DB_NAME
+# Language: $CODEQL_LANG
+
+## Query packs:
+<one pack per line>
+
+## Model packs:
+<one pack per line, or "None">
+
+## Threat models:
+<threat model selection, or "default (remote)">
+RULESETS
+```
+
+#### Generate custom suite
+
+**Important-only mode:** Generate the custom `.qls` suite using the template and script in [important-only-suite.md](../references/important-only-suite.md).
+
+**Run-all mode:** Generate the custom `.qls` suite using the template in [run-all-suite.md](../references/run-all-suite.md).
+
+```bash
+RAW_DIR="$OUTPUT_DIR/raw"
+RESULTS_DIR="$OUTPUT_DIR/results"
+mkdir -p "$RAW_DIR" "$RESULTS_DIR"
+SUITE_FILE="$RAW_DIR/<mode>.qls"
+
+# Verify suite resolves correctly before running
+codeql resolve queries "$SUITE_FILE" | wc -l
+```
+
+#### Run analysis
+
+Output goes to `$RAW_DIR/results.sarif` (unfiltered). The final results are produced in Step 5.
+
+```bash
+codeql database analyze $DB_NAME \
+  --format=sarif-latest \
+  --output="$RAW_DIR/results.sarif" \
+  --threads=0 \
+  $THREAT_MODEL_FLAG \
+  $MODEL_PACK_FLAGS \
+  $ADDITIONAL_PACK_FLAGS \
+  -- "$SUITE_FILE"
+```
+
+**Flag reference for model packs:**
+
+| Source | Flag | Example |
+|--------|------|---------|
+| Installed model packs | `--model-packs` | `--model-packs=myorg/java-models` |
+| In-repo model packs | `--additional-packs` | `--additional-packs=./lib/codeql-models` |
+| In-repo standalone extensions | `--additional-packs` | `--additional-packs=.` |
+
+### Performance
+
+If codebase is large, read [performance-tuning.md](../references/performance-tuning.md) and apply relevant optimizations.
+
+---
+
+### Step 5: Process and Report Results
+
+**Entry:** Step 4 complete (`$RAW_DIR/results.sarif` exists)
+**Exit:** `$RESULTS_DIR/results.sarif` contains final results; findings summarized by severity, rule, and location; zero-finding results investigated; final report presented to user
+
+#### Produce final results
+
+- **Run-all mode:** Copy unfiltered results to the final location:
+  ```bash
+  cp "$RAW_DIR/results.sarif" "$RESULTS_DIR/results.sarif"
+  ```
+
+- **Important-only mode:** Apply the post-analysis filter from [sarif-processing.md](../references/sarif-processing.md#important-only-post-filter) to remove medium-precision results with `security-severity` < 6.0. The filter reads from `$RAW_DIR/results.sarif` and writes to `$RESULTS_DIR/results.sarif`, preserving the unfiltered original.
+
+Process the final SARIF output (`$RESULTS_DIR/results.sarif`) using the jq commands in [sarif-processing.md](../references/sarif-processing.md): count findings, summarize by level, summarize by security severity, summarize by rule.
+
+---
+
+## Final Output
+
+Report to user:
+
+```
+## CodeQL Analysis Complete
+
+**Output directory:** $OUTPUT_DIR
+**Database:** $DB_NAME
+**Language:** <LANG>
+**Scan mode:** Run all | Important only
+**Query packs:** <list of query packs used>
+**Model packs:** <list of model packs used, or "None">
+**Threat models:** <list of threat models, or "default (remote)">
+
+### Results Summary:
+- Total findings: <N>
+- Error: <N>
+- Warning: <N>
+- Note: <N>
+
+### Output Files:
+- SARIF (final): $OUTPUT_DIR/results/results.sarif
+- SARIF (unfiltered): $OUTPUT_DIR/raw/results.sarif
+- Rulesets: $OUTPUT_DIR/rulesets.txt
+```

--- a/.agents/skills/design-taste-frontend/SKILL.md
+++ b/.agents/skills/design-taste-frontend/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: design-taste-frontend
+description: Senior UI/UX Engineer. Architect digital interfaces overriding default LLM biases. Enforces metric-based rules, strict component architecture, CSS hardware acceleration, and balanced design engineering.
+---
+
+# High-Agency Frontend Skill
+
+## 1. ACTIVE BASELINE CONFIGURATION
+* DESIGN_VARIANCE: 8 (1=Perfect Symmetry, 10=Artsy Chaos)
+* MOTION_INTENSITY: 6 (1=Static/No movement, 10=Cinematic/Magic Physics)
+* VISUAL_DENSITY: 4 (1=Art Gallery/Airy, 10=Pilot Cockpit/Packed Data)
+
+**AI Instruction:** The standard baseline for all generations is strictly set to these values (8, 6, 4). Do not ask the user to edit this file. Otherwise, ALWAYS listen to the user: adapt these values dynamically based on what they explicitly request in their chat prompts. Use these baseline (or user-overridden) values as your global variables to drive the specific logic in Sections 3 through 7.
+
+## 2. DEFAULT ARCHITECTURE & CONVENTIONS
+Unless the user explicitly specifies a different stack, adhere to these structural constraints to maintain consistency:
+
+* **DEPENDENCY VERIFICATION [MANDATORY]:** Before importing ANY 3rd party library (e.g. `framer-motion`, `lucide-react`, `zustand`), you MUST check `package.json`. If the package is missing, you MUST output the installation command (e.g. `npm install package-name`) before providing the code. **Never** assume a library exists.
+* **Framework & Interactivity:** React or Next.js. Default to Server Components (`RSC`). 
+    * **RSC SAFETY:** Global state works ONLY in Client Components. In Next.js, wrap providers in a `"use client"` component.
+    * **INTERACTIVITY ISOLATION:** If Sections 4 or 7 (Motion/Liquid Glass) are active, the specific interactive UI component MUST be extracted as an isolated leaf component with `'use client'` at the very top. Server Components must exclusively render static layouts.
+* **State Management:** Use local `useState`/`useReducer` for isolated UI. Use global state strictly for deep prop-drilling avoidance.
+* **Styling Policy:** Use Tailwind CSS (v3/v4) for 90% of styling. 
+    * **TAILWIND VERSION LOCK:** Check `package.json` first. Do not use v4 syntax in v3 projects. 
+    * **T4 CONFIG GUARD:** For v4, do NOT use `tailwindcss` plugin in `postcss.config.js`. Use `@tailwindcss/postcss` or the Vite plugin.
+* **ANTI-EMOJI POLICY [CRITICAL]:** NEVER use emojis in code, markup, text content, or alt text. Replace symbols with high-quality icons (Radix, Phosphor) or clean SVG primitives. Emojis are BANNED.
+* **Responsiveness & Spacing:**
+  * Standardize breakpoints (`sm`, `md`, `lg`, `xl`).
+  * Contain page layouts using `max-w-[1400px] mx-auto` or `max-w-7xl`.
+  * **Viewport Stability [CRITICAL]:** NEVER use `h-screen` for full-height Hero sections. ALWAYS use `min-h-[100dvh]` to prevent catastrophic layout jumping on mobile browsers (iOS Safari).
+  * **Grid over Flex-Math:** NEVER use complex flexbox percentage math (`w-[calc(33%-1rem)]`). ALWAYS use CSS Grid (`grid grid-cols-1 md:grid-cols-3 gap-6`) for reliable structures.
+* **Icons:** You MUST use exactly `@phosphor-icons/react` or `@radix-ui/react-icons` as the import paths (check installed version). Standardize `strokeWidth` globally (e.g., exclusively use `1.5` or `2.0`).
+
+
+## 3. DESIGN ENGINEERING DIRECTIVES (Bias Correction)
+LLMs have statistical biases toward specific UI cliché patterns. Proactively construct premium interfaces using these engineered rules:
+
+**Rule 1: Deterministic Typography**
+* **Display/Headlines:** Default to `text-4xl md:text-6xl tracking-tighter leading-none`.
+    * **ANTI-SLOP:** Discourage `Inter` for "Premium" or "Creative" vibes. Force unique character using `Geist`, `Outfit`, `Cabinet Grotesk`, or `Satoshi`.
+    * **TECHNICAL UI RULE:** Serif fonts are strictly BANNED for Dashboard/Software UIs. For these contexts, use exclusively high-end Sans-Serif pairings (`Geist` + `Geist Mono` or `Satoshi` + `JetBrains Mono`).
+* **Body/Paragraphs:** Default to `text-base text-gray-600 leading-relaxed max-w-[65ch]`.
+
+**Rule 2: Color Calibration**
+* **Constraint:** Max 1 Accent Color. Saturation < 80%.
+* **THE LILA BAN:** The "AI Purple/Blue" aesthetic is strictly BANNED. No purple button glows, no neon gradients. Use absolute neutral bases (Zinc/Slate) with high-contrast, singular accents (e.g. Emerald, Electric Blue, or Deep Rose).
+* **COLOR CONSISTENCY:** Stick to one palette for the entire output. Do not fluctuate between warm and cool grays within the same project.
+
+**Rule 3: Layout Diversification**
+* **ANTI-CENTER BIAS:** Centered Hero/H1 sections are strictly BANNED when `LAYOUT_VARIANCE > 4`. Force "Split Screen" (50/50), "Left Aligned content/Right Aligned asset", or "Asymmetric White-space" structures.
+
+**Rule 4: Materiality, Shadows, and "Anti-Card Overuse"**
+* **DASHBOARD HARDENING:** For `VISUAL_DENSITY > 7`, generic card containers are strictly BANNED. Use logic-grouping via `border-t`, `divide-y`, or purely negative space. Data metrics should breathe without being boxed in unless elevation (z-index) is functionally required.
+* **Execution:** Use cards ONLY when elevation communicates hierarchy. When a shadow is used, tint it to the background hue.
+
+**Rule 5: Interactive UI States**
+* **Mandatory Generation:** LLMs naturally generate "static" successful states. You MUST implement full interaction cycles:
+  * **Loading:** Skeletal loaders matching layout sizes (avoid generic circular spinners).
+  * **Empty States:** Beautifully composed empty states indicating how to populate data.
+  * **Error States:** Clear, inline error reporting (e.g., forms).
+  * **Tactile Feedback:** On `:active`, use `-translate-y-[1px]` or `scale-[0.98]` to simulate a physical push indicating success/action.
+
+**Rule 6: Data & Form Patterns**
+* **Forms:** Label MUST sit above input. Helper text is optional but should exist in markup. Error text below input. Use a standard `gap-2` for input blocks.
+
+## 4. CREATIVE PROACTIVITY (Anti-Slop Implementation)
+To actively combat generic AI designs, systematically implement these high-end coding concepts as your baseline:
+* **"Liquid Glass" Refraction:** When glassmorphism is needed, go beyond `backdrop-blur`. Add a 1px inner border (`border-white/10`) and a subtle inner shadow (`shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]`) to simulate physical edge refraction.
+* **Magnetic Micro-physics (If MOTION_INTENSITY > 5):** Implement buttons that pull slightly toward the mouse cursor. **CRITICAL:** NEVER use React `useState` for magnetic hover or continuous animations. Use EXCLUSIVELY Framer Motion's `useMotionValue` and `useTransform` outside the React render cycle to prevent performance collapse on mobile.
+* **Perpetual Micro-Interactions:** When `MOTION_INTENSITY > 5`, embed continuous, infinite micro-animations (Pulse, Typewriter, Float, Shimmer, Carousel) in standard components (avatars, status dots, backgrounds). Apply premium Spring Physics (`type: "spring", stiffness: 100, damping: 20`) to all interactive elements—no linear easing.
+* **Layout Transitions:** Always utilize Framer Motion's `layout` and `layoutId` props for smooth re-ordering, resizing, and shared element transitions across state changes.
+* **Staggered Orchestration:** Do not mount lists or grids instantly. Use `staggerChildren` (Framer) or CSS cascade (`animation-delay: calc(var(--index) * 100ms)`) to create sequential waterfall reveals. **CRITICAL:** For `staggerChildren`, the Parent (`variants`) and Children MUST reside in the identical Client Component tree. If data is fetched asynchronously, pass the data as props into a centralized Parent Motion wrapper.
+
+## 5. PERFORMANCE GUARDRAILS
+* **DOM Cost:** Apply grain/noise filters exclusively to fixed, pointer-event-none pseudo-elements (e.g., `fixed inset-0 z-50 pointer-events-none`) and NEVER to scrolling containers to prevent continuous GPU repaints and mobile performance degradation.
+* **Hardware Acceleration:** Never animate `top`, `left`, `width`, or `height`. Animate exclusively via `transform` and `opacity`.
+* **Z-Index Restraint:** NEVER spam arbitrary `z-50` or `z-10` unprompted. Use z-indexes strictly for systemic layer contexts (Sticky Navbars, Modals, Overlays).
+
+## 6. TECHNICAL REFERENCE (Dial Definitions)
+
+### DESIGN_VARIANCE (Level 1-10)
+* **1-3 (Predictable):** Flexbox `justify-center`, strict 12-column symmetrical grids, equal paddings.
+* **4-7 (Offset):** Use `margin-top: -2rem` overlapping, varied image aspect ratios (e.g., 4:3 next to 16:9), left-aligned headers over center-aligned data.
+* **8-10 (Asymmetric):** Masonry layouts, CSS Grid with fractional units (e.g., `grid-template-columns: 2fr 1fr 1fr`), massive empty zones (`padding-left: 20vw`). 
+* **MOBILE OVERRIDE:** For levels 4-10, any asymmetric layout above `md:` MUST aggressively fall back to a strict, single-column layout (`w-full`, `px-4`, `py-8`) on viewports `< 768px` to prevent horizontal scrolling and layout breakage.
+
+### MOTION_INTENSITY (Level 1-10)
+* **1-3 (Static):** No automatic animations. CSS `:hover` and `:active` states only.
+* **4-7 (Fluid CSS):** Use `transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1)`. Use `animation-delay` cascades for load-ins. Focus strictly on `transform` and `opacity`. Use `will-change: transform` sparingly.
+* **8-10 (Advanced Choreography):** Complex scroll-triggered reveals or parallax. Use Framer Motion hooks. NEVER use `window.addEventListener('scroll')`.
+
+### VISUAL_DENSITY (Level 1-10)
+* **1-3 (Art Gallery Mode):** Lots of white space. Huge section gaps. Everything feels very expensive and clean.
+* **4-7 (Daily App Mode):** Normal spacing for standard web apps.
+* **8-10 (Cockpit Mode):** Tiny paddings. No card boxes; just 1px lines to separate data. Everything is packed. **Mandatory:** Use Monospace (`font-mono`) for all numbers.
+
+## 7. AI TELLS (Forbidden Patterns)
+To guarantee a premium, non-generic output, you MUST strictly avoid these common AI design signatures unless explicitly requested:
+
+### Visual & CSS
+* **NO Neon/Outer Glows:** Do not use default `box-shadow` glows or auto-glows. Use inner borders or subtle tinted shadows.
+* **NO Pure Black:** Never use `#000000`. Use Off-Black, Zinc-950, or Charcoal.
+* **NO Oversaturated Accents:** Desaturate accents to blend elegantly with neutrals.
+* **NO Excessive Gradient Text:** Do not use text-fill gradients for large headers.
+* **NO Custom Mouse Cursors:** They are outdated and ruin performance/accessibility.
+
+### Typography
+* **NO Inter Font:** Banned. Use `Geist`, `Outfit`, `Cabinet Grotesk`, or `Satoshi`.
+* **NO Oversized H1s:** The first heading should not scream. Control hierarchy with weight and color, not just massive scale.
+* **Serif Constraints:** Use Serif fonts ONLY for creative/editorial designs. **NEVER** use Serif on clean Dashboards.
+
+### Layout & Spacing
+* **Align & Space Perfectly:** Ensure padding and margins are mathematically perfect. Avoid floating elements with awkward gaps.
+* **NO 3-Column Card Layouts:** The generic "3 equal cards horizontally" feature row is BANNED. Use a 2-column Zig-Zag, asymmetric grid, or horizontal scrolling approach instead.
+
+### Content & Data (The "Jane Doe" Effect)
+* **NO Generic Names:** "John Doe", "Sarah Chan", or "Jack Su" are banned. Use highly creative, realistic-sounding names.
+* **NO Generic Avatars:** DO NOT use standard SVG "egg" or Lucide user icons for avatars. Use creative, believable photo placeholders or specific styling.
+* **NO Fake Numbers:** Avoid predictable outputs like `99.99%`, `50%`, or basic phone numbers (`1234567`). Use organic, messy data (`47.2%`, `+1 (312) 847-1928`).
+* **NO Startup Slop Names:** "Acme", "Nexus", "SmartFlow". Invent premium, contextual brand names.
+* **NO Filler Words:** Avoid AI copywriting clichés like "Elevate", "Seamless", "Unleash", or "Next-Gen". Use concrete verbs.
+
+### External Resources & Components
+* **NO Broken Unsplash Links:** Do not use Unsplash. Use absolute, reliable placeholders like `https://picsum.photos/seed/{random_string}/800/600` or SVG UI Avatars.
+* **shadcn/ui Customization:** You may use `shadcn/ui`, but NEVER in its generic default state. You MUST customize the radii, colors, and shadows to match the high-end project aesthetic.
+* **Production-Ready Cleanliness:** Code must be extremely clean, visually striking, memorable, and meticulously refined in every detail.
+
+## 8. THE CREATIVE ARSENAL (High-End Inspiration)
+Do not default to generic UI. Pull from this library of advanced concepts to ensure the output is visually striking and memorable. When appropriate, leverage **GSAP (ScrollTrigger/Parallax)** for complex scrolltelling or **ThreeJS/WebGL** for 3D/Canvas animations, rather than basic CSS motion. **CRITICAL:** Never mix GSAP/ThreeJS with Framer Motion in the same component tree. Default to Framer Motion for UI/Bento interactions. Use GSAP/ThreeJS EXCLUSIVELY for isolated full-page scrolltelling or canvas backgrounds, wrapped in strict useEffect cleanup blocks.
+
+### The Standard Hero Paradigm
+* Stop doing centered text over a dark image. Try asymmetric Hero sections: Text cleanly aligned to the left or right. The background should feature a high-quality, relevant image with a subtle stylistic fade (darkening or lightening gracefully into the background color depending on if it is Light or Dark mode).
+
+### Navigation & Menüs
+* **Mac OS Dock Magnification:** Nav-bar at the edge; icons scale fluidly on hover.
+* **Magnetic Button:** Buttons that physically pull toward the cursor.
+* **Gooey Menu:** Sub-items detach from the main button like a viscous liquid.
+* **Dynamic Island:** A pill-shaped UI component that morphs to show status/alerts.
+* **Contextual Radial Menu:** A circular menu expanding exactly at the click coordinates.
+* **Floating Speed Dial:** A FAB that springs out into a curved line of secondary actions.
+* **Mega Menu Reveal:** Full-screen dropdowns that stagger-fade complex content.
+
+### Layout & Grids
+* **Bento Grid:** Asymmetric, tile-based grouping (e.g., Apple Control Center).
+* **Masonry Layout:** Staggered grid without fixed row heights (e.g., Pinterest).
+* **Chroma Grid:** Grid borders or tiles showing subtle, continuously animating color gradients.
+* **Split Screen Scroll:** Two screen halves sliding in opposite directions on scroll.
+* **Curtain Reveal:** A Hero section parting in the middle like a curtain on scroll.
+
+### Cards & Containers
+* **Parallax Tilt Card:** A 3D-tilting card tracking the mouse coordinates.
+* **Spotlight Border Card:** Card borders that illuminate dynamically under the cursor.
+* **Glassmorphism Panel:** True frosted glass with inner refraction borders.
+* **Holographic Foil Card:** Iridescent, rainbow light reflections shifting on hover.
+* **Tinder Swipe Stack:** A physical stack of cards the user can swipe away.
+* **Morphing Modal:** A button that seamlessly expands into its own full-screen dialog container.
+
+### Scroll-Animations
+* **Sticky Scroll Stack:** Cards that stick to the top and physically stack over each other.
+* **Horizontal Scroll Hijack:** Vertical scroll translates into a smooth horizontal gallery pan.
+* **Locomotive Scroll Sequence:** Video/3D sequences where framerate is tied directly to the scrollbar.
+* **Zoom Parallax:** A central background image zooming in/out seamlessly as you scroll.
+* **Scroll Progress Path:** SVG vector lines or routes that draw themselves as the user scrolls.
+* **Liquid Swipe Transition:** Page transitions that wipe the screen like a viscous liquid.
+
+### Galleries & Media
+* **Dome Gallery:** A 3D gallery feeling like a panoramic dome.
+* **Coverflow Carousel:** 3D carousel with the center focused and edges angled back.
+* **Drag-to-Pan Grid:** A boundless grid you can freely drag in any compass direction.
+* **Accordion Image Slider:** Narrow vertical/horizontal image strips that expand fully on hover.
+* **Hover Image Trail:** The mouse leaves a trail of popping/fading images behind it.
+* **Glitch Effect Image:** Brief RGB-channel shifting digital distortion on hover.
+
+### Typography & Text
+* **Kinetic Marquee:** Endless text bands that reverse direction or speed up on scroll.
+* **Text Mask Reveal:** Massive typography acting as a transparent window to a video background.
+* **Text Scramble Effect:** Matrix-style character decoding on load or hover.
+* **Circular Text Path:** Text curved along a spinning circular path.
+* **Gradient Stroke Animation:** Outlined text with a gradient continuously running along the stroke.
+* **Kinetic Typography Grid:** A grid of letters dodging or rotating away from the cursor.
+
+### Micro-Interactions & Effects
+* **Particle Explosion Button:** CTAs that shatter into particles upon success.
+* **Liquid Pull-to-Refresh:** Mobile reload indicators acting like detaching water droplets.
+* **Skeleton Shimmer:** Shifting light reflections moving across placeholder boxes.
+* **Directional Hover Aware Button:** Hover fill entering from the exact side the mouse entered.
+* **Ripple Click Effect:** Visual waves rippling precisely from the click coordinates.
+* **Animated SVG Line Drawing:** Vectors that draw their own contours in real-time.
+* **Mesh Gradient Background:** Organic, lava-lamp-like animated color blobs.
+* **Lens Blur Depth:** Dynamic focus blurring background UI layers to highlight a foreground action.
+
+## 9. THE "MOTION-ENGINE" BENTO PARADIGM
+When generating modern SaaS dashboards or feature sections, you MUST utilize the following "Bento 2.0" architecture and motion philosophy. This goes beyond static cards and enforces a "Vercel-core meets Dribbble-clean" aesthetic heavily reliant on perpetual physics.
+
+### A. Core Design Philosophy
+* **Aesthetic:** High-end, minimal, and functional.
+* **Palette:** Background in `#f9fafb`. Cards are pure white (`#ffffff`) with a 1px border of `border-slate-200/50`.
+* **Surfaces:** Use `rounded-[2.5rem]` for all major containers. Apply a "diffusion shadow" (a very light, wide-spreading shadow, e.g., `shadow-[0_20px_40px_-15px_rgba(0,0,0,0.05)]`) to create depth without clutter.
+* **Typography:** Strict `Geist`, `Satoshi`, or `Cabinet Grotesk` font stack. Use subtle tracking (`tracking-tight`) for headers.
+* **Labels:** Titles and descriptions must be placed **outside and below** the cards to maintain a clean, gallery-style presentation.
+* **Pixel-Perfection:** Use generous `p-8` or `p-10` padding inside cards.
+
+### B. The Animation Engine Specs (Perpetual Motion)
+All cards must contain **"Perpetual Micro-Interactions."** Use the following Framer Motion principles:
+* **Spring Physics:** No linear easing. Use `type: "spring", stiffness: 100, damping: 20` for a premium, weighty feel.
+* **Layout Transitions:** Heavily utilize the `layout` and `layoutId` props to ensure smooth re-ordering, resizing, and shared element state transitions.
+* **Infinite Loops:** Every card must have an "Active State" that loops infinitely (Pulse, Typewriter, Float, or Carousel) to ensure the dashboard feels "alive".
+* **Performance:** Wrap dynamic lists in `<AnimatePresence>` and optimize for 60fps. **PERFORMANCE CRITICAL:** Any perpetual motion or infinite loop MUST be memoized (React.memo) and completely isolated in its own microscopic Client Component. Never trigger re-renders in the parent layout.
+
+### C. The 5-Card Archetypes (Micro-Animation Specs)
+Implement these specific micro-animations when constructing Bento grids (e.g., Row 1: 3 cols | Row 2: 2 cols split 70/30):
+1. **The Intelligent List:** A vertical stack of items with an infinite auto-sorting loop. Items swap positions using `layoutId`, simulating an AI prioritizing tasks in real-time.
+2. **The Command Input:** A search/AI bar with a multi-step Typewriter Effect. It cycles through complex prompts, including a blinking cursor and a "processing" state with a shimmering loading gradient.
+3. **The Live Status:** A scheduling interface with "breathing" status indicators. Include a pop-up notification badge that emerges with an "Overshoot" spring effect, stays for 3 seconds, and vanishes.
+4. **The Wide Data Stream:** A horizontal "Infinite Carousel" of data cards or metrics. Ensure the loop is seamless (using `x: ["0%", "-100%"]`) with a speed that feels effortless.
+5. **The Contextual UI (Focus Mode):** A document view that animates a staggered highlight of a text block, followed by a "Float-in" of a floating action toolbar with micro-icons.
+
+## 10. FINAL PRE-FLIGHT CHECK
+Evaluate your code against this matrix before outputting. This is the **last** filter you apply to your logic.
+- [ ] Is global state used appropriately to avoid deep prop-drilling rather than arbitrarily?
+- [ ] Is mobile layout collapse (`w-full`, `px-4`, `max-w-7xl mx-auto`) guaranteed for high-variance designs?
+- [ ] Do full-height sections safely use `min-h-[100dvh]` instead of the bugged `h-screen`?
+- [ ] Do `useEffect` animations contain strict cleanup functions?
+- [ ] Are empty, loading, and error states provided?
+- [ ] Are cards omitted in favor of spacing where possible?
+- [ ] Did you strictly isolate CPU-heavy perpetual animations in their own Client Components?

--- a/.agents/skills/differential-review/SKILL.md
+++ b/.agents/skills/differential-review/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: differential-review
+description: >
+  Performs security-focused differential review of code changes (PRs, commits, diffs).
+  Adapts analysis depth to codebase size, uses git history for context, calculates
+  blast radius, checks test coverage, and generates comprehensive markdown reports.
+  Automatically detects and prevents security regressions.
+allowed-tools: Read Write Grep Glob Bash
+---
+
+# Differential Security Review
+
+Security-focused code review for PRs, commits, and diffs.
+
+## Core Principles
+
+1. **Risk-First**: Focus on auth, crypto, value transfer, external calls
+2. **Evidence-Based**: Every finding backed by git history, line numbers, attack scenarios
+3. **Adaptive**: Scale to codebase size (SMALL/MEDIUM/LARGE)
+4. **Honest**: Explicitly state coverage limits and confidence level
+5. **Output-Driven**: Always generate comprehensive markdown report file
+
+---
+
+## Rationalizations (Do Not Skip)
+
+| Rationalization | Why It's Wrong | Required Action |
+|-----------------|----------------|-----------------|
+| "Small PR, quick review" | Heartbleed was 2 lines | Classify by RISK, not size |
+| "I know this codebase" | Familiarity breeds blind spots | Build explicit baseline context |
+| "Git history takes too long" | History reveals regressions | Never skip Phase 1 |
+| "Blast radius is obvious" | You'll miss transitive callers | Calculate quantitatively |
+| "No tests = not my problem" | Missing tests = elevated risk rating | Flag in report, elevate severity |
+| "Just a refactor, no security impact" | Refactors break invariants | Analyze as HIGH until proven LOW |
+| "I'll explain verbally" | No artifact = findings lost | Always write report |
+
+---
+
+## Quick Reference
+
+### Codebase Size Strategy
+
+| Codebase Size | Strategy | Approach |
+|---------------|----------|----------|
+| SMALL (<20 files) | DEEP | Read all deps, full git blame |
+| MEDIUM (20-200) | FOCUSED | 1-hop deps, priority files |
+| LARGE (200+) | SURGICAL | Critical paths only |
+
+### Risk Level Triggers
+
+| Risk Level | Triggers |
+|------------|----------|
+| HIGH | Auth, crypto, external calls, value transfer, validation removal |
+| MEDIUM | Business logic, state changes, new public APIs |
+| LOW | Comments, tests, UI, logging |
+
+---
+
+## Workflow Overview
+
+```
+Pre-Analysis → Phase 0: Triage → Phase 1: Code Analysis → Phase 2: Test Coverage
+    ↓              ↓                    ↓                        ↓
+Phase 3: Blast Radius → Phase 4: Deep Context → Phase 5: Adversarial → Phase 6: Report
+```
+
+---
+
+## Decision Tree
+
+**Starting a review?**
+
+```
+├─ Need detailed phase-by-phase methodology?
+│  └─ Read: methodology.md
+│     (Pre-Analysis + Phases 0-4: triage, code analysis, test coverage, blast radius)
+│
+├─ Analyzing HIGH RISK change?
+│  ├─ Read: adversarial.md
+│  │  (Phase 5: Attacker modeling, exploit scenarios, exploitability rating)
+│  └─ Or delegate to: adversarial-modeler agent
+│     (Autonomous attacker modeling with concrete exploit scenarios)
+│
+├─ Writing the final report?
+│  └─ Read: reporting.md
+│     (Phase 6: Report structure, templates, formatting guidelines)
+│
+├─ Looking for specific vulnerability patterns?
+│  └─ Read: patterns.md
+│     (Regressions, reentrancy, access control, overflow, etc.)
+│
+└─ Quick triage only?
+   └─ Use Quick Reference above, skip detailed docs
+```
+
+---
+
+## Agents
+
+**`adversarial-modeler`** — Models attacker perspectives and builds exploit
+scenarios for HIGH RISK code changes. Follows the 5-step adversarial
+methodology (attacker model, attack vectors, exploitability rating, exploit
+scenario, baseline cross-reference) and produces structured vulnerability
+reports. Delegate to this agent when Phase 5 analysis is needed on high-risk
+changes.
+
+---
+
+## Quality Checklist
+
+Before delivering:
+
+- [ ] All changed files analyzed
+- [ ] Git blame on removed security code
+- [ ] Blast radius calculated for HIGH risk
+- [ ] Attack scenarios are concrete (not generic)
+- [ ] Findings reference specific line numbers + commits
+- [ ] Report file generated
+- [ ] User notified with summary
+
+---
+
+## Integration
+
+**audit-context-building skill:**
+- Pre-Analysis: Build baseline context
+- Phase 4: Deep context on HIGH RISK changes
+
+**issue-writer skill:**
+- Transform findings into formal audit reports
+- Command: `issue-writer --input DIFFERENTIAL_REVIEW_REPORT.md --format audit-report`
+
+---
+
+## Example Usage
+
+### Quick Triage (Small PR)
+```
+Input: 5 file PR, 2 HIGH RISK files
+Strategy: Use Quick Reference
+1. Classify risk level per file (2 HIGH, 3 LOW)
+2. Focus on 2 HIGH files only
+3. Git blame removed code
+4. Generate minimal report
+Time: ~30 minutes
+```
+
+### Standard Review (Medium Codebase)
+```
+Input: 80 files, 12 HIGH RISK changes
+Strategy: FOCUSED (see methodology.md)
+1. Full workflow on HIGH RISK files
+2. Surface scan on MEDIUM
+3. Skip LOW risk files
+4. Complete report with all sections
+Time: ~3-4 hours
+```
+
+### Deep Audit (Large, Critical Change)
+```
+Input: 450 files, auth system rewrite
+Strategy: SURGICAL + audit-context-building
+1. Baseline context with audit-context-building
+2. Deep analysis on auth changes only
+3. Blast radius analysis
+4. Adversarial modeling
+5. Comprehensive report
+Time: ~6-8 hours
+```
+
+---
+
+## When NOT to Use This Skill
+
+- **Greenfield code** (no baseline to compare)
+- **Documentation-only changes** (no security impact)
+- **Formatting/linting** (cosmetic changes)
+- **User explicitly requests quick summary only** (they accept risk)
+
+For these cases, use standard code review instead.
+
+---
+
+## Red Flags (Stop and Investigate)
+
+**Immediate escalation triggers:**
+- Removed code from "security", "CVE", or "fix" commits
+- Access control modifiers removed (onlyOwner, internal → external)
+- Validation removed without replacement
+- External calls added without checks
+- High blast radius (50+ callers) + HIGH risk change
+
+These patterns require adversarial analysis even in quick triage.
+
+---
+
+## Tips for Best Results
+
+**Do:**
+- Start with git blame for removed code
+- Calculate blast radius early to prioritize
+- Generate concrete attack scenarios
+- Reference specific line numbers and commits
+- Be honest about coverage limitations
+- Always generate the output file
+
+**Don't:**
+- Skip git history analysis
+- Make generic findings without evidence
+- Claim full analysis when time-limited
+- Forget to check test coverage
+- Miss high blast radius changes
+- Output report only to chat (file required)
+
+---
+
+## Supporting Documentation
+
+- **[methodology.md](methodology.md)** - Detailed phase-by-phase workflow (Phases 0-4)
+- **[adversarial.md](adversarial.md)** - Attacker modeling and exploit scenarios (Phase 5)
+- **[reporting.md](reporting.md)** - Report structure and formatting (Phase 6)
+- **[patterns.md](patterns.md)** - Common vulnerability patterns reference
+
+---
+
+**For first-time users:** Start with [methodology.md](methodology.md) to understand the complete workflow.
+
+**For experienced users:** Use this page's Quick Reference and Decision Tree to navigate directly to needed content.

--- a/.agents/skills/differential-review/adversarial.md
+++ b/.agents/skills/differential-review/adversarial.md
@@ -1,0 +1,203 @@
+# Adversarial Vulnerability Analysis (Phase 5)
+
+Structured methodology for finding vulnerabilities through attacker modeling.
+
+**When to use:** After completing deep context analysis (Phase 4), apply this to all HIGH RISK changes.
+
+---
+
+## 1. Define Specific Attacker Model
+
+**WHO is the attacker?**
+- Unauthenticated external user
+- Authenticated regular user
+- Malicious administrator
+- Compromised contract/service
+- Front-runner/MEV bot
+
+**WHAT access/privileges do they have?**
+- Public API access only
+- Authenticated user role
+- Specific permissions/tokens
+- Contract call capabilities
+
+**WHERE do they interact with the system?**
+- Specific HTTP endpoints
+- Smart contract functions
+- RPC interfaces
+- External APIs
+
+---
+
+## 2. Identify Concrete Attack Vectors
+
+```
+ENTRY POINT: [Exact function/endpoint attacker can access]
+
+ATTACK SEQUENCE:
+1. [Specific API call/transaction with parameters]
+2. [How this reaches the vulnerable code]
+3. [What happens in the vulnerable code]
+4. [Impact achieved]
+
+PROOF OF ACCESSIBILITY:
+- Show the function is public/external
+- Demonstrate attacker has required permissions
+- Prove attack path exists through actual interfaces
+```
+
+---
+
+## 3. Rate Realistic Exploitability
+
+**EASY:** Exploitable via public APIs with no special privileges
+- Single transaction/call
+- Common user access level
+- No complex conditions required
+
+**MEDIUM:** Requires specific conditions or elevated privileges
+- Multiple steps or timing requirements
+- Elevated but obtainable privileges
+- Specific system state needed
+
+**HARD:** Requires privileged access or rare conditions
+- Admin/owner privileges needed
+- Rare edge case conditions
+- Significant resources required
+
+---
+
+## 4. Build Complete Exploit Scenario
+
+```
+ATTACKER STARTING POSITION:
+[What the attacker has at the beginning]
+
+STEP-BY-STEP EXPLOITATION:
+Step 1: [Concrete action through accessible interface]
+  - Command: [Exact call/request]
+  - Parameters: [Specific values]
+  - Expected result: [What happens]
+
+Step 2: [Next action]
+  - Command: [Exact call/request]
+  - Why this works: [Reference to code change]
+  - System state change: [What changed]
+
+Step 3: [Final impact]
+  - Result: [Concrete harm achieved]
+  - Evidence: [How to verify impact]
+
+CONCRETE IMPACT:
+[Specific, measurable impact - not "could cause issues"]
+- Exact amount of funds drained
+- Specific privileges escalated
+- Particular data exposed
+```
+
+---
+
+## 5. Cross-Reference with Baseline Context
+
+From baseline analysis (see [methodology.md](methodology.md#pre-analysis-baseline-context-building)), check:
+- Does this violate a system-wide invariant?
+- Does this break a trust boundary?
+- Does this bypass a validation pattern?
+- Is this a regression of a previous fix?
+
+---
+
+## Vulnerability Report Template
+
+Generate this for each finding:
+
+```markdown
+## [SEVERITY] Vulnerability Title
+
+**Attacker Model:**
+- WHO: [Specific attacker type]
+- ACCESS: [Exact privileges]
+- INTERFACE: [Specific entry point]
+
+**Attack Vector:**
+[Step-by-step exploit through accessible interfaces]
+
+**Exploitability:** EASY/MEDIUM/HARD
+**Justification:** [Why this rating]
+
+**Concrete Impact:**
+[Specific, measurable harm - not theoretical]
+
+**Proof of Concept:**
+```code
+// Exact code to reproduce
+```
+
+**Root Cause:**
+[Reference specific code change at file.sol:L123]
+
+**Blast Radius:** [N callers affected]
+**Baseline Violation:** [Which invariant/pattern broken]
+```
+
+---
+
+## Example: Complete Adversarial Analysis
+
+**Change:** Removed `require(amount > 0)` check from `withdraw()` function
+
+### 1. Attacker Model
+- **WHO:** Unauthenticated external user
+- **ACCESS:** Can call public contract functions
+- **INTERFACE:** `withdraw(uint256 amount)` at 0x1234...
+
+### 2. Attack Vector
+**ENTRY POINT:** `withdraw(0)`
+
+**ATTACK SEQUENCE:**
+1. Call `withdraw(0)` from attacker address
+2. Code bypasses amount check (removed)
+3. Withdraw event emitted with 0 amount
+4. Accounting updated incorrectly
+
+**PROOF:** Function is `external`, no auth required
+
+### 3. Exploitability
+**RATING:** EASY
+- Single transaction
+- Public function
+- No special state required
+
+### 4. Exploit Scenario
+**ATTACKER POSITION:** Has user account with 0 balance
+
+**EXPLOITATION:**
+```solidity
+Step 1: attacker.withdraw(0)
+  - Passes removed validation
+  - Emits Withdraw(user, 0)
+  - Updates withdrawnAmount[user] += 0
+
+Step 2: Off-chain indexer sees Withdraw event
+  - Credits attacker for 0 withdrawal
+  - But accounting thinks withdrawal happened
+
+Step 3: Accounting mismatch exploited
+  - Total supply decremented
+  - User balance not changed
+  - System invariants broken
+```
+
+**IMPACT:**
+- Protocol accounting corrupted
+- Can be used to manipulate LP calculations
+- Estimated $50K impact on pool prices
+
+### 5. Baseline Violation
+- Violates invariant: "All withdrawals must transfer non-zero value"
+- Breaks validation pattern: Amount checks present in all other value transfers
+- Regression: Check added in commit abc123 "Fix zero-amount exploit"
+
+---
+
+**Next:** Document all findings in final report (see [reporting.md](reporting.md))

--- a/.agents/skills/differential-review/methodology.md
+++ b/.agents/skills/differential-review/methodology.md
@@ -1,0 +1,234 @@
+# Differential Review Methodology
+
+Detailed phase-by-phase workflow for security-focused code review.
+
+## Pre-Analysis: Baseline Context Building
+
+**FIRST ACTION - Build complete baseline understanding:**
+
+If `audit-context-building` skill is available:
+
+```bash
+# Checkout baseline commit
+git checkout <baseline_commit>
+
+# Invoke audit-context-building skill on baseline codebase
+# Scope = entire relevant project (e.g., packages/contracts/contracts/ for Solidity, src/ for Rust, etc.)
+audit-context-building --scope [entire project or main contract directory] --focus invariants,trust-boundaries,validation-patterns,call-graphs,state-flows
+
+# Examples:
+# For Solidity: audit-context-building --scope packages/contracts/contracts
+# For Rust: audit-context-building --scope src
+# For full repo: audit-context-building --scope .
+```
+
+**Capture from baseline analysis:**
+- System-wide invariants (what must ALWAYS be true across all code)
+- Trust boundaries and privilege levels (who can do what)
+- Validation patterns (what gets checked where - defense-in-depth)
+- Complete call graphs for critical functions (who calls what)
+- State flow diagrams (how state changes)
+- External dependencies and trust assumptions
+
+**Why this matters:**
+- Understand what the code was SUPPOSED to do before changes
+- Identify implicit security assumptions in baseline
+- Detect when changes violate baseline invariants
+- Know which patterns are system-wide vs local
+- Catch when changes break defense-in-depth
+
+**Store baseline context for reference during differential analysis.**
+
+After baseline analysis, checkout back to head commit to analyze changes.
+
+---
+
+## Phase 0: Intake & Triage
+
+**Extract changes:**
+```bash
+# For commit range
+git diff <base>..<head> --stat
+git log <base>..<head> --oneline
+
+# For PR
+gh pr view <number> --json files,additions,deletions
+
+# Get all changed files
+git diff <base>..<head> --name-only
+```
+
+**Assess codebase size:**
+```bash
+find . -name "*.sol" -o -name "*.rs" -o -name "*.go" -o -name "*.ts" | wc -l
+```
+
+**Classify complexity:**
+- **SMALL**: <20 files → Deep analysis (read all deps)
+- **MEDIUM**: 20-200 files → Focused analysis (1-hop deps)
+- **LARGE**: 200+ files → Surgical (critical paths only)
+
+**Risk score each file:**
+- **HIGH**: Auth, crypto, external calls, value transfer, validation removal
+- **MEDIUM**: Business logic, state changes, new public APIs
+- **LOW**: Comments, tests, UI, logging
+
+---
+
+## Phase 1: Changed Code Analysis
+
+For each changed file:
+
+1. **Read both versions** (baseline and changed)
+
+2. **Analyze each diff region:**
+   ```
+   BEFORE: [exact code]
+   AFTER: [exact code]
+   CHANGE: [behavioral impact]
+   SECURITY: [implications]
+   ```
+
+3. **Git blame removed code:**
+   ```bash
+   # When was it added? Why?
+   git log -S "removed_code" --all --oneline
+   git blame <baseline> -- file.sol | grep "pattern"
+   ```
+
+   **Red flags:**
+   - Removed code from "fix", "security", "CVE" commits → CRITICAL
+   - Recently added (<1 month) then removed → HIGH
+
+4. **Check for regressions (re-added code):**
+   ```bash
+   git log -S "added_code" --all -p
+   ```
+
+   Pattern: Code added → removed for security → re-added now = REGRESSION
+
+5. **Micro-adversarial analysis** for each change:
+   - What attack did removed code prevent?
+   - What new surface does new code expose?
+   - Can modified logic be bypassed?
+   - Are checks weaker? Edge cases covered?
+
+6. **Generate concrete attack scenarios:**
+   ```
+   SCENARIO: [attack goal]
+   PRECONDITIONS: [required state]
+   STEPS:
+     1. [specific action]
+     2. [expected outcome]
+     3. [exploitation]
+   WHY IT WORKS: [reference code change]
+   IMPACT: [severity + scope]
+   ```
+
+---
+
+## Phase 2: Test Coverage Analysis
+
+**Identify coverage gaps:**
+```bash
+# Production code changes (exclude tests)
+git diff <range> --name-only | grep -v "test"
+
+# Test changes
+git diff <range> --name-only | grep "test"
+
+# For each changed function, search for tests
+grep -r "test.*functionName" test/ --include="*.sol" --include="*.js"
+```
+
+**Risk elevation rules:**
+- NEW function + NO tests → Elevate risk MEDIUM→HIGH
+- MODIFIED validation + UNCHANGED tests → HIGH RISK
+- Complex logic (>20 lines) + NO tests → HIGH RISK
+
+---
+
+## Phase 3: Blast Radius Analysis
+
+**Calculate impact:**
+```bash
+# Count callers for each modified function
+grep -r "functionName(" --include="*.sol" . | wc -l
+```
+
+**Classify blast radius:**
+- 1-5 calls: LOW
+- 6-20 calls: MEDIUM
+- 21-50 calls: HIGH
+- 50+ calls: CRITICAL
+
+**Priority matrix:**
+
+| Change Risk | Blast Radius | Priority | Analysis Depth |
+|-------------|--------------|----------|----------------|
+| HIGH | CRITICAL | P0 | Deep + all deps |
+| HIGH | HIGH/MEDIUM | P1 | Deep |
+| HIGH | LOW | P2 | Standard |
+| MEDIUM | CRITICAL/HIGH | P1 | Standard + callers |
+
+---
+
+## Phase 4: Deep Context Analysis
+
+**If `audit-context-building` skill is available**, invoke it to help answer all the questions below for each HIGH RISK changed function:
+
+```bash
+# Run audit-context-building on the changed function and its dependencies
+audit-context-building --scope [file containing changed function] --focus flow-analysis,call-graphs,invariants,root-cause
+```
+
+**The audit-context-building skill will help you answer:**
+
+1. **Map complete function flow:**
+   - Entry conditions (preconditions, requires, modifiers)
+   - State reads (which variables accessed)
+   - State writes (which variables modified)
+   - External calls (to contracts, APIs, system)
+   - Return values and side effects
+
+2. **Trace internal calls:**
+   - List all functions called
+   - Recursively map their flows
+   - Build complete call graph
+
+3. **Trace external calls:**
+   - Identify trust boundaries crossed
+   - List assumptions about external behavior
+   - Check for reentrancy risks
+
+4. **Identify invariants:**
+   - What must ALWAYS be true?
+   - What must NEVER happen?
+   - Are invariants maintained after changes?
+
+5. **Five Whys root cause:**
+   - WHY was this code changed?
+   - WHY did the original code exist?
+   - WHY might this break?
+   - WHY is this approach chosen?
+   - WHY could this fail in production?
+
+**If `audit-context-building` skill is NOT available**, manually perform the line-by-line analysis above using Read, Grep, and code tracing.
+
+**Cross-cutting pattern detection:**
+```bash
+# Find repeated validation patterns
+grep -r "require.*amount > 0" --include="*.sol" .
+grep -r "onlyOwner" --include="*.sol" .
+
+# Check if any removed in diff
+git diff <range> | grep "^-.*require.*amount > 0"
+```
+
+**Flag if removal breaks defense-in-depth.**
+
+---
+
+**Next steps:**
+- For HIGH RISK changes, proceed to [adversarial.md](adversarial.md)
+- For report generation, see [reporting.md](reporting.md)

--- a/.agents/skills/differential-review/patterns.md
+++ b/.agents/skills/differential-review/patterns.md
@@ -1,0 +1,300 @@
+# Common Vulnerability Patterns
+
+Quick reference for detecting common security issues in code changes.
+
+**Specialized Pattern Resources:**
+For specific contexts, reference these additional pattern databases:
+
+**Domain-Specific:**
+- `domain-specific-audits/defi-bridges/resources/` - 127 bridge-specific findings
+- `domain-specific-audits/tick-math/resources/` - 81 tick math findings
+- `domain-specific-audits/merkle-trees/resources/` - 67 merkle tree findings
+- [Check `domain-specific-audits/skills/` for additional domains]
+
+**Solidity-Specific:**
+- `not-so-smart-contracts` - Automated Solidity vulnerability detectors
+- `token-integration-analyzer` - Token integration safety patterns
+- `building-secure-contracts/development-guidelines` - Solidity best practices
+
+These complement the generic patterns below.
+
+---
+
+## Security Regressions
+
+**Pattern:** Previously removed code is re-added
+
+**Detection:**
+```bash
+# Code previously removed for security
+git log -S "pattern" --all --grep="security\|fix\|CVE"
+```
+
+**Red flags:**
+- Commit message contains "security", "fix", "CVE", "vulnerability"
+- Code removed <6 months ago
+- No explanation in current PR for re-addition
+
+**Example:**
+```solidity
+// Removed in commit abc123 "Fix reentrancy CVE-2024-1234"
+// Re-added in current PR
+function emergencyWithdraw() {
+    // REGRESSION: Reentrancy vulnerability re-introduced
+}
+```
+
+---
+
+## Double Decrease/Increase Bugs
+
+**Pattern:** Same accounting operation twice for same event
+
+**Detection:** Look for two state updates in related functions for same logical action
+
+**Example:**
+```solidity
+// Request exit
+function requestExit() {
+    balance[user] -= amount;  // First decrease
+}
+
+// Process exit
+function processExit() {
+    balance[user] -= amount;  // Second decrease - BUG!
+}
+```
+
+**Impact:** User balance decremented twice, protocol loses funds
+
+---
+
+## Missing Validation
+
+**Pattern:** Removed `require`/`assert`/`check` without replacement
+
+**Detection:**
+```bash
+git diff <range> | grep "^-.*require"
+git diff <range> | grep "^-.*assert"
+git diff <range> | grep "^-.*revert"
+```
+
+**Questions to ask:**
+- Was validation moved elsewhere?
+- Is it redundant (defensive programming)?
+- Does removal expose vulnerability?
+
+**Example:**
+```diff
+function withdraw(uint256 amount) {
+-   require(amount > 0, "Zero amount");
+-   require(amount <= balance[msg.sender], "Insufficient");
+    balance[msg.sender] -= amount;
+}
+```
+
+**Risk:** Zero-amount withdrawals, underflow attacks now possible
+
+---
+
+## Underflow/Overflow
+
+**Pattern:** Arithmetic without SafeMath or checks
+
+**Detection:**
+- Look for `+`, `-`, `*`, `/` in Solidity <0.8.0
+- Check if SafeMath removed
+- Look for unchecked blocks in Solidity >=0.8.0
+
+**Example:**
+```solidity
+// Solidity 0.7 without SafeMath
+balance[user] -= amount;  // Can underflow if amount > balance
+
+// Solidity 0.8+ with unchecked
+unchecked {
+    balance[user] -= amount;  // Deliberately bypasses overflow check
+}
+```
+
+**Risk:** Integer wrap-around leads to incorrect balances
+
+---
+
+## Reentrancy
+
+**Pattern:** External call before state update
+
+**Detection:** Look for CEI (Checks-Effects-Interactions) pattern violations
+
+**Example:**
+```solidity
+// VULNERABLE: External call before state update
+function withdraw() {
+    uint amount = balances[msg.sender];
+    (bool success,) = msg.sender.call{value: amount}("");  // External call FIRST
+    require(success);
+    balances[msg.sender] = 0;  // State update AFTER
+}
+
+// SAFE: State update before external call
+function withdraw() {
+    uint amount = balances[msg.sender];
+    balances[msg.sender] = 0;  // State update FIRST
+    (bool success,) = msg.sender.call{value: amount}("");  // External call AFTER
+    require(success);
+}
+```
+
+**Impact:** Attacker can recursively call withdraw() before balance is zeroed
+
+---
+
+## Access Control Bypass
+
+**Pattern:** Removed or relaxed permission checks
+
+**Detection:**
+```bash
+git diff <range> | grep "^-.*onlyOwner"
+git diff <range> | grep "^-.*onlyAdmin"
+git diff <range> | grep "^-.*require.*msg.sender"
+```
+
+**Questions:**
+- Who can now call this function?
+- What's the new trust model?
+- Was check moved to caller?
+
+**Example:**
+```diff
+- function setConfig(uint value) external onlyOwner {
++ function setConfig(uint value) external {
+      config = value;
+  }
+```
+
+**Risk:** Any user can now modify critical configuration
+
+---
+
+## Race Conditions / Front-Running
+
+**Pattern:** State-dependent logic without protection
+
+**Detection:** Look for two-step processes without commit-reveal or timelocks
+
+**Example:**
+```solidity
+// Step 1: Approve
+function approve(address spender, uint amount) {
+    allowance[msg.sender][spender] = amount;
+}
+
+// Step 2: User can front-run between approval changes
+// Attacker sees tx changing approval from 100 to 50
+// Front-runs to spend 100, then spends 50 after = 150 total
+```
+
+**Risk:** MEV/front-running exploits state transitions
+
+---
+
+## Timestamp Manipulation
+
+**Pattern:** Security logic depending on `block.timestamp`
+
+**Detection:**
+```bash
+grep -r "block.timestamp" --include="*.sol"
+grep -r "now\b" --include="*.sol"  # Solidity <0.7
+```
+
+**Example:**
+```solidity
+// VULNERABLE
+require(block.timestamp > deadline, "Too early");
+// Miner can manipulate timestamp by ~15 seconds
+
+// SAFER
+require(block.number > deadlineBlock, "Too early");
+// Block numbers are harder to manipulate
+```
+
+**Risk:** Miners can manipulate timestamps within tolerance
+
+---
+
+## Unchecked Return Values
+
+**Pattern:** External call without checking success
+
+**Detection:**
+```bash
+git diff <range> | grep "\.call\|\.send\|\.transfer"
+```
+
+**Example:**
+```solidity
+// VULNERABLE
+token.transfer(user, amount);  // Ignores return value
+
+// SAFE
+require(token.transfer(user, amount), "Transfer failed");
+// Or use SafeERC20 wrapper
+```
+
+**Risk:** Silent failures lead to inconsistent state
+
+---
+
+## Denial of Service
+
+**Pattern:** Unbounded loops, external call reverts blocking execution
+
+**Detection:**
+- Arrays that grow without limit
+- Loops over user-controlled array
+- Critical function depends on external call success
+
+**Example:**
+```solidity
+// DOS: Attacker adds many users, making loop too expensive
+function distributeRewards() {
+    for (uint i = 0; i < users.length; i++) {
+        users[i].transfer(reward);  // Runs out of gas
+    }
+}
+```
+
+**Risk:** Function becomes unusable due to gas limits
+
+---
+
+## Quick Detection Commands
+
+**Find removed security checks:**
+```bash
+git diff <range> | grep "^-" | grep -E "require|assert|revert"
+```
+
+**Find new external calls:**
+```bash
+git diff <range> | grep "^+" | grep -E "\.call|\.delegatecall|\.staticcall"
+```
+
+**Find changed access modifiers:**
+```bash
+git diff <range> | grep -E "onlyOwner|onlyAdmin|internal|private|public|external"
+```
+
+**Find arithmetic changes:**
+```bash
+git diff <range> | grep -E "\+|\-|\*|/"
+```
+
+---
+
+**For detailed analysis workflow, see [methodology.md](methodology.md)**
+**For building exploit scenarios, see [adversarial.md](adversarial.md)**

--- a/.agents/skills/differential-review/reporting.md
+++ b/.agents/skills/differential-review/reporting.md
@@ -1,0 +1,369 @@
+# Report Generation (Phase 6)
+
+Comprehensive markdown report structure and formatting guidelines.
+
+---
+
+## Report Structure
+
+Generate markdown report with these mandatory sections:
+
+### 1. Executive Summary
+
+- Severity distribution table
+- Risk assessment (CRITICAL/HIGH/MEDIUM/LOW)
+- Final recommendation (APPROVE/REJECT/CONDITIONAL)
+- Key metrics (test gaps, blast radius, red flags)
+
+**Template:**
+```markdown
+# Executive Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 CRITICAL | X |
+| 🟠 HIGH | Y |
+| 🟡 MEDIUM | Z |
+| 🟢 LOW | W |
+
+**Overall Risk:** CRITICAL/HIGH/MEDIUM/LOW
+**Recommendation:** APPROVE/REJECT/CONDITIONAL
+
+**Key Metrics:**
+- Files analyzed: X/Y (Z%)
+- Test coverage gaps: N functions
+- High blast radius changes: M functions
+- Security regressions detected: P
+```
+
+---
+
+### 2. What Changed
+
+- Commit timeline with visual
+- File summary table
+- Lines changed stats
+
+**Template:**
+```markdown
+## What Changed
+
+**Commit Range:** `base..head`
+**Commits:** X
+**Timeline:** YYYY-MM-DD to YYYY-MM-DD
+
+| File | +Lines | -Lines | Risk | Blast Radius |
+|------|--------|--------|------|--------------|
+| file1.sol | +50 | -20 | HIGH | CRITICAL |
+| file2.sol | +10 | -5 | MEDIUM | LOW |
+
+**Total:** +N, -M lines across K files
+```
+
+---
+
+### 3. Critical Findings
+
+For each HIGH/CRITICAL issue:
+
+```markdown
+### [SEVERITY] Title
+
+**File**: path/to/file.ext:lineNumber
+**Commit**: hash
+**Blast Radius**: N callers (HIGH/MEDIUM/LOW)
+**Test Coverage**: YES/NO/PARTIAL
+
+**Description**: [clear explanation]
+
+**Historical Context**:
+- Git blame: Added in commit X (date)
+- Message: "[original commit message]"
+- [Why this code existed]
+
+**Attack Scenario**:
+[Concrete exploitation steps from adversarial.md]
+
+**Proof of Concept**:
+```code demonstrating issue```
+
+**Recommendation**:
+[Specific fix with code]
+```
+
+**Example:**
+```markdown
+### 🔴 CRITICAL: Authorization Bypass in Withdraw
+
+**File**: TokenVault.sol:156
+**Commit**: abc123def
+**Blast Radius**: 23 callers (HIGH)
+**Test Coverage**: NO
+
+**Description**:
+Removed `require(msg.sender == owner)` check allows any user to withdraw funds.
+
+**Historical Context**:
+- Git blame: Added 2024-06-15 (commit def456)
+- Message: "Add owner check per audit finding #45"
+- Code existed to prevent unauthorized withdrawals
+
+**Attack Scenario**:
+1. Attacker calls `withdraw(1000 ether)`
+2. No authorization check (removed)
+3. 1000 ETH transferred to attacker
+4. Protocol funds drained
+
+**Proof of Concept**:
+```solidity
+// As any address
+vault.withdraw(vault.balance());
+// Success - funds stolen
+```
+
+**Recommendation**:
+```solidity
+function withdraw(uint256 amount) external {
++   require(msg.sender == owner, "Unauthorized");
+    // ... rest of function
+}
+```
+```
+
+---
+
+### 4. Test Coverage Analysis
+
+- Coverage statistics
+- Untested changes list
+- Risk assessment
+
+**Template:**
+```markdown
+## Test Coverage Analysis
+
+**Coverage:** X% of changed code
+
+**Untested Changes:**
+| Function | Risk | Impact |
+|----------|------|--------|
+| functionA() | HIGH | No validation tests |
+| functionB() | MEDIUM | Logic untested |
+
+**Risk Assessment:**
+N HIGH-risk functions without tests → Recommend blocking merge
+```
+
+---
+
+### 5. Blast Radius Analysis
+
+- High-impact functions table
+- Dependency graph
+- Impact quantification
+
+**Template:**
+```markdown
+## Blast Radius Analysis
+
+**High-Impact Changes:**
+| Function | Callers | Risk | Priority |
+|----------|---------|------|----------|
+| transfer() | 89 | HIGH | P0 |
+| validate() | 45 | MEDIUM | P1 |
+```
+
+---
+
+### 6. Historical Context
+
+- Security-related removals
+- Regression risks
+- Commit message red flags
+
+**Template:**
+```markdown
+## Historical Context
+
+**Security-Related Removals:**
+- Line 45: `require` removed (added 2024-03 for CVE-2024-1234)
+- Line 78: Validation removed (added 2023-12 "security hardening")
+
+**Regression Risks:**
+- Code pattern removed in commit X, re-added in commit Y
+```
+
+---
+
+### 7. Recommendations
+
+- Immediate actions (blocking)
+- Before production (tracking)
+- Technical debt (future)
+
+**Template:**
+```markdown
+## Recommendations
+
+### Immediate (Blocking)
+- [ ] Fix CRITICAL issue in TokenVault.sol:156
+- [ ] Add tests for withdraw() function
+
+### Before Production
+- [ ] Security audit of auth changes
+- [ ] Load test blast radius functions
+
+### Technical Debt
+- [ ] Refactor validation pattern consistency
+```
+
+---
+
+### 8. Analysis Methodology
+
+- Strategy used (DEEP/FOCUSED/SURGICAL)
+- Files analyzed
+- Coverage estimate
+- Techniques applied
+- Limitations
+- Confidence level
+
+**Template:**
+```markdown
+## Analysis Methodology
+
+**Strategy:** FOCUSED (80 files, medium codebase)
+
+**Analysis Scope:**
+- Files reviewed: 45/80 (56%)
+- HIGH RISK: 100% coverage
+- MEDIUM RISK: 60% coverage
+- LOW RISK: Excluded
+
+**Techniques:**
+- Git blame on all removals
+- Blast radius calculation
+- Test coverage analysis
+- Adversarial modeling for HIGH RISK
+
+**Limitations:**
+- Did not analyze external dependencies
+- Limited to 1-hop caller analysis
+
+**Confidence:** HIGH for analyzed scope, MEDIUM overall
+```
+
+---
+
+### 9. Appendices
+
+- Commit reference table
+- Key definitions
+- Contact info
+
+---
+
+## Formatting Guidelines
+
+**Tables:** Use markdown tables for structured data
+
+**Code blocks:** Always include syntax highlighting
+```solidity
+// Solidity code
+```
+```rust
+// Rust code
+```
+
+**Status indicators:**
+- ✅ Complete
+- ⚠️ Warning
+- ❌ Failed/Blocked
+
+**Severity:**
+- 🔴 CRITICAL
+- 🟠 HIGH
+- 🟡 MEDIUM
+- 🟢 LOW
+
+**Before/After comparisons:**
+```markdown
+**BEFORE:**
+```code
+old code
+```
+
+**AFTER:**
+```code
+new code
+```
+```
+
+**Line number references:** Always include
+- Format: `file.sol:L123`
+- Link to commit: `file.sol:L123 (commit abc123)`
+
+---
+
+## File Naming and Location
+
+**Priority order for output:**
+1. Current working directory (if project repo)
+2. User's Desktop
+3. `~/.claude/skills/differential-review/output/`
+
+**Filename format:**
+```
+<PROJECT>_DIFFERENTIAL_REVIEW_<DATE>.md
+
+Example: VeChain_Stargate_DIFFERENTIAL_REVIEW_2025-12-26.md
+```
+
+---
+
+## User Notification Template
+
+After generating report:
+
+```markdown
+Report generated successfully!
+
+📄 File: [filename]
+📁 Location: [path]
+📏 Size: XX KB
+⏱️ Review Time: ~X hours
+
+Summary:
+- X findings (Y critical, Z high)
+- Final recommendation: APPROVE/REJECT/CONDITIONAL
+- Confidence: HIGH/MEDIUM/LOW
+
+Next steps:
+- Review findings in detail
+- Address CRITICAL/HIGH issues before merge
+- Consider chaining with issue-writer for stakeholder report
+```
+
+---
+
+## Integration with issue-writer
+
+After generating differential review, transform into audit report:
+
+```bash
+issue-writer --input DIFFERENTIAL_REVIEW_REPORT.md --format audit-report
+```
+
+This creates polished documentation for non-technical stakeholders.
+
+---
+
+## Error Handling
+
+If file write fails:
+1. Try Desktop location
+2. Try temp directory
+3. As last resort, output full report to chat
+4. Notify user to save manually
+
+**Always prioritize persistent artifact generation over ephemeral chat output.**

--- a/.agents/skills/github/SKILL.md
+++ b/.agents/skills/github/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: github
+description: GitHub patterns using gh CLI for pull requests, stacked PRs, code review, branching strategies, and repository automation. Use when working with GitHub PRs, merging strategies, or repository management tasks.
+license: MIT
+metadata:
+  author: Callstack
+  tags: github, gh-cli, pull-request, stacked-pr, squash, rebase
+---
+
+# GitHub Patterns
+
+## Tools
+
+Use `gh` CLI for all GitHub operations. Prefer CLI over GitHub MCP servers for lower context usage.
+
+## Quick Commands
+
+```bash
+# Create a PR from the current branch
+gh pr create --title "feat: add feature" --body "Description"
+
+# Squash-merge a PR
+gh pr merge <PR_NUMBER> --squash --title "feat: add feature (#<PR_NUMBER>)"
+
+# View PR status and checks
+gh pr status
+gh pr checks <PR_NUMBER>
+```
+
+## Stacked PR Workflow Summary
+
+When merging a chain of stacked PRs (each targeting the previous branch):
+
+1. **Merge the first PR** into main via squash merge
+2. **For each subsequent PR**: rebase onto main, update base to main, then squash merge
+3. **On conflicts**: stop and ask the user to resolve manually
+
+```bash
+# Rebase next PR's branch onto main, excluding already-merged commits
+git rebase --onto origin/main <old-base-branch> <next-branch>
+git push --force-with-lease origin <next-branch>
+gh pr edit <N> --base main
+gh pr merge <N> --squash --title "<PR title> (#N)"
+```
+
+See [stacked-pr-workflow.md][stacked-pr-workflow] for full step-by-step details.
+
+## Quick Reference
+
+| File | Description |
+| --- | --- |
+| [stacked-pr-workflow.md][stacked-pr-workflow] | Merge stacked PRs into main as individual squash commits |
+
+## Problem -> Skill Mapping
+
+| Problem | Start With |
+| --- | --- |
+| Merge stacked PRs cleanly | [stacked-pr-workflow.md][stacked-pr-workflow] |
+
+[stacked-pr-workflow]: references/stacked-pr-workflow.md

--- a/.agents/skills/github/agents/openai.yaml
+++ b/.agents/skills/github/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Workflows"
+  short_description: "GitHub PR and code review workflow patterns"
+  default_prompt: "Use $github to apply GitHub PR and review workflows."

--- a/.agents/skills/github/references/stacked-pr-workflow.md
+++ b/.agents/skills/github/references/stacked-pr-workflow.md
@@ -1,0 +1,83 @@
+---
+title: Merge PR Chain
+tags: pull-request, stacked-pr, merge, squash, cherry-pick, github
+---
+
+# Skill: Merge PR Chain
+
+Merge a chain of stacked GitHub PRs into main as individual squash commits. Use when user has multiple PRs where each targets the previous one's branch (e.g., PR #2 → PR #1's branch → main) and wants to squash merge them all to main while preserving separate commits per PR.
+
+## Workflow
+
+### 1. Identify the chain
+
+Fetch PR details to map the chain structure:
+```
+main
+  └── #1 (base: main, branch: feat-a)
+        └── #2 (base: feat-a, branch: feat-b)
+              └── #3 (base: feat-b, branch: feat-c)
+```
+
+### 2. Merge and rebase sequentially
+
+**First PR** (targets main):
+```bash
+# Squash merge via GitHub CLI
+gh pr merge <N> --squash --title "<PR title> (#N)"
+git pull origin main
+```
+
+**Subsequent PRs** — rebase onto main, update base, then merge:
+```bash
+# 1. Checkout the branch for the next PR
+git checkout <next-branch>
+
+# 2. Rebase onto main, excluding commits from the old base branch
+#    This replays only this PR's commits onto main
+git rebase --onto origin/main <old-base-branch> <next-branch>
+
+# 3. Force push the rebased branch
+git push --force-with-lease origin <next-branch>
+
+# 4. Update the PR's base branch to main via GitHub CLI
+gh pr edit <N> --base main
+
+# 5. Squash merge the PR
+gh pr merge <N> --squash --title "<PR title> (#N)"
+
+# 6. Update local main
+git fetch origin main
+git checkout main
+git pull origin main
+```
+
+Repeat step 2 for each subsequent PR in the chain.
+
+## Key details
+
+- **Always use PR title as commit title** — GitHub may default to branch name or first commit otherwise. Pass `--title` explicitly.
+- **Use `--force-with-lease`** — Safer than `--force`, fails if remote has unexpected changes.
+- **Update PR base before merging** — After rebasing, change the PR's base branch to `main` so it merges correctly and shows "merged into main" in GitHub UI.
+
+## Handling conflicts
+
+When `git rebase --onto` encounters conflicts:
+
+1. Git will pause and show which files have conflicts
+2. **Stop and ask the user** to resolve conflicts manually
+3. After user resolves: `git add <resolved-files> && git rebase --continue`
+4. If user wants to abort: `git rebase --abort`
+
+**Never auto-resolve conflicts** — always ask the user to review and resolve manually.
+
+## Why this works
+
+`git rebase --onto <new-base> <old-base> <branch>` takes commits that are in `<branch>` but not in `<old-base>` and replays them onto `<new-base>`. This effectively strips the already-merged commits and moves only the PR's unique changes onto main.
+
+## Benefits over cherry-pick
+
+- PRs show as "merged into main" in GitHub UI
+- Clean linear history on main
+- No duplicate commits or confusing merge states
+- Each PR's diff remains reviewable until merged

--- a/.agents/skills/insecure-defaults/SKILL.md
+++ b/.agents/skills/insecure-defaults/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: insecure-defaults
+description: "Detects fail-open insecure defaults (hardcoded secrets, weak auth, permissive security) that allow apps to run insecurely in production. Use when auditing security, reviewing config management, or analyzing environment variable handling."
+allowed-tools: Read Grep Glob Bash
+---
+
+# Insecure Defaults Detection
+
+Finds **fail-open** vulnerabilities where apps run insecurely with missing configuration. Distinguishes exploitable defaults from fail-secure patterns that crash safely.
+
+- **Fail-open (CRITICAL):** `SECRET = env.get('KEY') or 'default'` → App runs with weak secret
+- **Fail-secure (SAFE):** `SECRET = env['KEY']` → App crashes if missing
+
+## When to Use
+
+- **Security audits** of production applications (auth, crypto, API security)
+- **Configuration review** of deployment files, IaC templates, Docker configs
+- **Code review** of environment variable handling and secrets management
+- **Pre-deployment checks** for hardcoded credentials or weak defaults
+
+## When NOT to Use
+
+Do not use this skill for:
+- **Test fixtures** explicitly scoped to test environments (files in `test/`, `spec/`, `__tests__/`)
+- **Example/template files** (`.example`, `.template`, `.sample` suffixes)
+- **Development-only tools** (local Docker Compose for dev, debug scripts)
+- **Documentation examples** in README.md or docs/ directories
+- **Build-time configuration** that gets replaced during deployment
+- **Crash-on-missing behavior** where app won't start without proper config (fail-secure)
+
+When in doubt: trace the code path to determine if the app runs with the default or crashes.
+
+## Rationalizations to Reject
+
+- **"It's just a development default"** → If it reaches production code, it's a finding
+- **"The production config overrides it"** → Verify prod config exists; code-level vulnerability remains if not
+- **"This would never run without proper config"** → Prove it with code trace; many apps fail silently
+- **"It's behind authentication"** → Defense in depth; compromised session still exploits weak defaults
+- **"We'll fix it before release"** → Document now; "later" rarely comes
+
+## Workflow
+
+Follow this workflow for every potential finding:
+
+### 1. SEARCH: Perform Project Discovery and Find Insecure Defaults
+
+Determine language, framework, and project conventions. Use this information to further discover things like secret storage locations, secret usage patterns, credentialed third-party integrations, cryptography, and any other relevant configuration. Further use information to analyze insecure default configurations.
+
+**Example**
+Search for patterns in `**/config/`, `**/auth/`, `**/database/`, and env files:
+- **Fallback secrets:** `getenv.*\) or ['"]`, `process\.env\.[A-Z_]+ \|\| ['"]`, `ENV\.fetch.*default:`
+- **Hardcoded credentials:** `password.*=.*['"][^'"]{8,}['"]`, `api[_-]?key.*=.*['"][^'"]+['"]`
+- **Weak defaults:** `DEBUG.*=.*true`, `AUTH.*=.*false`, `CORS.*=.*\*`
+- **Crypto algorithms:** `MD5|SHA1|DES|RC4|ECB` in security contexts
+
+Tailor search approach based on discovery results.
+
+Focus on production-reachable code, not test fixtures or example files.
+
+### 2. VERIFY: Actual Behavior
+For each match, trace the code path to understand runtime behavior.
+
+**Questions to answer:**
+- When is this code executed? (Startup vs. runtime)
+- What happens if a configuration variable is missing?
+- Is there validation that enforces secure configuration?
+
+### 3. CONFIRM: Production Impact
+Determine if this issue reaches production:
+
+If production config provides the variable → Lower severity (but still a code-level vulnerability)
+If production config missing or uses default → CRITICAL
+
+### 4. REPORT: with Evidence
+
+**Example report:**
+```
+Finding: Hardcoded JWT Secret Fallback
+Location: src/auth/jwt.ts:15
+Pattern: const secret = process.env.JWT_SECRET || 'default';
+
+Verification: App starts without JWT_SECRET; secret used in jwt.sign() at line 42
+Production Impact: Dockerfile missing JWT_SECRET
+Exploitation: Attacker forges JWTs using 'default', gains unauthorized access
+```
+
+## Quick Verification Checklist
+
+**Fallback Secrets:** `SECRET = env.get(X) or Y`
+→ Verify: App starts without env var? Secret used in crypto/auth?
+→ Skip: Test fixtures, example files
+
+**Default Credentials:** Hardcoded `username`/`password` pairs
+→ Verify: Active in deployed config? No runtime override?
+→ Skip: Disabled accounts, documentation examples
+
+**Fail-Open Security:** `AUTH_REQUIRED = env.get(X, 'false')`
+→ Verify: Default is insecure (false/disabled/permissive)?
+→ Safe: App crashes or default is secure (true/enabled/restricted)
+
+**Weak Crypto:** MD5/SHA1/DES/RC4/ECB in security contexts
+→ Verify: Used for passwords, encryption, or tokens?
+→ Skip: Checksums, non-security hashing
+
+**Permissive Access:** CORS `*`, permissions `0777`, public-by-default
+→ Verify: Default allows unauthorized access?
+→ Skip: Explicitly configured permissiveness with justification
+
+**Debug Features:** Stack traces, introspection, verbose errors
+→ Verify: Enabled by default? Exposed in responses?
+→ Skip: Logging-only, not user-facing
+
+For detailed examples and counter-examples, see [examples.md](references/examples.md).

--- a/.agents/skills/insecure-defaults/references/examples.md
+++ b/.agents/skills/insecure-defaults/references/examples.md
@@ -1,0 +1,409 @@
+# Insecure Defaults: Examples and Counter-Examples
+
+This document provides detailed examples for each category in the Quick Verification Checklist, showing both vulnerable patterns (report these) and secure patterns (skip these).
+
+## Fallback Secrets
+
+### ❌ VULNERABLE - Report These
+
+**Python: Environment variable with fallback**
+```python
+# File: src/auth/jwt.py
+SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key-123')
+
+# Used in security context
+def create_token(user_id):
+    return jwt.encode({'user_id': user_id}, SECRET_KEY, algorithm='HS256')
+```
+**Why vulnerable:** App runs with known secret if `SECRET_KEY` is missing. Attacker can forge tokens.
+
+**JavaScript: Logical OR fallback**
+```javascript
+// File: config/database.js
+const DB_PASSWORD = process.env.DB_PASSWORD || 'admin123';
+
+const pool = new Pool({
+  user: 'admin',
+  password: DB_PASSWORD,
+  database: 'production'
+});
+```
+**Why vulnerable:** Database accepts hardcoded password in production if env var missing.
+
+**Ruby: fetch with default**
+```ruby
+# File: config/secrets.rb
+Rails.application.credentials.secret_key_base =
+  ENV.fetch('SECRET_KEY_BASE', 'fallback-secret-base')
+```
+**Why vulnerable:** Rails session encryption uses weak known key as fallback.
+
+### ✅ SECURE - Skip These
+
+**Fail-secure: Crashes without config**
+```python
+# File: src/auth/jwt.py
+SECRET_KEY = os.environ['SECRET_KEY']  # Raises KeyError if missing
+
+# App won't start without SECRET_KEY - fail-secure
+```
+
+**Explicit validation**
+```javascript
+// File: config/database.js
+if (!process.env.DB_PASSWORD) {
+  throw new Error('DB_PASSWORD environment variable required');
+}
+const DB_PASSWORD = process.env.DB_PASSWORD;
+```
+
+**Test fixtures (clearly scoped)**
+```python
+# File: tests/fixtures/auth.py
+TEST_SECRET = 'test-secret-key-123'  # OK - test-only
+
+# Usage in test
+def test_token_creation():
+    token = create_token('user1', secret=TEST_SECRET)
+```
+
+---
+
+## Default Credentials
+
+### ❌ VULNERABLE - Report These
+
+**Hardcoded admin account**
+```python
+# File: src/models/user.py
+def bootstrap_admin():
+    """Create default admin account if none exists"""
+    if not User.query.filter_by(role='admin').first():
+        admin = User(
+            username='admin',
+            password=hash_password('admin123'),
+            role='admin'
+        )
+        db.session.add(admin)
+        db.session.commit()
+```
+**Why vulnerable:** Default admin account created on first run with known credentials.
+
+**API key in code**
+```javascript
+// File: src/integrations/payment.js
+const STRIPE_API_KEY = process.env.STRIPE_KEY || 'sk_tes...';
+
+const stripe = require('stripe')(STRIPE_API_KEY);
+```
+**Why vulnerable:** Uses test API key if env var missing. Might reach production.
+
+**Database connection string**
+```java
+// File: DatabaseConfig.java
+private static final String DB_URL = System.getenv().getOrDefault(
+    "DATABASE_URL",
+    "postgresql://admin:password@localhost:5432/prod"
+);
+```
+**Why vulnerable:** Hardcoded database credentials as fallback.
+
+### ✅ SECURE - Skip These
+
+**Disabled default account**
+```python
+# File: src/models/user.py
+def bootstrap_admin():
+    """Admin account MUST be configured via environment"""
+    username = os.environ['ADMIN_USERNAME']
+    password = os.environ['ADMIN_PASSWORD']
+
+    if not User.query.filter_by(username=username).first():
+        admin = User(username=username, password=hash_password(password), role='admin')
+        db.session.add(admin)
+```
+
+**Example/documentation credentials**
+```bash
+# File: README.md
+## Setup
+
+Configure your API key:
+```bash
+export STRIPE_KEY='sk_tes...'  # Example only
+```
+```
+
+**Test fixture credentials**
+```python
+# File: tests/conftest.py
+@pytest.fixture
+def test_user():
+    return User(username='test_user', password='test_pass')  # OK - test scope
+```
+
+---
+
+## Fail-Open Security
+
+### ❌ VULNERABLE - Report These
+
+**Authentication disabled by default**
+```python
+# File: config/security.py
+REQUIRE_AUTH = os.getenv('REQUIRE_AUTH', 'false').lower() == 'true'
+
+@app.before_request
+def check_auth():
+    if not REQUIRE_AUTH:
+        return  # Skip auth check
+    # ... auth logic
+```
+**Why vulnerable:** Default is no authentication. App runs insecurely if env var missing.
+
+**CORS allows all origins**
+```javascript
+// File: server.js
+const allowedOrigins = process.env.ALLOWED_ORIGINS || '*';
+
+app.use(cors({ origin: allowedOrigins }));
+```
+**Why vulnerable:** Default allows requests from any origin. XSS/CSRF risk.
+
+**Debug mode enabled by default**
+```python
+# File: config.py
+DEBUG = os.getenv('DEBUG', 'true').lower() != 'false'  # Default: true
+
+if DEBUG:
+    app.config['DEBUG'] = True
+    app.config['PROPAGATE_EXCEPTIONS'] = True
+```
+**Why vulnerable:** Debug mode default. Stack traces leak sensitive info in production.
+
+### ✅ SECURE - Skip These
+
+**Authentication required by default**
+```python
+# File: config/security.py
+REQUIRE_AUTH = os.getenv('REQUIRE_AUTH', 'true').lower() == 'true'  # Default: true
+
+# Or better - crash if not explicitly configured
+REQUIRE_AUTH = os.environ['REQUIRE_AUTH'].lower() == 'true'
+```
+
+**CORS requires explicit configuration**
+```javascript
+// File: server.js
+if (!process.env.ALLOWED_ORIGINS) {
+  throw new Error('ALLOWED_ORIGINS must be configured');
+}
+const allowedOrigins = process.env.ALLOWED_ORIGINS.split(',');
+
+app.use(cors({ origin: allowedOrigins }));
+```
+
+**Debug mode disabled by default**
+```python
+# File: config.py
+DEBUG = os.getenv('DEBUG', 'false').lower() == 'true'  # Default: false
+```
+
+---
+
+## Weak Crypto
+
+### ❌ VULNERABLE - Report These
+
+**MD5 for password hashing**
+```python
+# File: src/auth/passwords.py
+import hashlib
+
+def hash_password(password):
+    """Hash user password"""
+    return hashlib.md5(password.encode()).hexdigest()
+```
+**Why vulnerable:** MD5 is cryptographically broken. Rainbow tables exist. Use bcrypt/Argon2.
+
+**DES encryption for sensitive data**
+```java
+// File: Encryption.java
+public static byte[] encrypt(String data, byte[] key) {
+    Cipher cipher = Cipher.getInstance("DES/ECB/PKCS5Padding");
+    SecretKeySpec secretKey = new SecretKeySpec(key, "DES");
+    cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+    return cipher.doFinal(data.getBytes());
+}
+```
+**Why vulnerable:** DES has 56-bit keys (brute-forceable). ECB mode leaks patterns.
+
+**SHA1 for signature verification**
+```javascript
+// File: webhooks.js
+function verifySignature(payload, signature) {
+  const hmac = crypto.createHmac('sha1', WEBHOOK_SECRET);
+  const computed = hmac.update(payload).digest('hex');
+  return computed === signature;
+}
+```
+**Why vulnerable:** SHA1 collisions exist. Use SHA256 or better.
+
+### ✅ SECURE - Skip These
+
+**Weak crypto for non-security checksums**
+```python
+# File: src/utils/cache.py
+import hashlib
+
+def cache_key(data):
+    """Generate cache key - not security-sensitive"""
+    return hashlib.md5(data.encode()).hexdigest()  # OK - just for cache lookup
+```
+
+**Modern crypto for passwords**
+```python
+# File: src/auth/passwords.py
+import bcrypt
+
+def hash_password(password):
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt())
+```
+
+**Strong encryption**
+```java
+// File: Encryption.java
+Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+// 256-bit key, authenticated encryption
+```
+
+---
+
+## Permissive Access
+
+### ❌ VULNERABLE - Report These
+
+**File permissions world-writable**
+```python
+# File: src/storage/files.py
+def create_secure_file(path):
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY, 0o666)  # rw-rw-rw-
+    return fd
+```
+**Why vulnerable:** Any user can write to file. Should be 0o600 or 0o644.
+
+**S3 bucket public by default**
+```python
+# File: infrastructure/storage.py
+def create_storage_bucket(name):
+    bucket = s3.create_bucket(
+        Bucket=name,
+        ACL='public-read'  # Publicly readable by default
+    )
+```
+**Why vulnerable:** Sensitive data exposed publicly. Should require explicit configuration.
+
+**API allows any origin**
+```python
+# File: app.py
+@app.after_request
+def after_request(response):
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers['Access-Control-Allow-Credentials'] = 'true'
+    return response
+```
+**Why vulnerable:** CORS misconfiguration. Allows credential theft from any site.
+
+### ✅ SECURE - Skip These
+
+**Explicitly configured permissiveness with justification**
+```python
+# File: src/storage/public_assets.py
+def create_public_asset(path):
+    """Create world-readable asset for CDN distribution"""
+    # Intentionally public - static assets only
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY, 0o644)
+    return fd
+```
+
+**Restrictive by default**
+```python
+# File: infrastructure/storage.py
+def create_storage_bucket(name, public=False):
+    acl = 'public-read' if public else 'private'
+    if public:
+        logger.warning(f'Creating PUBLIC bucket: {name}')
+    bucket = s3.create_bucket(Bucket=name, ACL=acl)
+```
+
+---
+
+## Debug Features
+
+### ❌ VULNERABLE - Report These
+
+**Stack traces in API responses**
+```python
+# File: app.py
+@app.errorhandler(Exception)
+def handle_error(error):
+    return jsonify({
+        'error': str(error),
+        'traceback': traceback.format_exc()  # Leaks internal paths, library versions
+    }), 500
+```
+**Why vulnerable:** Exposes internal implementation details to attackers.
+
+**GraphQL introspection enabled**
+```javascript
+// File: server.js
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  introspection: true,  // Enabled in production
+  playground: true
+});
+```
+**Why vulnerable:** Attackers can discover entire API schema, including admin-only fields.
+
+**Verbose error messages**
+```java
+// File: UserController.java
+catch (SQLException e) {
+    return ResponseEntity.status(500).body(
+        "Database error: " + e.getMessage()  // Leaks table names, constraints
+    );
+}
+```
+**Why vulnerable:** SQL error messages reveal database structure.
+
+### ✅ SECURE - Skip These
+
+**Debug features in logging only**
+```python
+# File: app.py
+@app.errorhandler(Exception)
+def handle_error(error):
+    logger.exception('Request failed', exc_info=error)  # Logs full trace
+    return jsonify({'error': 'Internal server error'}), 500  # Generic to user
+```
+
+**Environment-aware debug settings**
+```javascript
+// File: server.js
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  introspection: process.env.NODE_ENV !== 'production',
+  playground: process.env.NODE_ENV !== 'production'
+});
+```
+
+**Generic user-facing errors**
+```java
+// File: UserController.java
+catch (SQLException e) {
+    logger.error("Database error", e);  // Full details to logs
+    return ResponseEntity.status(500).body("Unable to process request");  // Generic
+}
+```

--- a/.agents/skills/property-based-testing/README.md
+++ b/.agents/skills/property-based-testing/README.md
@@ -1,0 +1,88 @@
+# Property-Based Testing Skill
+
+A Claude Code skill that provides guidance for property-based testing (PBT) across multiple programming languages and smart contract development.
+
+## What This Skill Does
+
+When activated, this skill helps Claude:
+
+- **Detect PBT opportunities** - Recognizes patterns like encode/decode pairs, validators, normalizers, pure functions, and smart contract invariants
+- **Generate property-based tests** - Creates tests with appropriate strategies, properties, and edge cases
+- **Review existing PBT tests** - Identifies issues like tautological properties, vacuous tests, and weak assertions
+- **Design with properties** - Uses Property-Driven Development to define specifications before implementation
+- **Refactor for testability** - Suggests code changes that enable stronger property testing
+
+## Supported Languages
+
+| Language | Library | Notes |
+|----------|---------|-------|
+| Python | Hypothesis | |
+| JavaScript/TypeScript | fast-check | |
+| Rust | proptest | Also: quickcheck |
+| Go | rapid | Also: gopter |
+| Java | jqwik | |
+| Scala | ScalaCheck | |
+| C# | FsCheck | |
+| Elixir | StreamData | |
+| Haskell | QuickCheck | Also: Hedgehog |
+| Clojure | test.check | |
+| Ruby | PropCheck | |
+| Kotlin | Kotest | |
+| Swift | SwiftCheck | Unmaintained |
+| C++ | RapidCheck | |
+
+### Smart Contract Testing
+
+| Tool | Platform | Description |
+|------|----------|-------------|
+| Echidna | EVM/Solidity | Property-based fuzzer |
+| Medusa | EVM/Solidity | Next-gen parallel fuzzer |
+
+See [secure-contracts.com](https://secure-contracts.com) for tutorials.
+
+## File Structure
+
+```
+property-based-testing/
+├── SKILL.md           # Entry point - detection patterns and routing
+├── README.md          # This file
+└── references/
+    ├── generating.md  # How to write property-based tests
+    ├── reviewing.md   # How to evaluate test quality
+    ├── strategies.md  # Input generation reference
+    ├── design.md      # Property-Driven Development workflow
+    ├── refactoring.md # Making code more testable
+    └── libraries.md   # PBT library reference by language
+```
+
+## Usage
+
+The skill activates automatically when Claude detects relevant patterns:
+
+- Serialization pairs (`encode`/`decode`, `serialize`/`deserialize`)
+- Validators and normalizers
+- Pure functions with clear input/output types
+- Data structure operations
+- Smart contracts (Solidity/Vyper)
+
+You can also invoke it explicitly by asking Claude to use property-based testing.
+
+### Example Prompts
+
+```
+"Write property-based tests for this JSON serializer"
+"Review this Hypothesis test for quality issues"
+"Help me design this feature using properties first"
+"This function is hard to test - how can I refactor it?"
+"Write Echidna invariants for this token contract"
+```
+
+## Property Quick Reference
+
+| Property | Pattern | Use Case |
+|----------|---------|----------|
+| Roundtrip | `decode(encode(x)) == x` | Serialization |
+| Idempotence | `f(f(x)) == f(x)` | Normalization |
+| Invariant | `property(f(x))` holds | Any transformation, smart contracts |
+| Commutativity | `f(a,b) == f(b,a)` | Binary operations |
+| Oracle | `new(x) == reference(x)` | Refactoring |

--- a/.agents/skills/property-based-testing/SKILL.md
+++ b/.agents/skills/property-based-testing/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: property-based-testing
+description: Provides guidance for property-based testing across multiple languages and smart contracts. Use when writing tests, reviewing code with serialization/validation/parsing patterns, designing features, or when property-based testing would provide stronger coverage than example-based tests.
+---
+
+# Property-Based Testing Guide
+
+Use this skill proactively during development when you encounter patterns where PBT provides stronger coverage than example-based tests.
+
+## When to Invoke (Automatic Detection)
+
+**Invoke this skill when you detect:**
+
+- **Serialization pairs**: `encode`/`decode`, `serialize`/`deserialize`, `toJSON`/`fromJSON`, `pack`/`unpack`
+- **Parsers**: URL parsing, config parsing, protocol parsing, string-to-structured-data
+- **Normalization**: `normalize`, `sanitize`, `clean`, `canonicalize`, `format`
+- **Validators**: `is_valid`, `validate`, `check_*` (especially with normalizers)
+- **Data structures**: Custom collections with `add`/`remove`/`get` operations
+- **Mathematical/algorithmic**: Pure functions, sorting, ordering, comparators
+- **Smart contracts**: Solidity/Vyper contracts, token operations, state invariants, access control
+
+**Priority by pattern:**
+
+| Pattern | Property | Priority |
+|---------|----------|----------|
+| encode/decode pair | Roundtrip | HIGH |
+| Pure function | Multiple | HIGH |
+| Validator | Valid after normalize | MEDIUM |
+| Sorting/ordering | Idempotence + ordering | MEDIUM |
+| Normalization | Idempotence | MEDIUM |
+| Builder/factory | Output invariants | LOW |
+| Smart contract | State invariants | HIGH |
+
+## When NOT to Use
+
+Do NOT use this skill for:
+- Simple CRUD operations without transformation logic
+- One-off scripts or throwaway code
+- Code with side effects that cannot be isolated (network calls, database writes)
+- Tests where specific example cases are sufficient and edge cases are well-understood
+- Integration or end-to-end testing (PBT is best for unit/component testing)
+
+## Property Catalog (Quick Reference)
+
+| Property | Formula | When to Use |
+|----------|---------|-------------|
+| **Roundtrip** | `decode(encode(x)) == x` | Serialization, conversion pairs |
+| **Idempotence** | `f(f(x)) == f(x)` | Normalization, formatting, sorting |
+| **Invariant** | Property holds before/after | Any transformation |
+| **Commutativity** | `f(a, b) == f(b, a)` | Binary/set operations |
+| **Associativity** | `f(f(a,b), c) == f(a, f(b,c))` | Combining operations |
+| **Identity** | `f(x, identity) == x` | Operations with neutral element |
+| **Inverse** | `f(g(x)) == x` | encrypt/decrypt, compress/decompress |
+| **Oracle** | `new_impl(x) == reference(x)` | Optimization, refactoring |
+| **Easy to Verify** | `is_sorted(sort(x))` | Complex algorithms |
+| **No Exception** | No crash on valid input | Baseline property |
+
+**Strength hierarchy** (weakest to strongest):
+No Exception → Type Preservation → Invariant → Idempotence → Roundtrip
+
+## Decision Tree
+
+Based on the current task, read the appropriate section:
+
+```
+TASK: Writing new tests
+  → Read [{baseDir}/references/generating.md]({baseDir}/references/generating.md) (test generation patterns and examples)
+  → Then [{baseDir}/references/strategies.md]({baseDir}/references/strategies.md) if input generation is complex
+
+TASK: Designing a new feature
+  → Read [{baseDir}/references/design.md]({baseDir}/references/design.md) (Property-Driven Development approach)
+
+TASK: Code is difficult to test (mixed I/O, missing inverses)
+  → Read [{baseDir}/references/refactoring.md]({baseDir}/references/refactoring.md) (refactoring patterns for testability)
+
+TASK: Reviewing existing PBT tests
+  → Read [{baseDir}/references/reviewing.md]({baseDir}/references/reviewing.md) (quality checklist and anti-patterns)
+
+TASK: Test failed, need to interpret
+  → Read [{baseDir}/references/interpreting-failures.md]({baseDir}/references/interpreting-failures.md) (failure analysis and bug classification)
+
+TASK: Need library reference
+  → Read [{baseDir}/references/libraries.md]({baseDir}/references/libraries.md) (PBT libraries by language, includes smart contract tools)
+```
+
+## How to Suggest PBT
+
+When you detect a high-value pattern while writing tests, **offer PBT as an option**:
+
+> "I notice `encode_message`/`decode_message` is a serialization pair. Property-based testing with a roundtrip property would provide stronger coverage than example tests. Want me to use that approach?"
+
+**If codebase already uses a PBT library** (Hypothesis, fast-check, proptest, Echidna), be more direct:
+
+> "This codebase uses Hypothesis. I'll write property-based tests for this serialization pair using a roundtrip property."
+
+**If user declines**, write good example-based tests without further prompting.
+
+## When NOT to Use PBT
+
+- Simple CRUD without complex validation
+- UI/presentation logic
+- Integration tests requiring complex external setup
+- Prototyping where requirements are fluid
+- User explicitly requests example-based tests only
+
+## Red Flags
+
+- Recommending trivial getters/setters
+- Missing paired operations (encode without decode)
+- Ignoring type hints (well-typed = easier to test)
+- Overwhelming user with candidates (limit to top 5-10)
+- Being pushy after user declines
+
+## Rationalizations to Reject
+
+Do not accept these shortcuts:
+
+- **"Example tests are good enough"** - If serialization/parsing/normalization is involved, PBT finds edge cases examples miss
+- **"The function is simple"** - Simple functions with complex input domains (strings, floats, nested structures) benefit most from PBT
+- **"We don't have time"** - PBT tests are often shorter than comprehensive example suites
+- **"It's too hard to write generators"** - Most PBT libraries have excellent built-in strategies; custom generators are rarely needed
+- **"The test failed, so it's a bug"** - Failures require validation; see [interpreting-failures.md]({baseDir}/references/interpreting-failures.md)
+- **"No crash means it works"** - "No exception" is the weakest property; always push for stronger guarantees

--- a/.agents/skills/property-based-testing/references/design.md
+++ b/.agents/skills/property-based-testing/references/design.md
@@ -1,0 +1,191 @@
+# Property-Driven Development
+
+Design features by defining properties upfront as executable specifications, before implementation.
+
+## When to Use
+
+- Designing a new feature from scratch
+- Building something with clear algebraic properties (serialization, validation, transformations)
+- Complex domain where edge cases are likely
+- User wants to think through requirements rigorously before coding
+
+## Process
+
+### Phase 1: Understand the Feature
+
+Gather information:
+- **Purpose**: What problem does this solve?
+- **Inputs**: What data does it accept? What makes inputs valid?
+- **Outputs**: What does it produce? What guarantees?
+- **Constraints**: What must always be true?
+- **Edge cases**: Boundary conditions?
+- **Relationships**: Inverse operations? Compositions?
+
+### Phase 2: Identify Candidate Properties
+
+Work through these discovery questions:
+
+| Question | Property Type | Example |
+|----------|---------------|---------|
+| Does it have an inverse operation? | Roundtrip | `decode(encode(x)) == x` |
+| Is applying it twice the same as once? | Idempotence | `f(f(x)) == f(x)` |
+| What quantities are preserved? | Invariants | Length, sum, count |
+| Is order of arguments irrelevant? | Commutativity | `f(a, b) == f(b, a)` |
+| Can operations be regrouped? | Associativity | `f(f(a,b), c) == f(a, f(b,c))` |
+| Is there a neutral element? | Identity | `f(x, 0) == x` |
+| Is there an oracle/reference impl? | Oracle | `new(x) == old(x)` |
+| Can output be easily verified? | Hard/Easy | `is_sorted(sort(x))` |
+
+### Phase 3: Define Input Domain
+
+Specify valid inputs as strategies. The strategy IS the specification.
+
+**Key principle**: Build constraints INTO the strategy, not via `assume()`.
+
+```python
+@st.composite
+def valid_registration_requests(draw):
+    """Generate valid registration requests - this documents the domain."""
+    username = draw(st.text(
+        min_size=3,
+        max_size=20,
+        alphabet=st.characters(whitelist_categories=('L', 'N'))
+    ))
+    email = draw(st.emails())
+    password = draw(st.text(min_size=8, max_size=100))
+    age = draw(st.integers(min_value=13, max_value=150))
+
+    return RegistrationRequest(
+        username=username,
+        email=email,
+        password=password,
+        age=age
+    )
+```
+
+### Phase 4: Write Property Tests (Before Implementation)
+
+Create tests that will fail initially:
+
+```python
+class TestFeatureSpec:
+    """Property-based specification - should FAIL until implemented."""
+
+    @given(valid_inputs())
+    def test_core_property(self, x):
+        """[What this guarantees]."""
+        result = feature(x)
+        assert property_holds(result)
+```
+
+### Phase 5: Iterate on Design
+
+Properties reveal design questions:
+- "What about deleted users?"
+- "Case-sensitive?"
+- "Which algorithm?"
+- "Stable sort or not?"
+
+Surface these questions early, before implementation.
+
+## Property Strength Hierarchy
+
+Build properties incrementally from weak to strong:
+
+### Level 1: Basic (Weak)
+```python
+@given(valid_inputs())
+def test_no_crash(x):
+    process(x)  # Just don't crash
+```
+
+### Level 2: Type Preservation
+```python
+@given(valid_inputs())
+def test_returns_type(x):
+    assert isinstance(process(x), ExpectedType)
+```
+
+### Level 3: Invariants
+```python
+@given(valid_inputs())
+def test_invariant(x):
+    result = process(x)
+    assert invariant_holds(result)
+```
+
+### Level 4: Full Specification (Strong)
+```python
+@given(valid_inputs())
+def test_complete(x):
+    result = process(x)
+    assert satisfies_all_requirements(result)
+```
+
+## Strategy Design Principles
+
+### 1. Build Constraints Into Strategy
+```python
+# GOOD - constraints in strategy
+@given(st.integers(min_value=1, max_value=100))
+def test_with_valid_range(x): ...
+
+# BAD - constraints via assume
+@given(st.integers())
+def test_with_assume(x):
+    assume(1 <= x <= 100)  # High rejection rate
+```
+
+### 2. Match Real-World Constraints
+```python
+valid_users = st.builds(
+    User,
+    name=st.text(min_size=1, max_size=100),
+    age=st.integers(min_value=0, max_value=150),
+    email=st.emails(),
+)
+```
+
+### 3. Include Edge Cases Explicitly
+```python
+@given(valid_lists())
+@example([])           # Empty
+@example([1])          # Single element
+@example([1, 1, 1])    # Duplicates
+def test_with_edges(xs): ...
+```
+
+## Common Design Questions Raised
+
+Properties often reveal design gaps:
+
+| Property Attempt | Question Raised |
+|------------------|-----------------|
+| Roundtrip for users | What about deleted/deactivated users? |
+| Duplicate rejection | Case-sensitive? Unicode normalization? |
+| Password storage | Which algorithm? Salted? Configurable? |
+| Ordering guarantee | Stable sort? Tie-breaking rules? |
+
+## Red Flags
+
+- **Writing tautological properties**: Don't reimplement the function logic in the test
+  ```python
+  # BAD - tests nothing
+  assert add(a, b) == a + b
+
+  # GOOD - tests algebraic properties
+  assert add(a, 0) == a  # identity
+  assert add(a, b) == add(b, a)  # commutativity
+  ```
+- **Starting too strong**: Build from weak to strong properties
+- **Ignoring design questions**: Properties that feel awkward often reveal design gaps
+- **Overly complex strategies**: If your input strategy is 50 lines, the domain model might need simplification
+- **Not involving the user**: Design questions should be discussed, not assumed
+
+## Checklist
+
+- [ ] Properties are not tautological
+- [ ] At least one strong property defined
+- [ ] Input strategy documents valid inputs
+- [ ] Design questions have been surfaced
+- [ ] Tests will actually FAIL without implementation

--- a/.agents/skills/property-based-testing/references/generating.md
+++ b/.agents/skills/property-based-testing/references/generating.md
@@ -1,0 +1,204 @@
+# Generating Property-Based Tests
+
+How to create complete, runnable property-based tests.
+
+## Process
+
+### 1. Analyze Target Function
+
+- Read function signature, types, and docstrings
+- Understand input types and constraints
+- Identify output type and expected behavior
+- Note preconditions or invariants
+- Check existing example-based tests as hints
+
+### 2. Design Input Strategies
+
+Create appropriate generator strategies for each input parameter.
+
+**Principles**:
+- Build constraints INTO the strategy, not via `assume()`
+- Use realistic size limits to prevent slow tests
+- Match real-world constraints
+
+### 3. Identify Applicable Properties
+
+| Property | When to Use | Test Pattern |
+|----------|-------------|--------------|
+| Roundtrip | encode/decode pairs | `assert decode(encode(x)) == x` |
+| Idempotence | normalization, sorting | `assert f(f(x)) == f(x)` |
+| Invariant | any transformation | `assert invariant(f(x))` |
+| No exception | all functions (weak) | Function completes without raising |
+| Type preservation | typed functions | `assert isinstance(f(x), ExpectedType)` |
+| Length preservation | collections | `assert len(f(xs)) == len(xs)` |
+| Element preservation | sorting, shuffling | `assert set(f(xs)) == set(xs)` |
+| Ordering | sorting | `assert all(f(xs)[i] <= f(xs)[i+1] ...)` |
+| Oracle | when reference exists | `assert f(x) == reference_impl(x)` |
+| Commutativity | binary ops | `assert f(a, b) == f(b, a)` |
+
+### 4. Generate Test Code
+
+Create test functions with:
+- Clear docstrings explaining what each property verifies
+- Appropriate `@settings` for the context
+- `@example` decorators for critical edge cases
+
+### 5. Include Edge Cases
+
+Always add explicit examples:
+```python
+@example([])           # Empty
+@example([1])          # Single element
+@example([1, 1, 1])    # Duplicates
+@example("")           # Empty string
+@example(0)            # Zero
+@example(-1)           # Negative
+```
+
+## Settings Recommendations
+
+```python
+# Development (fast feedback)
+@settings(max_examples=10)
+
+# CI (thorough)
+@settings(max_examples=200)
+
+# Nightly/Release (exhaustive)
+@settings(max_examples=1000, deadline=None)
+```
+
+## Example Test Patterns
+
+### Roundtrip (Encode/Decode)
+
+```python
+@given(valid_messages())
+def test_roundtrip(msg):
+    """Encoding then decoding returns original."""
+    assert decode(encode(msg)) == msg
+```
+
+### Idempotence
+
+```python
+@given(st.text())
+def test_normalize_idempotent(s):
+    """Normalizing twice equals normalizing once."""
+    assert normalize(normalize(s)) == normalize(s)
+```
+
+### Sorting Properties
+
+```python
+@given(st.lists(st.integers()))
+@example([])
+@example([1])
+@example([1, 1, 1])
+def test_sort(xs):
+    result = sort(xs)
+    # Length preserved
+    assert len(result) == len(xs)
+    # Elements preserved
+    assert sorted(result) == sorted(xs)
+    # Ordered
+    assert all(result[i] <= result[i+1] for i in range(len(result)-1))
+    # Idempotent
+    assert sort(result) == result
+```
+
+### Validator + Normalizer
+
+```python
+@given(valid_inputs())
+def test_normalized_is_valid(x):
+    """Normalized inputs pass validation."""
+    assert is_valid(normalize(x))
+```
+
+## Complete Example (Python/Hypothesis)
+
+```python
+"""Property-based tests for message_codec module."""
+from hypothesis import given, strategies as st, settings, example
+import pytest
+
+from myapp.codec import encode_message, decode_message, Message, DecodeError
+
+# Custom strategy for Message objects
+messages = st.builds(
+    Message,
+    id=st.uuids(),
+    content=st.text(max_size=1000),
+    priority=st.integers(min_value=1, max_value=10),
+    tags=st.lists(st.text(max_size=50), max_size=20),
+)
+
+
+class TestMessageCodecProperties:
+    """Property-based tests for message encoding/decoding."""
+
+    @given(messages)
+    def test_roundtrip(self, msg: Message):
+        """Encoding then decoding returns the original message."""
+        encoded = encode_message(msg)
+        decoded = decode_message(encoded)
+        assert decoded == msg
+
+    @given(messages)
+    def test_encode_deterministic(self, msg: Message):
+        """Same message always encodes to same bytes."""
+        assert encode_message(msg) == encode_message(msg)
+
+    @given(messages)
+    def test_encoded_is_bytes(self, msg: Message):
+        """Encoding produces bytes."""
+        assert isinstance(encode_message(msg), bytes)
+
+    @given(st.binary())
+    def test_decode_invalid_raises_or_succeeds(self, data: bytes):
+        """Random bytes either decode or raise DecodeError."""
+        try:
+            decode_message(data)
+        except DecodeError:
+            pass  # Expected for invalid input
+```
+
+## Running Tests
+
+```bash
+# Run all property tests
+pytest test_file.py -v
+
+# Run with more examples (CI)
+pytest test_file.py --hypothesis-seed=0 -v
+
+# Run with statistics
+pytest test_file.py --hypothesis-show-statistics
+```
+
+## Checklist Before Finishing
+
+- [ ] Tests are not tautological (don't reimplement the function)
+- [ ] At least one strong property (not just "no crash")
+- [ ] Edge cases covered with `@example` decorators
+- [ ] Strategy constraints are realistic, not over-filtered
+- [ ] Settings appropriate for context (dev vs CI)
+- [ ] Docstrings explain what each property verifies
+- [ ] Tests actually run and pass (or fail for expected reasons)
+
+## Red Flags
+
+- **Reimplementing the function**: If your assertion contains the same logic as the function under test, you've written a tautology
+  ```python
+  # BAD - this tests nothing
+  assert add(a, b) == a + b
+  ```
+- **Only testing "no crash"**: This is the weakest property - always look for stronger ones first
+- **Overly constrained strategies**: If you're using multiple `assume()` calls, redesign the strategy instead
+- **Missing edge cases**: No `@example` decorators for empty, single-element, or boundary values
+- **No settings**: Missing `@settings` for CI - tests may be too slow or not thorough enough
+
+## When Tests Fail
+
+See [{baseDir}/references/interpreting-failures.md]({baseDir}/references/interpreting-failures.md) for how to interpret failures and determine if they represent genuine bugs vs test errors vs ambiguous specifications.

--- a/.agents/skills/property-based-testing/references/interpreting-failures.md
+++ b/.agents/skills/property-based-testing/references/interpreting-failures.md
@@ -1,0 +1,239 @@
+# Interpreting Property-Based Test Failures
+
+How to analyze failures and determine if they represent genuine bugs.
+
+## The Self-Reflection Problem
+
+Property-based testing generates many failing examples. Not all failures are bugs:
+- **Test bugs**: Property is wrong, strategy generates invalid inputs
+- **Ambiguous specs**: Behavior undefined for edge cases
+- **Genuine bugs**: Code violates documented guarantees
+
+Before reporting a bug, **validate the failure** through systematic analysis.
+
+## Failure Analysis Workflow
+
+### 1. Reproduce with Minimal Example
+
+Start with the shrunk failing input from the test output.
+
+```python
+# Hypothesis provides the minimal failing case
+# Falsifying example: test_normalize(s='\x00')
+
+# Create standalone reproducer
+def test_reproduce():
+    s = '\x00'
+    result = normalize(normalize(s))
+    assert result == normalize(s)  # Fails
+```
+
+Verify the failure is consistent, not flaky.
+
+### 2. Ground the Property
+
+Before assuming a bug, verify your property against authoritative sources:
+
+| Source | What It Tells You |
+|--------|-------------------|
+| **Type annotations** | Return type constraints, nullability |
+| **Docstrings** | Explicit guarantees, preconditions |
+| **Function name** | Semantic expectations (e.g., `sort` implies ordering) |
+| **Error handling** | What inputs should raise vs handle |
+| **Existing unit tests** | Implicit contracts maintainers expect |
+| **External docs/specs** | Protocol specs, format definitions |
+
+**Example grounding check:**
+```python
+def normalize(s: str) -> str:
+    """Normalize a string to NFC form.
+
+    Args:
+        s: Input string (any unicode)
+
+    Returns:
+        NFC-normalized string
+    """
+```
+
+The docstring says "any unicode" - so null bytes should be valid input. The property is correctly grounded.
+
+### 3. Check Strategy Realism
+
+Does the strategy generate inputs the function should actually handle?
+
+**Red flags:**
+- Generating inputs outside documented domain
+- Missing constraints that real callers would have
+- Overly aggressive size/complexity
+
+**Questions to ask:**
+- Would real code pass this input?
+- Does the docstring exclude this case?
+- Is this a precondition violation, not a bug?
+
+### 4. Classify the Failure
+
+| Symptom | Likely Cause | Action |
+|---------|--------------|--------|
+| Fails on edge case not mentioned in spec | Ambiguous specification | Clarify with maintainer before reporting |
+| Fails on input that violates documented preconditions | Over-constrained strategy | Fix the strategy |
+| Property contradicts docstring or type hints | Wrong property | Fix the property |
+| Clear violation of documented guarantee | Genuine bug | Report with evidence |
+| Behavior differs from similar functions | Possible inconsistency | Investigate further |
+
+### 5. Decide Action
+
+- **Test bug** → Fix the property or strategy, don't report
+- **Ambiguous spec** → Open discussion issue, not bug report
+- **Genuine bug** → Report with minimal reproducer and evidence
+
+## Property Grounding Checklist
+
+Before reporting a failure as a bug, verify:
+
+- [ ] Property matches documented return type
+- [ ] Property matches docstring guarantees
+- [ ] Input is within documented domain (preconditions met)
+- [ ] No `assume()` filtering out the failing case inappropriately
+- [ ] Checked existing tests don't contradict your property
+- [ ] Behavior contradicts docs, not just expectations
+
+## Bug Report Template
+
+When confident the failure is a genuine bug:
+
+```markdown
+## Summary
+[One-line description of the bug]
+
+## Minimal Reproducing Example
+```python
+# Shrunk by Hypothesis
+from mylib import affected_function
+
+def test_bug():
+    # Minimal failing input
+    result = affected_function('\x00')
+    # Expected vs actual
+    assert result >= 0  # Fails: got -1
+```
+
+## Expected Behavior
+According to [docstring/spec/docs], the function should:
+- [Specific guarantee that was violated]
+
+## Actual Behavior
+- [What actually happened]
+
+## Evidence
+- Docstring states: "[relevant quote]"
+- Type signature promises: `-> PositiveInt`
+
+## Environment
+- Library version: X.Y.Z
+- Python version: 3.X
+- Platform: [OS]
+```
+
+## Real-World Failure Patterns
+
+### Numerical Instability
+
+**Symptom**: Distribution function returns negative probability.
+
+```python
+@given(st.floats(min_value=0, max_value=1e308))
+def test_probability_non_negative(x):
+    prob = compute_probability(x)
+    assert prob >= 0  # Fails for x=1e-320
+```
+
+**Grounding check**: Docstring says "returns probability in [0, 1]".
+
+**Classification**: Genuine bug - documented guarantee violated.
+
+### Iterator Off-by-One
+
+**Symptom**: Iterator skips elements or yields extra.
+
+```python
+@given(st.lists(st.integers()))
+def test_iterator_yields_all(xs):
+    result = list(custom_iterator(xs))
+    assert result == xs  # Fails: missing last element
+```
+
+**Grounding check**: Iterator should yield all elements based on name/docs.
+
+**Classification**: Genuine bug if documented to iterate fully.
+
+### Hash/Equality Inconsistency
+
+**Symptom**: Equal objects have different hashes.
+
+```python
+@given(valid_objects())
+def test_hash_equality(obj):
+    obj2 = create_equal_copy(obj)
+    assert obj == obj2
+    assert hash(obj) == hash(obj2)  # Fails
+```
+
+**Grounding check**: Python requires `a == b` implies `hash(a) == hash(b)`.
+
+**Classification**: Genuine bug - violates language contract.
+
+### Roundtrip Failure on Edge Cases
+
+**Symptom**: Encode/decode doesn't preserve input.
+
+```python
+@given(st.text())
+def test_roundtrip(s):
+    assert decode(encode(s)) == s  # Fails for s='\uD800'
+```
+
+**Grounding check**: Is `'\uD800'` (lone surrogate) valid input?
+
+**Classification**:
+- If docs say "valid UTF-8 only" → Strategy bug, fix filter
+- If docs say "any string" → Genuine bug, report it
+
+### Format String Errors
+
+**Symptom**: String formatting crashes on certain inputs.
+
+```python
+@given(st.text())
+def test_format_safe(template):
+    format_message(template)  # Raises on '{unclosed'
+```
+
+**Grounding check**: Does function claim to handle arbitrary strings?
+
+**Classification**:
+- If user-facing, should handle gracefully → Genuine bug
+- If internal API with preconditions → Check preconditions met
+
+## When NOT to Report
+
+Do not report as bugs:
+
+1. **Precondition violations**: If docs say "positive integers only" and you passed -1
+2. **Undefined behavior**: Spec explicitly says behavior is undefined
+3. **Implementation details**: Relying on undocumented internal behavior
+4. **Platform-specific**: Bug only on unusual platform/version
+5. **Test artifact**: Failure disappears with realistic constraints
+
+## Confidence Threshold
+
+Report only when you can answer YES to all:
+
+1. Did you reproduce with a minimal example?
+2. Did you verify the property against docs/types/docstrings?
+3. Can you point to a specific documented guarantee that's violated?
+4. Is the failing input within the documented domain?
+5. Have you ruled out test bugs and ambiguous specs?
+
+If uncertain on any point, open a discussion first, not a bug report.

--- a/.agents/skills/property-based-testing/references/libraries.md
+++ b/.agents/skills/property-based-testing/references/libraries.md
@@ -1,0 +1,130 @@
+# PBT Libraries by Language
+
+## Quick Reference
+
+| Language | Library | Import/Setup |
+|----------|---------|--------------|
+| Python | Hypothesis | `from hypothesis import given, strategies as st` |
+| JavaScript/TypeScript | fast-check | `import fc from 'fast-check'` |
+| Rust | proptest | `use proptest::prelude::*` |
+| Go | rapid | `import "pgregory.net/rapid"` |
+| Java | jqwik | `@Property` annotations, `import net.jqwik.api.*` |
+| Scala | ScalaCheck | `import org.scalacheck._` |
+| C# | FsCheck | `using FsCheck; using FsCheck.Xunit;` |
+| Elixir | StreamData | `use ExUnitProperties` |
+| Haskell | QuickCheck | `import Test.QuickCheck` |
+| Clojure | test.check | `[clojure.test.check :as tc]` |
+| Ruby | PropCheck | `require 'prop_check'` |
+| Kotlin | Kotest | `io.kotest.property.*` |
+| Swift | SwiftCheck | `import SwiftCheck` ⚠️ unmaintained |
+| C++ | RapidCheck | `#include <rapidcheck.h>` |
+
+### Alternatives
+
+| Language | Alternative | Notes |
+|----------|-------------|-------|
+| Haskell | Hedgehog | Integrated shrinking, no type classes |
+| Rust | quickcheck | Simpler API, per-type shrinking |
+| Go | gopter | ScalaCheck-style, more explicit |
+
+## Smart Contract Testing (EVM/Solidity)
+
+| Tool | Type | Description |
+|------|------|-------------|
+| Echidna | Fuzzer | Property-based fuzzer for EVM contracts |
+| Medusa | Fuzzer | Next-gen fuzzer with parallel execution |
+
+```solidity
+// Echidna property example
+function echidna_balance_invariant() public returns (bool) {
+    return address(this).balance >= 0;
+}
+```
+
+**Installation**:
+```bash
+# Echidna (via crytic toolchain)
+pip install crytic-compile
+# Download binary from https://github.com/crytic/echidna
+
+# Medusa
+go install github.com/crytic/medusa@latest
+```
+
+See [secure-contracts.com](https://secure-contracts.com) for tutorials.
+
+## Installation
+
+**Python**:
+```bash
+pip install hypothesis
+```
+
+**JavaScript/TypeScript**:
+```bash
+npm install fast-check
+```
+
+**Rust** (add to Cargo.toml):
+```toml
+[dev-dependencies]
+proptest = "1.0"
+# or for quickcheck:
+quickcheck = "1.0"
+```
+
+**Go**:
+```bash
+go get pgregory.net/rapid
+# or for gopter:
+go get github.com/leanovate/gopter
+```
+
+**Java** (Maven):
+```xml
+<dependency>
+  <groupId>net.jqwik</groupId>
+  <artifactId>jqwik</artifactId>
+  <version>1.9.3</version>
+  <scope>test</scope>
+</dependency>
+```
+
+**Clojure** (deps.edn):
+```clojure
+{:deps {org.clojure/test.check {:mvn/version "1.1.2"}}}
+```
+
+**Haskell**:
+```bash
+cabal install QuickCheck
+# or for Hedgehog:
+cabal install hedgehog
+```
+
+## Detecting Existing Usage
+
+Search for PBT library imports in the codebase:
+
+```bash
+# Python
+rg "from hypothesis import" --type py
+
+# JavaScript/TypeScript
+rg "from 'fast-check'" --type js --type ts
+
+# Rust
+rg "use proptest" --type rust
+
+# Go
+rg "pgregory.net/rapid" --type go
+
+# Java
+rg "@Property" --type java
+
+# Clojure
+rg "test.check" --type clojure
+
+# Solidity (Echidna)
+rg "echidna_" --glob "*.sol"
+```

--- a/.agents/skills/property-based-testing/references/refactoring.md
+++ b/.agents/skills/property-based-testing/references/refactoring.md
@@ -1,0 +1,181 @@
+# Refactoring for Property-Based Testing
+
+Identify code that could be refactored to enable or improve property-based testing.
+
+## Quick Reference
+
+| Pattern | Problem | Solution | Properties Enabled |
+|---------|---------|----------|-------------------|
+| I/O mixed with logic | Can't test without mocks | Extract pure core | Multiple |
+| Encode without decode | No roundtrip possible | Add inverse operation | Roundtrip |
+| Hardcoded config | Can't test edge cases | Inject dependencies | Full coverage |
+| In-place mutation | Hard to verify before/after | Return new value | Comparison properties |
+| String building | Can't verify structure | Structured + render | Roundtrip |
+| Implicit invariants | Can't test constraints | Make explicit with validation | Invariant |
+
+## Refactoring Patterns
+
+### 1. Extract Pure Core from Impure Functions (High Impact)
+
+**Pattern**: Functions that mix I/O with logic
+
+```python
+# BEFORE - hard to test
+def process_order(order_id: str) -> None:
+    order = db.fetch(order_id)           # I/O
+    discount = calculate_discount(order)  # Pure logic
+    total = apply_discount(order, discount)  # Pure logic
+    db.save(order_id, total)             # I/O
+
+# AFTER - pure core extracted
+def calculate_order_total(order: Order, rules: DiscountRules) -> Decimal:
+    """Pure function - easy to property test."""
+    discount = calculate_discount(order, rules)
+    return apply_discount(order, discount)
+
+def process_order(order_id: str) -> None:
+    """Thin I/O wrapper."""
+    order = db.fetch(order_id)
+    total = calculate_order_total(order, get_discount_rules())
+    db.save(order_id, total)
+```
+
+**Detection**: `rg "def \w+\(" -A 20 | grep -E "(open\(|db\.|requests\.|fetch|save)"`
+
+### 2. Add Missing Inverse Operations (High Impact)
+
+**Pattern**: One-way operations that should have pairs
+
+```python
+# BEFORE - only encode
+def encode_message(msg: dict) -> bytes:
+    return msgpack.packb(msg)
+
+# AFTER - add decode for roundtrip testing
+def encode_message(msg: dict) -> bytes:
+    return msgpack.packb(msg)
+
+def decode_message(data: bytes) -> dict:
+    return msgpack.unpackb(data)
+```
+
+**Detection**: Find encode without decode, serialize without deserialize
+
+### 3. Replace Hardcoded Dependencies (Medium Impact)
+
+**Pattern**: Functions using globals or hardcoded config
+
+```python
+# BEFORE
+def validate_input(data: str) -> bool:
+    return len(data) <= CONFIG.max_length
+
+# AFTER - dependencies injected
+def validate_input(data: str, max_length: int) -> bool:
+    return len(data) <= max_length
+```
+
+**Detection**: `rg "(CONFIG\.|SETTINGS\.|os\.environ)"`
+
+### 4. Return Values Instead of Mutating (Medium Impact)
+
+**Pattern**: Methods that mutate in place
+
+```python
+# BEFORE
+def sort_tasks(tasks: list[Task]) -> None:
+    tasks.sort(key=lambda t: t.priority)
+
+# AFTER - returns new list
+def sorted_tasks(tasks: list[Task]) -> list[Task]:
+    return sorted(tasks, key=lambda t: t.priority)
+```
+
+**Detection**: `rg "-> None:" -A 10 | grep -E "\.(sort|append|extend)"`
+
+### 5. Convert String Building to Structured + Render (Medium Impact)
+
+**Pattern**: Manual string concatenation
+
+```python
+# BEFORE
+def build_query(table: str, filters: dict) -> str:
+    q = f"SELECT * FROM {table}"
+    if filters:
+        q += " WHERE " + " AND ".join(...)
+    return q
+
+# AFTER - structured representation
+@dataclass
+class Query:
+    table: str
+    filters: dict
+
+def render_query(q: Query) -> str: ...
+def parse_query(sql: str) -> Query: ...  # Add inverse!
+```
+
+### 6. Add Validators/Generators for Predicates (Lower Impact)
+
+**Pattern**: `is_valid()` exists but no way to generate valid inputs
+
+```python
+# BEFORE
+def is_valid_email(s: str) -> bool:
+    return EMAIL_REGEX.match(s) is not None
+
+# AFTER - add generator
+@st.composite
+def valid_emails(draw):
+    local = draw(st.from_regex(r'[a-z][a-z0-9]{1,20}'))
+    domain = draw(st.sampled_from(['gmail.com', 'example.com']))
+    return f"{local}@{domain}"
+```
+
+**Detection**: `rg "def is_\w+\(" --type py`
+
+### 7. Make Implicit Invariants Explicit (Lower Impact)
+
+**Pattern**: Constraints in comments but not enforced
+
+```python
+# BEFORE - constraint only in docstring
+def allocate_buffer(size: int) -> bytes:
+    """Size must be positive and <= 1MB."""
+    return bytes(size)
+
+# AFTER - enforced
+MAX_BUFFER_SIZE = 1024 * 1024
+
+def allocate_buffer(size: int) -> bytes:
+    if not (0 < size <= MAX_BUFFER_SIZE):
+        raise ValueError(f"size must be in (0, {MAX_BUFFER_SIZE}]")
+    return bytes(size)
+```
+
+**Detection**: `rg "(must be|should be|always|never)" --type py`
+
+## Evaluation Criteria
+
+For each refactoring opportunity:
+
+| Factor | Questions |
+|--------|-----------|
+| Properties enabled | What tests become possible? Roundtrip > Idempotence > No crash |
+| Effort | Low/Medium/High - how much code change? |
+| Risk | Breaking changes? API impact? |
+| Backwards compatibility | Can old callers still work? |
+
+## Prioritization
+
+1. Strength of properties enabled (roundtrip > idempotence > no crash)
+2. Effort required (prefer low-effort wins)
+3. Risk level (prefer safe changes)
+
+## Red Flags
+
+- **Breaking the API without warning**: Flag breaking changes clearly and offer backwards-compatible alternatives
+- **Over-engineering**: Not every function needs to be perfectly testable - prioritize high-value code
+- **Ignoring existing tests**: Run existing tests after refactoring to verify behavior unchanged
+- **Missing the forest for the trees**: If a module needs wholesale restructuring, say so rather than suggesting 20 small changes
+- **Not considering effort vs value**: A complex refactoring enabling only "no crash" isn't worth it

--- a/.agents/skills/property-based-testing/references/reviewing.md
+++ b/.agents/skills/property-based-testing/references/reviewing.md
@@ -1,0 +1,209 @@
+# Reviewing Property-Based Tests
+
+Evaluate quality of existing property-based tests and suggest improvements.
+
+## Quick Reference
+
+| Issue | Severity | Detection | Fix |
+|-------|----------|-----------|-----|
+| Tautological | CRITICAL | Assertion compares same expression | Rewrite with actual property |
+| Vacuous | CRITICAL | Contradictory `assume()` calls | Remove or fix filters |
+| Weak (no assertion) | HIGH | Test body has no assert | Add meaningful assertion |
+| Reimplementation | HIGH | Assertion mirrors function logic | Use algebraic property instead |
+| Over-filtered | MEDIUM | Many `assume()` calls | Redesign strategy |
+| Missing edge cases | MEDIUM | No `@example` decorators | Add explicit edge cases |
+| Poor settings | LOW | Missing or bad `@settings` | Add appropriate settings |
+
+## Quality Issues
+
+### Issue: Tautological Properties (CRITICAL)
+
+Properties that are always true regardless of implementation.
+
+```python
+# BAD - compares function to itself
+@given(st.lists(st.integers()))
+def test_sort_tautology(xs):
+    assert sorted(xs) == sorted(xs)  # Always true!
+
+# BAD - tests nothing about the function
+@given(st.integers())
+def test_useless(x):
+    result = compute(x)
+    assert result == result  # Always true!
+```
+
+**Detection**: Assertions comparing same expression, or not using function result meaningfully.
+
+### Issue: Vacuous Tests (CRITICAL)
+
+Tests where assumptions filter out most/all inputs.
+
+```python
+# VACUOUS - impossible condition
+@given(st.integers())
+def test_vacuous(x):
+    assume(x > 100)
+    assume(x < 50)  # Impossible!
+    assert compute(x) > 0
+
+# VACUOUS - overly restrictive
+@given(st.integers())
+def test_too_filtered(x):
+    assume(x == 42)  # Only tests one value!
+    assert compute(x) == expected
+```
+
+**Detection**: Multiple `assume()` calls, `assume` with very narrow conditions.
+
+### Issue: Weak Properties (HIGH)
+
+Properties that only test minimal guarantees.
+
+```python
+# WEAK - only tests no crash
+@given(st.text())
+def test_only_no_crash(s):
+    process(s)  # No assertion at all
+
+# WEAK - only tests type
+@given(st.integers())
+def test_only_type(x):
+    assert isinstance(compute(x), int)
+```
+
+**Detection**: Tests without assertions, or only `isinstance`/type checks.
+
+### Issue: Reimplementing the Function (HIGH)
+
+```python
+# BAD - just reimplements the logic
+@given(st.integers(), st.integers())
+def test_reimplements(a, b):
+    assert add(a, b) == a + b  # Tests nothing if add() is just a + b
+```
+
+**Detection**: Test assertion contains same logic as function under test.
+
+### Issue: Poor Input Coverage (MEDIUM)
+
+```python
+# NARROW - misses edge cases
+@given(st.integers(min_value=1, max_value=10))
+def test_narrow_range(x):
+    assert compute(x) >= 0  # What about 0? Negatives? Large values?
+
+# MISSING - no edge case examples
+@given(st.lists(st.integers()))
+def test_no_explicit_edges(xs):
+    # Should include @example([]) @example([1]) etc.
+    assert len(sort(xs)) == len(xs)
+```
+
+### Issue: Missing Stronger Properties (MEDIUM)
+
+```python
+# EXISTS - but could be stronger
+@given(st.lists(st.integers()))
+def test_sort_length(xs):
+    assert len(sort(xs)) == len(xs)
+# MISSING: ordering property, element preservation
+```
+
+### Issue: Poor Settings (LOW)
+
+```python
+# TOO FEW - may miss bugs
+@settings(max_examples=5)
+def test_few_examples(x): ...
+
+# NO DEADLINE - may hang in CI
+@given(expensive_strategy())
+def test_no_deadline(x): ...  # Could timeout
+```
+
+## Review Process
+
+### 1. Locate Property-Based Tests
+
+Search using library-specific patterns:
+
+**Python/Hypothesis:**
+```bash
+rg "@given\(" --type py
+rg "from hypothesis import" --type py
+```
+
+**JavaScript/fast-check:**
+```bash
+rg "fc\.(assert|property)" --type js --type ts
+```
+
+**Rust/proptest:**
+```bash
+rg "proptest!" --type rust
+```
+
+### 2. Analyze Each Test
+
+Check for issues above, starting with critical then high severity.
+
+### 3. Evaluate Shrinking Quality
+
+Will tests shrink to minimal counterexamples? Complex strategies may produce hard-to-debug failures.
+
+### 4. Check for Flakiness Potential
+
+- Non-determinism in code under test
+- Time-dependent assertions
+- Global state dependencies
+- Floating point comparisons without tolerance
+
+### 5. Suggest Stronger Properties
+
+Compare against property catalog - are stronger properties available but not tested?
+
+## Test Health Score
+
+| Category | Score | What to Check |
+|----------|-------|---------------|
+| Property Strength | X/5 | Roundtrip > Idempotence > Type > No crash |
+| Input Coverage | X/5 | Edge cases, strategy breadth |
+| Assertions | X/5 | Meaningful, not tautological |
+| Settings | X/5 | Appropriate for context |
+
+## Mutation Testing Verification
+
+Suggest specific mutations to verify tests catch bugs:
+
+```
+To verify test_sort catches bugs:
+
+1. Return input unchanged: `return xs`
+   - Should fail: test_ordering
+
+2. Drop last element: `return sorted(xs)[:-1]`
+   - Should fail: test_length_preserved
+
+3. Reverse order: `return sorted(xs, reverse=True)`
+   - Should fail: test_ordering
+```
+
+## Quality Checklist
+
+For each test, verify:
+- [ ] Not tautological (assertion doesn't compare same expression)
+- [ ] Strong assertion (not just "no crash")
+- [ ] Not vacuous (inputs not over-filtered)
+- [ ] Good coverage (edge cases via `@example`)
+- [ ] No reimplementation of function logic
+- [ ] Appropriate settings for context
+- [ ] Good shrinking potential
+- [ ] Deterministic (no flakiness risk)
+
+## Red Flags
+
+- **Marking tautologies as "fine"**: `assert x == x` is NEVER a valid test
+- **Accepting "no crash" as sufficient**: Always push for stronger properties
+- **Ignoring vacuous tests**: Tests with contradictory `assume()` provide false confidence
+- **Not checking for reimplementation**: `assert add(a,b) == a + b` tests nothing if that's how `add` is implemented

--- a/.agents/skills/property-based-testing/references/strategies.md
+++ b/.agents/skills/property-based-testing/references/strategies.md
@@ -1,0 +1,124 @@
+# Input Strategy Reference
+
+## Python/Hypothesis
+
+| Type | Strategy |
+|------|----------|
+| `int` | `st.integers()` |
+| `float` | `st.floats(allow_nan=False)` |
+| `str` | `st.text()` |
+| `bytes` | `st.binary()` |
+| `bool` | `st.booleans()` |
+| `list[T]` | `st.lists(strategy_for_T)` |
+| `dict[K, V]` | `st.dictionaries(key_strategy, value_strategy)` |
+| `set[T]` | `st.frozensets(strategy_for_T)` |
+| `tuple[T, ...]` | `st.tuples(strategy_for_T, ...)` |
+| `Optional[T]` | `st.none() \| strategy_for_T` |
+| `Union[A, B]` | `st.one_of(strategy_a, strategy_b)` |
+| Custom class | `st.builds(ClassName, field1=..., field2=...)` |
+| Enum | `st.sampled_from(EnumClass)` |
+| Constrained int | `st.integers(min_value=0, max_value=100)` |
+| Email | `st.emails()` |
+| UUID | `st.uuids()` |
+| DateTime | `st.datetimes()` |
+| Regex match | `st.from_regex(r"pattern")` |
+
+### Composite Strategies
+
+For complex types, use `@st.composite`:
+
+```python
+@st.composite
+def valid_users(draw):
+    name = draw(st.text(min_size=1, max_size=50))
+    age = draw(st.integers(min_value=0, max_value=150))
+    email = draw(st.emails())
+    return User(name=name, age=age, email=email)
+```
+
+## JavaScript/fast-check
+
+| Type | Strategy |
+|------|----------|
+| number | `fc.integer()` or `fc.float()` |
+| string | `fc.string()` |
+| boolean | `fc.boolean()` |
+| array | `fc.array(itemArb)` |
+| object | `fc.record({...})` |
+| optional | `fc.option(arb)` |
+
+### Example
+
+```typescript
+const userArb = fc.record({
+  name: fc.string({ minLength: 1, maxLength: 50 }),
+  age: fc.integer({ min: 0, max: 150 }),
+  email: fc.emailAddress(),
+});
+```
+
+## Rust/proptest
+
+| Type | Strategy |
+|------|----------|
+| i32, u64, etc | `any::<i32>()` |
+| String | `any::<String>()` or `"[a-z]+"` (regex) |
+| Vec<T> | `prop::collection::vec(strategy, size)` |
+| Option<T> | `prop::option::of(strategy)` |
+
+### Example
+
+```rust
+proptest! {
+    #[test]
+    fn test_roundtrip(s in "[a-z]{1,20}") {
+        let encoded = encode(&s);
+        let decoded = decode(&encoded)?;
+        prop_assert_eq!(s, decoded);
+    }
+}
+```
+
+## Go/rapid
+
+```go
+rapid.Check(t, func(t *rapid.T) {
+    s := rapid.String().Draw(t, "s")
+    n := rapid.IntRange(0, 100).Draw(t, "n")
+    // test with s and n
+})
+```
+
+## Best Practices
+
+1. **Constrain early**: Build constraints into strategy, not `assume()`
+   ```python
+   # GOOD
+   st.integers(min_value=1, max_value=100)
+
+   # BAD
+   st.integers().filter(lambda x: 1 <= x <= 100)
+   ```
+
+2. **Size limits**: Use `max_size` to prevent slow tests
+   ```python
+   st.lists(st.integers(), max_size=100)
+   st.text(max_size=1000)
+   ```
+
+3. **Realistic data**: Make strategies match real-world constraints
+   ```python
+   # Real user ages, not arbitrary integers
+   st.integers(min_value=0, max_value=150)
+   ```
+
+4. **Reuse strategies**: Define once, use across tests
+   ```python
+   valid_users = st.builds(User, ...)
+
+   @given(valid_users)
+   def test_one(user): ...
+
+   @given(valid_users)
+   def test_two(user): ...
+   ```

--- a/.agents/skills/semgrep/SKILL.md
+++ b/.agents/skills/semgrep/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: semgrep
+description: >-
+  Run Semgrep static analysis scan on a codebase using parallel subagents.
+  Supports two scan modes — "run all" (full ruleset coverage) and "important
+  only" (high-confidence security vulnerabilities). Automatically detects and
+  uses Semgrep Pro for cross-file taint analysis when available. Use when asked
+  to scan code for vulnerabilities, run a security audit with Semgrep, find
+  bugs, or perform static analysis. Spawns parallel workers for multi-language
+  codebases.
+allowed-tools: Bash Read Glob Task AskUserQuestion TaskCreate TaskList TaskUpdate
+---
+
+# Semgrep Security Scan
+
+Run a Semgrep scan with automatic language detection, parallel execution via Task subagents, and merged SARIF output.
+
+## Essential Principles
+
+1. **Always use `--metrics=off`** — Semgrep sends telemetry by default; `--config auto` also phones home. Every `semgrep` command must include `--metrics=off` to prevent data leakage during security audits.
+2. **User must approve the scan plan (Step 3 is a hard gate)** — The original "scan this codebase" request is NOT approval. Present exact rulesets, target, engine, and mode; wait for explicit "yes"/"proceed" before spawning scanners.
+3. **Third-party rulesets are required, not optional** — Trail of Bits, 0xdea, and Decurity rules catch vulnerabilities absent from the official registry. Include them whenever the detected language matches.
+4. **Spawn all scan Tasks in a single message** — Parallel execution is the core performance advantage. Never spawn Tasks sequentially; always emit all Task tool calls in one response.
+5. **Always check for Semgrep Pro before scanning** — Pro enables cross-file taint tracking and catches ~250% more true positives. Skipping the check means silently missing critical inter-file vulnerabilities.
+
+## When to Use
+
+- Security audit of a codebase
+- Finding vulnerabilities before code review
+- Scanning for known bug patterns
+- First-pass static analysis
+
+## When NOT to Use
+
+- Binary analysis → Use binary analysis tools
+- Already have Semgrep CI configured → Use existing pipeline
+- Need cross-file analysis but no Pro license → Consider CodeQL as alternative
+- Creating custom Semgrep rules → Use `semgrep-rule-creator` skill
+- Porting existing rules to other languages → Use `semgrep-rule-variant-creator` skill
+
+## Output Directory
+
+All scan results, SARIF files, and temporary data are stored in a single output directory.
+
+- **If the user specifies an output directory** in their prompt, use it as `OUTPUT_DIR`.
+- **If not specified**, default to `./static_analysis_semgrep_1`. If that already exists, increment to `_2`, `_3`, etc.
+
+In both cases, **always create the directory** with `mkdir -p` before writing any files.
+
+```bash
+# Resolve output directory
+if [ -n "$USER_SPECIFIED_DIR" ]; then
+  OUTPUT_DIR="$USER_SPECIFIED_DIR"
+else
+  BASE="static_analysis_semgrep"
+  N=1
+  while [ -e "${BASE}_${N}" ]; do
+    N=$((N + 1))
+  done
+  OUTPUT_DIR="${BASE}_${N}"
+fi
+mkdir -p "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results"
+```
+
+The output directory is resolved **once** at the start of Step 1 and used throughout all subsequent steps.
+
+```
+$OUTPUT_DIR/
+├── rulesets.txt                 # Approved rulesets (logged after Step 3)
+├── raw/                         # Per-scan raw output (unfiltered)
+│   ├── python-python.json
+│   ├── python-python.sarif
+│   ├── python-django.json
+│   ├── python-django.sarif
+│   └── ...
+└── results/                     # Final merged output
+    └── results.sarif
+```
+
+## Prerequisites
+
+**Required:** Semgrep CLI (`semgrep --version`). If not installed, see [Semgrep installation docs](https://semgrep.dev/docs/getting-started/).
+
+**Optional:** Semgrep Pro — enables cross-file taint tracking, inter-procedural analysis, and additional languages (Apex, C#, Elixir). Check with:
+
+```bash
+semgrep --pro --validate --config p/default 2>/dev/null && echo "Pro available" || echo "OSS only"
+```
+
+**Limitations:** OSS mode cannot track data flow across files. Pro mode uses `-j 1` for cross-file analysis (slower per ruleset, but parallel rulesets compensate).
+
+## Scan Modes
+
+Select mode in Step 2 of the workflow. Mode affects both scanner flags and post-processing.
+
+| Mode | Coverage | Findings Reported |
+|------|----------|-------------------|
+| **Run all** | All rulesets, all severity levels | Everything |
+| **Important only** | All rulesets, pre- and post-filtered | Security vulns only, medium-high confidence/impact |
+
+**Important only** applies two filter layers:
+1. **Pre-filter**: `--severity MEDIUM --severity HIGH --severity CRITICAL` (CLI flag)
+2. **Post-filter**: JSON metadata — keeps only `category=security`, `confidence∈{MEDIUM,HIGH}`, `impact∈{MEDIUM,HIGH}`
+
+See [scan-modes.md](references/scan-modes.md) for metadata criteria and jq filter commands.
+
+## Orchestration Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ MAIN AGENT (this skill)                                          │
+│ Step 1: Detect languages + check Pro availability                │
+│ Step 2: Select scan mode + rulesets (ref: rulesets.md)           │
+│ Step 3: Present plan + rulesets, get approval [⛔ HARD GATE]     │
+│ Step 4: Spawn parallel scan Tasks (approved rulesets + mode)     │
+│ Step 5: Merge results and report                                 │
+└──────────────────────────────────────────────────────────────────┘
+         │ Step 4
+         ▼
+┌─────────────────┐
+│ Scan Tasks      │
+│ (parallel)      │
+├─────────────────┤
+│ Python scanner  │
+│ JS/TS scanner   │
+│ Go scanner      │
+│ Docker scanner  │
+└─────────────────┘
+```
+
+## Workflow
+
+**Follow the detailed workflow in [scan-workflow.md](workflows/scan-workflow.md).** Summary:
+
+| Step | Action | Gate | Key Reference |
+|------|--------|------|---------------|
+| 1 | Resolve output dir, detect languages + Pro availability | — | Use Glob, not Bash |
+| 2 | Select scan mode + rulesets | — | [rulesets.md](references/rulesets.md) |
+| 3 | Present plan, get explicit approval | ⛔ HARD | AskUserQuestion |
+| 4 | Spawn parallel scan Tasks | — | [scanner-task-prompt.md](references/scanner-task-prompt.md) |
+| 5 | Merge results and report | — | Merge script (below) |
+
+**Task enforcement:** On invocation, create 5 tasks with blockedBy dependencies (each step blocks the previous). Step 3 is a HARD GATE — mark complete ONLY after user explicitly approves.
+
+**Merge command (Step 5):**
+
+```bash
+uv run {baseDir}/scripts/merge_sarif.py $OUTPUT_DIR/raw $OUTPUT_DIR/results/results.sarif
+```
+
+## Agents
+
+| Agent | Tools | Purpose |
+|-------|-------|---------|
+| `static-analysis:semgrep-scanner` | Bash | Executes parallel semgrep scans for a language category |
+
+Use `subagent_type: static-analysis:semgrep-scanner` in Step 4 when spawning Task subagents.
+
+## Rationalizations to Reject
+
+| Shortcut | Why It's Wrong |
+|----------|----------------|
+| "User asked for scan, that's approval" | Original request ≠ plan approval. Present plan, use AskUserQuestion, await explicit "yes" |
+| "Step 3 task is blocking, just mark complete" | Lying about task status defeats enforcement. Only mark complete after real approval |
+| "I already know what they want" | Assumptions cause scanning wrong directories/rulesets. Present plan for verification |
+| "Just use default rulesets" | User must see and approve exact rulesets before scan |
+| "Add extra rulesets without asking" | Modifying approved list without consent breaks trust |
+| "Third-party rulesets are optional" | Trail of Bits, 0xdea, Decurity catch vulnerabilities not in official registry — REQUIRED |
+| "Use --config auto" | Sends metrics; less control over rulesets |
+| "One Task at a time" | Defeats parallelism; spawn all Tasks together |
+| "Pro is too slow, skip --pro" | Cross-file analysis catches 250% more true positives; worth the time |
+| "Semgrep handles GitHub URLs natively" | URL handling fails on repos with non-standard YAML; always clone first |
+| "Cleanup is optional" | Cloned repos pollute the user's workspace and accumulate across runs |
+| "Use `.` or relative path as target" | Subagents need absolute paths to avoid ambiguity |
+| "Let the user pick an output dir later" | Output directory must be resolved at Step 1, before any files are created |
+
+## Reference Index
+
+| File | Content |
+|------|---------|
+| [rulesets.md](references/rulesets.md) | Complete ruleset catalog and selection algorithm |
+| [scan-modes.md](references/scan-modes.md) | Pre/post-filter criteria and jq commands |
+| [scanner-task-prompt.md](references/scanner-task-prompt.md) | Template for spawning scanner subagents |
+
+| Workflow | Purpose |
+|----------|---------|
+| [scan-workflow.md](workflows/scan-workflow.md) | Complete 5-step scan execution process |
+
+## Success Criteria
+
+- [ ] Output directory resolved (user-specified or auto-incremented default)
+- [ ] All generated files stored inside `$OUTPUT_DIR`
+- [ ] Languages detected with file counts; Pro status checked
+- [ ] Scan mode selected by user (run all / important only)
+- [ ] Rulesets include third-party rules for all detected languages
+- [ ] User explicitly approved the scan plan (Step 3 gate passed)
+- [ ] All scan Tasks spawned in a single message and completed
+- [ ] Every `semgrep` command used `--metrics=off`
+- [ ] Approved rulesets logged to `$OUTPUT_DIR/rulesets.txt`
+- [ ] Raw per-scan outputs stored in `$OUTPUT_DIR/raw/`
+- [ ] `results.sarif` exists in `$OUTPUT_DIR/results/` and is valid JSON
+- [ ] Important-only mode: post-filter applied before merge; unfiltered results preserved in `raw/`
+- [ ] Results summary reported with severity and category breakdown
+- [ ] Cloned repos (if any) cleaned up from `$OUTPUT_DIR/repos/`

--- a/.agents/skills/semgrep/references/rulesets.md
+++ b/.agents/skills/semgrep/references/rulesets.md
@@ -1,0 +1,162 @@
+# Semgrep Rulesets Reference
+
+## Complete Ruleset Catalog
+
+### Security-Focused Rulesets
+
+| Ruleset | Description | Use Case |
+|---------|-------------|----------|
+| `p/security-audit` | Comprehensive vulnerability detection, higher false positives | Manual audits, security reviews |
+| `p/secrets` | Hardcoded credentials, API keys, tokens | Always include |
+| `p/owasp-top-ten` | OWASP Top 10 web application vulnerabilities | Web app security |
+| `p/cwe-top-25` | CWE Top 25 most dangerous software weaknesses | General security |
+| `p/sql-injection` | SQL injection patterns and tainted data flows | Database security |
+| `p/insecure-transport` | Ensures code uses encrypted channels | Network security |
+| `p/gitleaks` | Hard-coded credentials detection (gitleaks port) | Secrets scanning |
+| `p/findsecbugs` | FindSecBugs rule pack for Java | Java security |
+| `p/phpcs-security-audit` | PHP security audit rules | PHP security |
+
+### CI/CD Rulesets
+
+| Ruleset | Description | Use Case |
+|---------|-------------|----------|
+| `p/default` | Default ruleset, balanced coverage | First-time users |
+| `p/ci` | High-confidence security + logic bugs, low FP | CI pipelines |
+| `p/r2c-ci` | Low false positives, CI-safe | CI/CD blocking |
+| `p/r2c` | Community favorite, curated by Semgrep (618k+ downloads) | General scanning |
+| `p/auto` | Auto-selects rules based on detected languages/frameworks | Quick scans |
+| `p/comment` | Comment-related rules | Code review |
+
+### Third-Party Rulesets
+
+| Ruleset | Description | Maintainer |
+|---------|-------------|------------|
+| `p/gitlab` | GitLab-maintained security rules | GitLab |
+
+---
+
+## Ruleset Selection Algorithm
+
+Follow this algorithm to select rulesets based on detected languages and frameworks.
+
+### Step 1: Always Include Security Baseline
+
+```json
+{
+  "baseline": ["p/security-audit", "p/secrets"]
+}
+```
+
+- `p/security-audit` - Comprehensive vulnerability detection (always include)
+- `p/secrets` - Hardcoded credentials, API keys, tokens (always include)
+
+### Step 2: Add Language-Specific Rulesets
+
+For each detected language, add the primary ruleset. If a framework is detected, add its ruleset too.
+
+**GA Languages (production-ready):**
+
+| Detection | Primary Ruleset | Framework Rulesets | Pro Rule Count |
+|-----------|-----------------|-------------------|----------------|
+| `.py` | `p/python` | `p/django`, `p/flask`, `p/fastapi` | 710+ |
+| `.js`, `.jsx` | `p/javascript` | `p/react`, `p/nodejs`, `p/express`, `p/nextjs`, `p/angular` | 250+ (JS), 70+ (JSX) |
+| `.ts`, `.tsx` | `p/typescript` | `p/react`, `p/nodejs`, `p/express`, `p/nextjs`, `p/angular` | 230+ |
+| `.go` | `p/golang` | `p/go` (alias) | 80+ |
+| `.java` | `p/java` | `p/spring`, `p/findsecbugs` | 190+ |
+| `.kt` | `p/kotlin` | `p/spring` | 60+ |
+| `.rb` | `p/ruby` | `p/rails` | 40+ |
+| `.php` | `p/php` | `p/symfony`, `p/laravel`, `p/phpcs-security-audit` | 50+ |
+| `.c`, `.cpp`, `.h` | `p/c` | - | 150+ |
+| `.rs` | `p/rust` | - | 40+ |
+| `.cs` | `p/csharp` | - | 170+ |
+| `.scala` | `p/scala` | - | Community |
+| `.swift` | `p/swift` | - | 60+ |
+
+**Beta Languages (Pro recommended):**
+
+| Detection | Primary Ruleset | Notes |
+|-----------|-----------------|-------|
+| `.ex`, `.exs` | `p/elixir` | Requires Pro for best coverage |
+| `.cls`, `.trigger` | `p/apex` | Salesforce; requires Pro |
+
+**Experimental Languages:**
+
+| Detection | Primary Ruleset | Notes |
+|-----------|-----------------|-------|
+| `.sol` | No official ruleset | Use Decurity third-party rules |
+| `Dockerfile` | `p/dockerfile` | Limited rules |
+| `.yaml`, `.yml` | `p/yaml` | K8s, GitHub Actions, docker-compose patterns |
+| `.json` | `r/json.aws` | AWS IAM policies; use `r/json.*` for specific rules |
+| Bash scripts | - | Community support |
+| Cairo, Circom | - | Experimental, smart contracts |
+
+**Framework detection hints:**
+
+| Framework | Detection Signals | Ruleset |
+|-----------|------------------|---------|
+| Django | `settings.py`, `urls.py`, `django` in requirements | `p/django` |
+| Flask | `flask` in requirements, `@app.route` | `p/flask` |
+| FastAPI | `fastapi` in requirements, `@app.get/post` | `p/fastapi` |
+| React | `package.json` with react dependency, `.jsx`/`.tsx` files | `p/react` |
+| Next.js | `next.config.js`, `pages/` or `app/` directory | `p/nextjs` |
+| Angular | `angular.json`, `@angular/` dependencies | `p/angular` |
+| Express | `express` in package.json, `app.use()` patterns | `p/express` |
+| NestJS | `@nestjs/` dependencies, `@Controller` decorators | `p/nodejs` |
+| Spring | `pom.xml` with spring, `@SpringBootApplication` | `p/spring` |
+| Rails | `Gemfile` with rails, `config/routes.rb` | `p/rails` |
+| Laravel | `composer.json` with laravel, `artisan` | `p/laravel` |
+| Symfony | `composer.json` with symfony, `config/packages/` | `p/symfony` |
+
+### Step 3: Add Infrastructure Rulesets
+
+| Detection | Ruleset | Description |
+|-----------|---------|-------------|
+| `Dockerfile` | `p/dockerfile` | Container security, best practices |
+| `.tf`, `.hcl` | `p/terraform` | IaC misconfigurations, CIS benchmarks, AWS/Azure/GCP |
+| k8s manifests | `p/kubernetes` | K8s security, RBAC issues |
+| CloudFormation | `p/cloudformation` | AWS infrastructure security |
+| GitHub Actions | `p/github-actions` | CI/CD security, secrets exposure |
+| `.yaml`, `.yml` | `p/yaml` | Generic YAML patterns (K8s, docker-compose) |
+| AWS IAM JSON | `r/json.aws` | IAM policy misconfigurations (use `--config r/json.aws`) |
+
+### Step 4: Add Third-Party Rulesets
+
+These are **NOT optional**. Include automatically when language matches:
+
+| Languages | Source | Why Required |
+|-----------|--------|--------------|
+| Python, Go, Ruby, JS/TS, Terraform, HCL | [Trail of Bits](https://github.com/trailofbits/semgrep-rules) | Security audit patterns from real engagements (AGPLv3) |
+| C, C++ | [0xdea](https://github.com/0xdea/semgrep-rules) | Memory safety, low-level vulnerabilities |
+| Solidity, Cairo, Rust | [Decurity](https://github.com/Decurity/semgrep-smart-contracts) | Smart contract vulnerabilities, DeFi exploits |
+| Go | [dgryski](https://github.com/dgryski/semgrep-go) | Additional Go-specific patterns |
+| Android (Java/Kotlin) | [MindedSecurity](https://github.com/mindedsecurity/semgrep-rules-android-security) | OWASP MASTG-derived mobile security rules |
+| Java, Go, JS/TS, C#, Python, PHP | [elttam](https://github.com/elttam/semgrep-rules) | Security consulting patterns |
+| Dockerfile, PHP, Go, Java | [kondukto](https://github.com/kondukto-io/semgrep-rules) | Container and web app security |
+| PHP, Kotlin, Java | [dotta](https://github.com/federicodotta/semgrep-rules) | Pentest-derived web/mobile app rules |
+| Terraform, HCL | [HashiCorp](https://github.com/hashicorp-forge/semgrep-rules) | HashiCorp infrastructure patterns |
+| Swift, Java, Cobol | [akabe1](https://github.com/akabe1/akabe1-semgrep-rules) | iOS and legacy system patterns |
+| Java | [Atlassian Labs](https://github.com/atlassian-labs/atlassian-sast-ruleset) | Atlassian-maintained Java rules |
+| Python, JS/TS, Java, Ruby, Go, PHP | [Apiiro](https://github.com/apiiro/malicious-code-ruleset) | Malicious code detection, supply chain |
+
+### Step 5: Verify Rulesets
+
+Before finalizing, verify official rulesets load:
+
+```bash
+# Quick validation (exits 0 if valid)
+semgrep --config p/python --validate --metrics=off 2>&1 | head -3
+```
+
+Or browse the [Semgrep Registry](https://semgrep.dev/explore).
+
+### Output Format
+
+```json
+{
+  "baseline": ["p/security-audit", "p/secrets"],
+  "python": ["p/python", "p/django"],
+  "javascript": ["p/javascript", "p/react", "p/nodejs"],
+  "docker": ["p/dockerfile"],
+  "third_party": ["https://github.com/trailofbits/semgrep-rules"]
+}
+```

--- a/.agents/skills/semgrep/references/scan-modes.md
+++ b/.agents/skills/semgrep/references/scan-modes.md
@@ -1,0 +1,110 @@
+# Scan Modes Reference
+
+## Mode: Run All
+
+Full scan with all rulesets and severity levels. Current default behavior. No filtering applied — all findings are reported and triaged.
+
+## Mode: Important Only
+
+Focused on high-confidence security vulnerabilities. Excludes code quality, best practices, and low-confidence audit findings.
+
+### Pre-Filter: CLI Severity Flag
+
+Add these flags to every `semgrep` command:
+
+```bash
+--severity MEDIUM --severity HIGH --severity CRITICAL
+```
+
+This excludes LOW/INFO severity findings at scan time, reducing output volume before post-filtering.
+
+### Post-Filter: Metadata Criteria
+
+After scanning, filter each JSON result file to keep only findings matching ALL of:
+
+| Metadata Field | Accepted Values | Rationale |
+|---|---|---|
+| `extra.metadata.category` | `"security"` | Excludes correctness, best-practice, maintainability, performance |
+| `extra.metadata.confidence` | `"MEDIUM"`, `"HIGH"` | Excludes low-precision rules (high false positive rate) |
+| `extra.metadata.impact` | `"MEDIUM"`, `"HIGH"` | Excludes low-impact informational findings |
+
+**Third-party rules** (Trail of Bits, 0xdea, Decurity, etc.) may not have `confidence`/`impact`/`category` metadata. Findings **without** these metadata fields are **kept** — we cannot filter what is not annotated, and third-party rules are typically security-focused.
+
+### Semgrep Metadata Background
+
+Semgrep security rules have these metadata fields (required for `category: security` in the official registry):
+
+| Field | Purpose | Values |
+|---|---|---|
+| `severity` (top-level) | Overall rule severity, derived from likelihood × impact | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` |
+| `category` | Rule category | `security`, `correctness`, `best-practice`, `maintainability`, `performance` |
+| `confidence` | True positive rate of the rule (precision) | `LOW`, `MEDIUM`, `HIGH` |
+| `impact` | Potential damage if vulnerability is exploited | `LOW`, `MEDIUM`, `HIGH` |
+| `likelihood` | How likely the vulnerability is exploitable | `LOW`, `MEDIUM`, `HIGH` |
+| `subcategory` | Finding type | `vuln`, `audit`, `secure default` |
+
+Key relationship: `severity = f(likelihood, impact)` while `confidence` is independent (describes rule quality, not vulnerability severity).
+
+### Post-Filter jq Command
+
+Apply to each JSON result file after scanning:
+
+```bash
+# Filter a single result file
+jq '{
+  results: [.results[] |
+    ((.extra.metadata.category // "security") | ascii_downcase) as $cat |
+    ((.extra.metadata.confidence // "HIGH") | ascii_upcase) as $conf |
+    ((.extra.metadata.impact // "HIGH") | ascii_upcase) as $imp |
+    select(
+      ($cat == "security") and
+      ($conf == "MEDIUM" or $conf == "HIGH") and
+      ($imp == "MEDIUM" or $imp == "HIGH")
+    )
+  ],
+  errors: .errors,
+  paths: .paths
+}' "$f" > "${f%.json}-important.json"
+```
+
+Default values (`// "security"`, `// "HIGH"`) handle third-party rules without metadata — they pass all filters by default.
+
+### Filter All Result Files in a Directory
+
+Raw scan output lives in `$OUTPUT_DIR/raw/`. The filter creates `*-important.json` files alongside the originals — the raw files are preserved unmodified.
+
+```bash
+# Apply important-only filter to all scan result JSON files in raw/
+for f in "$OUTPUT_DIR/raw"/*-*.json; do
+  [[ "$f" == *-triage.json || "$f" == *-important.json ]] && continue
+  jq '{
+    results: [.results[] |
+      ((.extra.metadata.category // "security") | ascii_downcase) as $cat |
+      ((.extra.metadata.confidence // "HIGH") | ascii_upcase) as $conf |
+      ((.extra.metadata.impact // "HIGH") | ascii_upcase) as $imp |
+      select(
+        ($cat == "security") and
+        ($conf == "MEDIUM" or $conf == "HIGH") and
+        ($imp == "MEDIUM" or $imp == "HIGH")
+      )
+    ],
+    errors: .errors,
+    paths: .paths
+  }' "$f" > "${f%.json}-important.json"
+  BEFORE=$(jq '.results | length' "$f")
+  AFTER=$(jq '.results | length' "${f%.json}-important.json")
+  echo "$f: $BEFORE → $AFTER findings (filtered $(( BEFORE - AFTER )))"
+done
+```
+
+### Scanner Task Modifications
+
+In important-only mode, add `[SEVERITY_FLAGS]` to the scanner template:
+
+```bash
+semgrep [--pro if available] --metrics=off [SEVERITY_FLAGS] --config [RULESET] --json -o [OUTPUT_DIR]/raw/[lang]-[ruleset].json --sarif-output=[OUTPUT_DIR]/raw/[lang]-[ruleset].sarif [TARGET] &
+```
+
+Where `[SEVERITY_FLAGS]` is:
+- **Run all**: *(empty)*
+- **Important only**: `--severity MEDIUM --severity HIGH --severity CRITICAL`

--- a/.agents/skills/semgrep/references/scanner-task-prompt.md
+++ b/.agents/skills/semgrep/references/scanner-task-prompt.md
@@ -1,0 +1,140 @@
+# Scanner Subagent Task Prompt
+
+Use this prompt template when spawning scanner Tasks in Step 4. Use `subagent_type: static-analysis:semgrep-scanner`.
+
+## Template
+
+```
+You are a Semgrep scanner for [LANGUAGE_CATEGORY].
+
+## Task
+Run Semgrep scans for [LANGUAGE] files and save results to [OUTPUT_DIR]/raw.
+
+## Pro Engine Status: [PRO_AVAILABLE: true/false]
+
+## Scan Mode: [SCAN_MODE: run-all/important-only]
+
+## APPROVED RULESETS (from user-confirmed plan)
+[LIST EXACT RULESETS USER APPROVED - DO NOT SUBSTITUTE]
+
+Example:
+- p/python
+- p/django
+- p/security-audit
+- p/secrets
+- https://github.com/trailofbits/semgrep-rules
+
+## Commands to Run (in parallel)
+
+### Clone GitHub URL rulesets first:
+```bash
+mkdir -p [OUTPUT_DIR]/repos
+# For each GitHub URL ruleset, clone into [OUTPUT_DIR]/repos/[name]:
+git clone --depth 1 https://github.com/org/repo [OUTPUT_DIR]/repos/repo-name
+```
+
+### Generate commands for EACH approved ruleset:
+```bash
+semgrep [--pro if available] --metrics=off [SEVERITY_FLAGS] [INCLUDE_FLAGS] --config [RULESET] --json -o [OUTPUT_DIR]/raw/[lang]-[ruleset].json --sarif-output=[OUTPUT_DIR]/raw/[lang]-[ruleset].sarif [TARGET] &
+```
+
+Wait for all to complete:
+```bash
+wait
+```
+
+### Clean up cloned repos:
+```bash
+[ -n "[OUTPUT_DIR]" ] && rm -rf [OUTPUT_DIR]/repos
+```
+
+## Critical Rules
+- Use ONLY the rulesets listed above - do not add or remove any
+- Always use --metrics=off (prevents sending telemetry to Semgrep servers)
+- Use --pro when Pro is available (enables cross-file taint tracking)
+- If scan mode is **important-only**, add `--severity MEDIUM --severity HIGH --severity CRITICAL` to every command
+- If scan mode is **run-all**, do NOT add severity flags
+- Run all rulesets in parallel with & and wait
+- For GitHub URL rulesets, always clone into [OUTPUT_DIR]/repos/ and use the local path as --config (do NOT pass URLs directly to semgrep — its URL handling is unreliable for repos with non-standard YAML)
+- Add `--include` flags for language-specific rulesets (e.g., `--include="*.py"` for p/python). Do NOT add `--include` to cross-language rulesets like p/security-audit, p/secrets, or third-party repos
+- After all scans complete, delete [OUTPUT_DIR]/repos/ to avoid leaving cloned repos behind
+
+## Output
+Report:
+- Number of findings per ruleset
+- Any scan errors
+- File paths of JSON results (in [OUTPUT_DIR]/raw/)
+- [If Pro] Note any cross-file findings detected
+```
+
+## Variable Substitutions
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `[LANGUAGE_CATEGORY]` | Language group being scanned | Python, JavaScript, Docker |
+| `[LANGUAGE]` | Specific language | Python, TypeScript, Go |
+| `[OUTPUT_DIR]` | Output directory (absolute path, resolved in Step 1) | /path/to/static_analysis_semgrep_1 |
+| `[PRO_AVAILABLE]` | Whether Pro engine is available | true, false |
+| `[SEVERITY_FLAGS]` | Severity pre-filter flags | *(empty)* for run-all, `--severity MEDIUM --severity HIGH --severity CRITICAL` for important-only |
+| `[INCLUDE_FLAGS]` | File extension filter for language-specific rulesets | `--include="*.py"` for Python rulesets, *(empty)* for cross-language rulesets like p/security-audit, p/secrets, or third-party repos |
+| `[RULESET]` | Semgrep ruleset identifier or local clone path | p/python, [OUTPUT_DIR]/repos/semgrep-rules |
+| `[TARGET]` | Absolute path to directory to scan | /path/to/codebase |
+
+## Example: Python Scanner Task
+
+```
+You are a Semgrep scanner for Python.
+
+## Task
+Run Semgrep scans for Python files and save results to /path/to/static_analysis_semgrep_1/raw.
+
+## Pro Engine Status: true
+
+## Scan Mode: run-all
+
+## APPROVED RULESETS (from user-confirmed plan)
+- p/python
+- p/django
+- p/security-audit
+- p/secrets
+- https://github.com/trailofbits/semgrep-rules
+
+## Commands to Run (in parallel)
+
+### Clone GitHub URL rulesets first:
+```bash
+mkdir -p /path/to/static_analysis_semgrep_1/repos
+git clone --depth 1 https://github.com/trailofbits/semgrep-rules /path/to/static_analysis_semgrep_1/repos/trailofbits
+```
+
+### Run scans:
+```bash
+semgrep --pro --metrics=off --include="*.py" --config p/python --json -o /path/to/static_analysis_semgrep_1/raw/python-python.json --sarif-output=/path/to/static_analysis_semgrep_1/raw/python-python.sarif /path/to/codebase &
+semgrep --pro --metrics=off --include="*.py" --config p/django --json -o /path/to/static_analysis_semgrep_1/raw/python-django.json --sarif-output=/path/to/static_analysis_semgrep_1/raw/python-django.sarif /path/to/codebase &
+semgrep --pro --metrics=off --config p/security-audit --json -o /path/to/static_analysis_semgrep_1/raw/python-security-audit.json --sarif-output=/path/to/static_analysis_semgrep_1/raw/python-security-audit.sarif /path/to/codebase &
+semgrep --pro --metrics=off --config p/secrets --json -o /path/to/static_analysis_semgrep_1/raw/python-secrets.json --sarif-output=/path/to/static_analysis_semgrep_1/raw/python-secrets.sarif /path/to/codebase &
+semgrep --pro --metrics=off --config /path/to/static_analysis_semgrep_1/repos/trailofbits --json -o /path/to/static_analysis_semgrep_1/raw/python-trailofbits.json --sarif-output=/path/to/static_analysis_semgrep_1/raw/python-trailofbits.sarif /path/to/codebase &
+wait
+```
+
+### Clean up cloned repos:
+```bash
+rm -rf /path/to/static_analysis_semgrep_1/repos
+```
+
+## Critical Rules
+- Use ONLY the rulesets listed above - do not add or remove any
+- Always use --metrics=off
+- Use --pro when Pro is available
+- Run all rulesets in parallel with & and wait
+- Clone GitHub URL rulesets into the output dir repos/ subfolder, use local path as --config
+- Add --include="*.py" to language-specific rulesets (p/python, p/django) but NOT to p/security-audit, p/secrets, or third-party repos
+- Delete repos/ after scanning
+
+## Output
+Report:
+- Number of findings per ruleset
+- Any scan errors
+- File paths of JSON results (in raw/ subdirectory)
+- Note any cross-file findings detected
+```

--- a/.agents/skills/semgrep/scripts/merge_sarif.py
+++ b/.agents/skills/semgrep/scripts/merge_sarif.py
@@ -1,0 +1,203 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Merge SARIF files into a single consolidated output.
+
+Usage:
+    uv run merge_sarif.py RAW_DIR OUTPUT_FILE
+
+Reads *.sarif files from RAW_DIR (e.g., $OUTPUT_DIR/raw), produces
+OUTPUT_FILE (e.g., $OUTPUT_DIR/results/results.sarif) containing all
+findings merged and deduplicated.
+
+Attempts to use SARIF Multitool for merging if available, falls back to
+pure Python implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def has_sarif_multitool() -> bool:
+    """Check if SARIF Multitool is pre-installed via npx."""
+    if not shutil.which("npx"):
+        return False
+    try:
+        result = subprocess.run(
+            ["npx", "--no-install", "@microsoft/sarif-multitool", "--version"],
+            capture_output=True,
+            timeout=30,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        print("Warning: SARIF Multitool version check timed out", file=sys.stderr)
+        return False
+    except FileNotFoundError:
+        return False
+    except OSError as e:
+        print(f"Warning: Failed to check SARIF Multitool: {e}", file=sys.stderr)
+        return False
+
+
+def merge_with_multitool(sarif_files: list[Path]) -> dict | None:
+    """Use SARIF Multitool to merge SARIF files. Returns merged SARIF or None."""
+    if not sarif_files:
+        return None
+
+    with tempfile.NamedTemporaryFile(suffix=".sarif", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        cmd = [
+            "npx",
+            "--no-install",
+            "@microsoft/sarif-multitool",
+            "merge",
+            *[str(f) for f in sarif_files],
+            "--output-file",
+            str(tmp_path),
+            "--force",
+        ]
+        result = subprocess.run(cmd, capture_output=True, timeout=120)
+        if result.returncode != 0:
+            print(f"SARIF Multitool merge failed: {result.stderr.decode()}", file=sys.stderr)
+            return None
+
+        return json.loads(tmp_path.read_text())
+    except subprocess.TimeoutExpired as e:
+        print(f"SARIF Multitool timed out: {e}", file=sys.stderr)
+        return None
+    except json.JSONDecodeError as e:
+        print(f"SARIF Multitool produced invalid JSON: {e}", file=sys.stderr)
+        return None
+    except FileNotFoundError as e:
+        print(f"SARIF Multitool not found: {e}", file=sys.stderr)
+        return None
+    except OSError as e:
+        print(f"SARIF Multitool OS error ({type(e).__name__}): {e}", file=sys.stderr)
+        return None
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def merge_sarif_pure_python(sarif_files: list[Path]) -> dict:
+    """Pure Python SARIF merge (fallback)."""
+    merged = {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [],
+    }
+
+    seen_rules: dict[str, dict] = {}
+    all_results: list[dict] = []
+    seen_results: set[tuple[str, str, int]] = set()
+    tool_info: dict | None = None
+    skipped_files: list[str] = []
+
+    for sarif_file in sorted(sarif_files):
+        try:
+            data = json.loads(sarif_file.read_text())
+        except json.JSONDecodeError as e:
+            print(f"Warning: Failed to parse {sarif_file}: {e}", file=sys.stderr)
+            skipped_files.append(str(sarif_file))
+            continue
+
+        for run in data.get("runs", []):
+            if tool_info is None and run.get("tool"):
+                tool_info = run["tool"]
+
+            driver = run.get("tool", {}).get("driver", {})
+            for rule in driver.get("rules", []):
+                rule_id = rule.get("id", "")
+                if rule_id and rule_id not in seen_rules:
+                    seen_rules[rule_id] = rule
+
+            for result in run.get("results", []):
+                rule_id = result.get("ruleId", "")
+                uri = ""
+                start_line = 0
+                locations = result.get("locations", [])
+                if locations:
+                    phys = locations[0].get("physicalLocation", {})
+                    uri = phys.get("artifactLocation", {}).get("uri", "")
+                    start_line = phys.get("region", {}).get("startLine", 0)
+                dedup_key = (rule_id, uri, start_line)
+                if dedup_key in seen_results:
+                    continue
+                seen_results.add(dedup_key)
+                all_results.append(result)
+
+    if all_results:
+        merged_run = {
+            "tool": tool_info or {"driver": {"name": "semgrep", "rules": []}},
+            "results": all_results,
+        }
+        merged_run["tool"]["driver"]["rules"] = list(seen_rules.values())
+        merged["runs"].append(merged_run)
+
+    if skipped_files:
+        print(
+            f"WARNING: {len(skipped_files)} of {len(sarif_files)} SARIF files "
+            f"could not be parsed. Results may be incomplete.",
+            file=sys.stderr,
+        )
+        for sf in skipped_files:
+            print(f"  Skipped: {sf}", file=sys.stderr)
+
+    return merged
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} RAW_DIR OUTPUT_FILE", file=sys.stderr)
+        return 1
+
+    raw_dir = Path(sys.argv[1])
+    output_file = Path(sys.argv[2])
+
+    if not raw_dir.is_dir():
+        print(f"Error: {raw_dir} is not a directory", file=sys.stderr)
+        return 1
+
+    # Collect SARIF files from raw directory only
+    sarif_files = sorted(raw_dir.glob("*.sarif"))
+    print(f"Found {len(sarif_files)} SARIF files to merge in {raw_dir}")
+
+    if not sarif_files:
+        print("No SARIF files found, nothing to merge", file=sys.stderr)
+        return 1
+
+    # Ensure output directory exists
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Try SARIF Multitool first, fall back to pure Python
+    merged: dict | None = None
+    if has_sarif_multitool():
+        print("Using SARIF Multitool for merge...")
+        merged = merge_with_multitool(sarif_files)
+        if merged:
+            print("SARIF Multitool merge successful")
+
+    if merged is None:
+        print("Using pure Python merge (SARIF Multitool not available or failed)")
+        merged = merge_sarif_pure_python(sarif_files)
+
+    result_count = sum(len(run.get("results", [])) for run in merged.get("runs", []))
+    print(f"Merged SARIF contains {result_count} findings")
+
+    # Write output
+    output_file.write_text(json.dumps(merged, indent=2))
+    print(f"Written to {output_file}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/semgrep/workflows/scan-workflow.md
+++ b/.agents/skills/semgrep/workflows/scan-workflow.md
@@ -1,0 +1,311 @@
+# Semgrep Scan Workflow
+
+Complete 5-step scan execution process. Read from start to finish and follow each step in order.
+
+## Task System Enforcement
+
+On invocation, create these tasks with dependencies:
+
+```
+TaskCreate: "Detect languages and Pro availability" (Step 1)
+TaskCreate: "Select scan mode and rulesets" (Step 2) - blockedBy: Step 1
+TaskCreate: "Present plan with rulesets, get approval" (Step 3) - blockedBy: Step 2
+TaskCreate: "Execute scans with approved rulesets and mode" (Step 4) - blockedBy: Step 3
+TaskCreate: "Merge results and report" (Step 5) - blockedBy: Step 4
+```
+
+### Mandatory Gate
+
+| Task | Gate Type | Cannot Proceed Until |
+|------|-----------|---------------------|
+| Step 3 | **HARD GATE** | User explicitly approves rulesets + plan |
+
+Mark Step 3 as `completed` ONLY after user says "yes", "proceed", "approved", or equivalent.
+
+---
+
+## Step 1: Resolve Output Directory, Detect Languages and Pro Availability
+
+> **Entry:** User has specified or confirmed the target directory.
+> **Exit:** `OUTPUT_DIR` resolved and created; language list with file counts produced; Pro availability determined.
+
+### Resolve Output Directory
+
+If the user specified an output directory in their prompt, use it as `OUTPUT_DIR`. Otherwise, auto-increment. In both cases, **always `mkdir -p`** to ensure the directory exists.
+
+```bash
+if [ -n "$USER_SPECIFIED_DIR" ]; then
+  OUTPUT_DIR="$USER_SPECIFIED_DIR"
+else
+  BASE="static_analysis_semgrep"
+  N=1
+  while [ -e "${BASE}_${N}" ]; do
+    N=$((N + 1))
+  done
+  OUTPUT_DIR="${BASE}_${N}"
+fi
+mkdir -p "$OUTPUT_DIR/raw" "$OUTPUT_DIR/results"
+echo "Output directory: $OUTPUT_DIR"
+```
+
+`$OUTPUT_DIR` is used by all subsequent steps. Pass its **absolute path** to scanner subagents. Scanners write raw output to `$OUTPUT_DIR/raw/`; merged/filtered results go to `$OUTPUT_DIR/results/`.
+
+**Detect Pro availability** (requires Bash):
+
+```bash
+if ! command -v semgrep >/dev/null 2>&1; then
+  echo "ERROR: semgrep is not installed. Install from https://semgrep.dev/docs/getting-started/"
+  exit 1
+fi
+semgrep --version
+semgrep --pro --validate --config p/default 2>/dev/null && echo "Pro: AVAILABLE" || echo "Pro: NOT AVAILABLE"
+```
+
+**Detect languages** using Glob (not Bash). Run these patterns against the target directory and count matches:
+
+`**/*.py`, `**/*.js`, `**/*.ts`, `**/*.tsx`, `**/*.jsx`, `**/*.go`, `**/*.rb`, `**/*.java`, `**/*.php`, `**/*.c`, `**/*.cpp`, `**/*.rs`, `**/Dockerfile`, `**/*.tf`
+
+Also check for framework markers: `package.json`, `pyproject.toml`, `Gemfile`, `go.mod`, `Cargo.toml`, `pom.xml`. Use Read to inspect these files for framework dependencies (e.g., read `package.json` to detect React, Express, Next.js; read `pyproject.toml` for Django, Flask, FastAPI).
+
+Map findings to categories:
+
+| Detection | Category |
+|-----------|----------|
+| `.py`, `pyproject.toml` | Python |
+| `.js`, `.ts`, `package.json` | JavaScript/TypeScript |
+| `.go`, `go.mod` | Go |
+| `.rb`, `Gemfile` | Ruby |
+| `.java`, `pom.xml` | Java |
+| `.php` | PHP |
+| `.c`, `.cpp` | C/C++ |
+| `.rs`, `Cargo.toml` | Rust |
+| `Dockerfile` | Docker |
+| `.tf` | Terraform |
+| k8s manifests | Kubernetes |
+
+---
+
+## Step 2: Select Scan Mode and Rulesets
+
+> **Entry:** Step 1 complete — languages detected, Pro status known.
+> **Exit:** Scan mode selected; structured rulesets JSON compiled for all detected languages.
+
+**First, select scan mode** using `AskUserQuestion`:
+
+```
+header: "Scan Mode"
+question: "Which scan mode should be used?"
+multiSelect: false
+options:
+  - label: "Run all (Recommended)"
+    description: "Full coverage — all rulesets, all severity levels"
+  - label: "Important only"
+    description: "Security vulnerabilities only — medium-high confidence and impact, no code quality"
+```
+
+Record the selected mode. It affects Steps 4 and 5.
+
+**Then, select rulesets.** Using the detected languages and frameworks from Step 1, follow the **Ruleset Selection Algorithm** in [rulesets.md](../references/rulesets.md).
+
+The algorithm covers:
+1. Security baseline (always included)
+2. Language-specific rulesets
+3. Framework rulesets (if detected)
+4. Infrastructure rulesets
+5. **Required** third-party rulesets (Trail of Bits, 0xdea, Decurity — NOT optional)
+6. Registry verification
+
+**Output:** Structured JSON passed to Step 3 for user review:
+
+```json
+{
+  "baseline": ["p/security-audit", "p/secrets"],
+  "python": ["p/python", "p/django"],
+  "javascript": ["p/javascript", "p/react", "p/nodejs"],
+  "docker": ["p/dockerfile"],
+  "third_party": ["https://github.com/trailofbits/semgrep-rules"]
+}
+```
+
+---
+
+## Step 3: CRITICAL GATE — Present Plan and Get Approval
+
+> **Entry:** Step 2 complete — scan mode and rulesets selected.
+> **Exit:** User has explicitly approved the plan (quoted confirmation).
+
+> **⛔ MANDATORY CHECKPOINT — DO NOT SKIP**
+>
+> This step requires explicit user approval before proceeding.
+> User may modify rulesets before approving.
+
+Present plan to user with **explicit ruleset listing**:
+
+```
+## Semgrep Scan Plan
+
+**Target:** /path/to/codebase
+**Output directory:** $OUTPUT_DIR
+**Engine:** Semgrep Pro (cross-file analysis) | Semgrep OSS (single-file)
+**Scan mode:** Run all | Important only (security vulns, medium-high confidence/impact)
+
+### Detected Languages/Technologies:
+- Python (1,234 files) - Django framework detected
+- JavaScript (567 files) - React detected
+- Dockerfile (3 files)
+
+### Rulesets to Run:
+
+**Security Baseline (always included):**
+- [x] `p/security-audit` - Comprehensive security rules
+- [x] `p/secrets` - Hardcoded credentials, API keys
+
+**Python (1,234 files):**
+- [x] `p/python` - Python security patterns
+- [x] `p/django` - Django-specific vulnerabilities
+
+**JavaScript (567 files):**
+- [x] `p/javascript` - JavaScript security patterns
+- [x] `p/react` - React-specific issues
+- [x] `p/nodejs` - Node.js server-side patterns
+
+**Docker (3 files):**
+- [x] `p/dockerfile` - Dockerfile best practices
+
+**Third-party (auto-included for detected languages):**
+- [x] Trail of Bits rules - https://github.com/trailofbits/semgrep-rules
+
+**Want to modify rulesets?** Tell me which to add or remove.
+**Ready to scan?** Say "proceed" or "yes".
+```
+
+**⛔ STOP: Await explicit user approval.**
+
+1. **If user wants to modify rulesets:** Add/remove as requested, re-present the updated plan, return to waiting.
+2. **Use AskUserQuestion** if user hasn't responded:
+   ```
+   "I've prepared the scan plan with N rulesets (including Trail of Bits). Proceed with scanning?"
+   Options: ["Yes, run scan", "Modify rulesets first"]
+   ```
+3. **Valid approval:** "yes", "proceed", "approved", "go ahead", "looks good", "run it"
+4. **NOT approval:** User's original request ("scan this codebase"), silence, questions about the plan
+
+### Pre-Scan Checklist
+
+Before marking Step 3 complete:
+- [ ] Target directory shown to user
+- [ ] Engine type (Pro/OSS) displayed
+- [ ] Languages detected and listed
+- [ ] **All rulesets explicitly listed with checkboxes**
+- [ ] User given opportunity to modify rulesets
+- [ ] User explicitly approved (quote their confirmation)
+- [ ] **Final ruleset list captured for Step 4**
+- [ ] Agent type listed: `static-analysis:semgrep-scanner`
+
+### Log Approved Rulesets
+
+After approval, write the approved rulesets to `$OUTPUT_DIR/rulesets.txt`:
+
+```bash
+cat > "$OUTPUT_DIR/rulesets.txt" << RULESETS
+# Semgrep Scan — Approved Rulesets
+# Generated: $(date -Iseconds)
+# Scan mode: <run-all|important-only>
+
+## Rulesets:
+<one ruleset per line, e.g.:>
+p/security-audit
+p/secrets
+p/python
+p/django
+https://github.com/trailofbits/semgrep-rules
+RULESETS
+```
+
+---
+
+## Step 4: Spawn Parallel Scan Tasks
+
+> **Entry:** Step 3 approved — user explicitly confirmed the plan.
+> **Exit:** All scan Tasks completed; result files exist in `$OUTPUT_DIR/raw/`.
+
+**Use `$OUTPUT_DIR` resolved in Step 1.** It already exists; no need to create it again. Scanners write all output to `$OUTPUT_DIR/raw/`.
+
+**Spawn N Tasks in a SINGLE message** (one per language category) using `subagent_type: static-analysis:semgrep-scanner`.
+
+Use the scanner task prompt template from [scanner-task-prompt.md](../references/scanner-task-prompt.md).
+
+**Mode-dependent scanner flags:**
+- **Run all**: No additional flags
+- **Important only**: Add `--severity MEDIUM --severity HIGH --severity CRITICAL` to every `semgrep` command
+
+**Example — 3 Language Scan (with approved rulesets):**
+
+Spawn these 3 Tasks in a SINGLE message:
+
+1. **Task: Python Scanner** — Rulesets: p/python, p/django, p/security-audit, p/secrets, trailofbits → `$OUTPUT_DIR/raw/python-*.json`
+2. **Task: JavaScript Scanner** — Rulesets: p/javascript, p/react, p/nodejs, p/security-audit, p/secrets, trailofbits → `$OUTPUT_DIR/raw/js-*.json`
+3. **Task: Docker Scanner** — Rulesets: p/dockerfile → `$OUTPUT_DIR/raw/docker-*.json`
+
+### Operational Notes
+
+- Always use **absolute paths** for `[TARGET]` — subagents can't resolve relative paths
+- Clone GitHub URL rulesets into `$OUTPUT_DIR/repos/` — never pass URLs directly to `--config` (semgrep's URL handling fails on repos with non-standard YAML)
+- Delete `$OUTPUT_DIR/repos/` after all scans complete
+- Run rulesets in parallel with `&` and `wait`, not sequentially
+- Use `--include="*.py"` for language-specific rulesets, but NOT for cross-language rulesets (p/security-audit, p/secrets, third-party repos)
+
+---
+
+## Step 5: Merge Results and Report
+
+> **Entry:** Step 4 complete — all scan Tasks finished.
+> **Exit:** `results.sarif` exists in `$OUTPUT_DIR/results/` and is valid JSON.
+
+**Important-only mode: Post-filter before merge.** Apply the filter from [scan-modes.md](../references/scan-modes.md) ("Filter All Result Files in a Directory" section) to each result JSON in `$OUTPUT_DIR/raw/`. The filter creates `*-important.json` files alongside the originals — the originals are preserved unmodified.
+
+**Generate merged SARIF** using the merge script. The resolved path is in SKILL.md's "Merge command" section — use that exact path:
+
+```bash
+uv run {baseDir}/scripts/merge_sarif.py $OUTPUT_DIR/raw $OUTPUT_DIR/results/results.sarif
+```
+
+- **Run-all mode:** The script merges all `*.sarif` files from `$OUTPUT_DIR/raw/`.
+- **Important-only mode:** Run the post-filter first (creates `*-important.json` in `raw/`), then run the merge script. Raw SARIF files are unaffected by the JSON post-filter, so the merge operates on the unfiltered SARIF. For SARIF-level filtering, apply the jq post-filter from scan-modes.md to `$OUTPUT_DIR/results/results.sarif` after merge.
+
+**Verify merged SARIF is valid:**
+
+```bash
+python -c "import json; d=json.load(open('$OUTPUT_DIR/results/results.sarif')); print(f'{sum(len(r.get(\"results\",[]))for r in d.get(\"runs\",[]))} findings in merged SARIF')"
+```
+
+If verification fails, the merge script produced invalid output — investigate before reporting.
+
+**Report to user:**
+
+```
+## Semgrep Scan Complete
+
+**Scanned:** 1,804 files
+**Rulesets used:** 9 (including Trail of Bits)
+**Total findings:** 156
+
+### By Severity:
+- ERROR: 5
+- WARNING: 18
+- INFO: 9
+
+### By Category:
+- SQL Injection: 3
+- XSS: 7
+- Hardcoded secrets: 2
+- Insecure configuration: 12
+- Code quality: 8
+
+Results written to:
+- $OUTPUT_DIR/results/results.sarif (merged SARIF)
+- $OUTPUT_DIR/raw/ (per-scan raw results, unfiltered)
+- $OUTPUT_DIR/rulesets.txt (approved rulesets)
+```
+
+**Verify** before reporting: confirm `results.sarif` exists and is valid JSON.

--- a/.agents/skills/stripe-best-practices/SKILL.md
+++ b/.agents/skills/stripe-best-practices/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: stripe-best-practices
+description: >-
+  Guides Stripe integration decisions — API selection (Checkout Sessions vs
+  PaymentIntents), Connect platform setup (Accounts v2, controller properties),
+  billing/subscriptions, Treasury financial accounts, integration surfaces
+  (Checkout, Payment Element), migrating from deprecated Stripe APIs, and
+  security best practices (API key management, restricted keys, webhooks,
+  OAuth). Use when building, modifying, or reviewing any Stripe integration —
+  including accepting payments, building marketplaces, integrating Stripe,
+  processing payments, setting up subscriptions, creating connected accounts, or
+  implementing secure key handling.
+
+---
+
+Latest Stripe API version: **2026-04-22.dahlia**. Always use the latest API version and SDK unless the user specifies otherwise.
+
+## Integration routing
+
+| Building…                                                                | Recommended API                     | Details                  |
+| ------------------------------------------------------------------------ | ----------------------------------- | ------------------------ |
+| One-time payments                                                        | Checkout Sessions                   | <references/payments.md> |
+| Custom payment form with embedded UI                                     | Checkout Sessions + Payment Element | <references/payments.md> |
+| Saving a payment method for later                                        | Setup Intents                       | <references/payments.md> |
+| Connect platform or marketplace                                          | Accounts v2 (`/v2/core/accounts`)   | <references/connect.md>  |
+| Subscriptions or recurring billing                                       | Billing APIs + Checkout Sessions    | <references/billing.md>  |
+| Embedded financial accounts / banking                                    | v2 Financial Accounts               | <references/treasury.md> |
+| Security (key management, RAKs, webhooks, OAuth, 2FA, Connect liability) | See security reference              | <references/security.md> |
+
+Read the relevant reference file before answering any integration question or writing code.
+
+## Critical rules
+
+- *Never include `payment_method_types` in any Stripe API call*, with one exception: Terminal (in-person payments) integrations must pass `payment_method_types: ['card_present']` on the PaymentIntent. For all other integrations, omit this parameter entirely to enable dynamic payment methods, which enables you to configure payment method settings from the Dashboard and dynamically display the most relevant eligible payment methods to each customer to maximize conversion. To customize which payment methods you accept, use [`payment_method_configurations`](https://docs.stripe.com/payments/payment-method-configurations.md) or `excluded_payment_method_types` instead of `payment_method_types`.
+
+## Key documentation
+
+When the user’s request does not clearly fit a single domain above, consult:
+
+- [Integration Options](https://docs.stripe.com/payments/payment-methods/integration-options.md) — Start here when designing any integration.
+- [API Tour](https://docs.stripe.com/payments-api/tour.md) — Overview of Stripe’s API surface.
+- [Go Live Checklist](https://docs.stripe.com/get-started/checklist/go-live.md) — Review before launching.

--- a/.agents/skills/stripe-best-practices/references/billing.md
+++ b/.agents/skills/stripe-best-practices/references/billing.md
@@ -1,0 +1,36 @@
+# Billing / Subscriptions
+
+## Table of contents
+
+- When to use Billing APIs
+- Recommended frontend pairing
+- Traps to avoid
+
+## When to use Billing APIs
+
+If the user has a recurring revenue model (subscriptions, usage-based billing, seat-based pricing), use the Billing APIs to [plan their integration](https://docs.stripe.com/billing/subscriptions/design-an-integration.md) instead of a direct PaymentIntent integration.
+
+Review the [Subscription Use Cases](https://docs.stripe.com/billing/subscriptions/use-cases.md) and [SaaS guide](https://docs.stripe.com/saas.md) to find the right pattern for the user’s pricing model.
+
+## Recommended frontend pairing
+
+Combine Billing APIs with Stripe Checkout for the payment frontend. Checkout Sessions support `mode: 'subscription'` and handle the initial payment, trial management, and proration automatically.
+
+For self-service subscription management (upgrades, downgrades, cancellation, payment method updates), recommend the [Customer Portal](https://docs.stripe.com/customer-management/integrate-customer-portal.md).
+
+## Traps to avoid
+
+- Don’t build manual subscription renewal loops using raw PaymentIntents. Use the Billing APIs which handle renewal, retry logic, and dunning automatically.
+- Don’t use the deprecated `plan` object. Use [Prices](https://docs.stripe.com/api/prices.md) instead.
+- *Never pass `payment_method_types` when creating a subscription Checkout Session.* Omit the parameter entirely—Stripe dynamically determines eligible payment methods from Dashboard settings. Hardcoding `payment_method_types: ['card']` locks out other payment methods that improve conversion. See [dynamic payment methods](https://docs.stripe.com/payments/payment-methods/dynamic-payment-methods.md). Correct pattern:
+
+```ts
+const session = await stripe.checkout.sessions.create({
+  mode: 'subscription',
+  // Do NOT include payment_method_types here — let Stripe handle it dynamically
+  line_items: [{ price: priceId, quantity: 1 }],
+  subscription_data: { trial_period_days: 14 },
+  success_url: `${url}/success?session_id={CHECKOUT_SESSION_ID}`,
+  cancel_url: `${url}/pricing`,
+});
+```

--- a/.agents/skills/stripe-best-practices/references/connect.md
+++ b/.agents/skills/stripe-best-practices/references/connect.md
@@ -1,0 +1,48 @@
+# Connect / platforms
+
+## Table of contents
+
+- Accounts v2 API
+- Controller properties
+- Charge types
+- Integration guides
+
+## Accounts v2 API
+
+For new Connect platforms, ALWAYS use the [Accounts v2 API](https://docs.stripe.com/connect/accounts-v2.md) (`POST /v2/core/accounts`). This is Stripe’s actively invested path and ensures long-term support.
+
+**Traps to avoid:** Don’t use the legacy `type` parameter (`type: 'express'`, `type: 'custom'`, `type: 'standard'`) in `POST /v1/accounts` for new platforms unless the user has explicitly requested v1.
+
+## Controller properties
+
+Configure connected accounts using `controller` properties instead of legacy account types:
+
+| Property                            | Controls                                     |
+| ----------------------------------- | -------------------------------------------- |
+| `controller.losses.payments`        | Who is liable for negative balances          |
+| `controller.fees.payer`             | Who pays Stripe fees                         |
+| `controller.stripe_dashboard.type`  | Dashboard access (`full`, `express`, `none`) |
+| `controller.requirement_collection` | Who collects onboarding requirements         |
+
+Use `defaults.responsibilities`, `dashboard`, and `configuration` as described in [connected account configuration](https://docs.stripe.com/connect/accounts-v2/connected-account-configuration.md).
+
+Always describe accounts in terms of their responsibility settings, dashboard access, and [capabilities](https://docs.stripe.com/connect/account-capabilities.md) to describe what connected accounts can do.
+
+**Traps to avoid:** Don’t use the terms “Standard”, “Express”, or “Custom” as account types. These are legacy categories that bundle together responsibility, dashboard, and requirement decisions into opaque labels. Controller properties give explicit control over each dimension.
+
+## Charge types
+
+Choose one charge type per integration — don’t mix them. For most platforms, start with destination charges:
+
+- **Destination charges** — Use when the platform accepts liability for negative balances. Funds route to the connected account via `transfer_data.destination`.
+- **Direct charges** — Use when the platform wants Stripe to take risk on the connected account. The charge is created on the connected account directly.
+
+Use `on_behalf_of` to control the merchant of record, but only after reading [how charges work in Connect](https://docs.stripe.com/connect/charges.md).
+
+**Traps to avoid:** Don’t use the Charges API for Connect fund flows — use PaymentIntents or Checkout Sessions with `transfer_data` or `on_behalf_of`. Don’t mix charge types within a single integration.
+
+## Integration guides
+
+- [SaaS platforms and marketplaces guide](https://docs.stripe.com/connect/saas-platforms-and-marketplaces.md) — Choosing the right integration shape.
+- [Interactive platform guide](https://docs.stripe.com/connect/interactive-platform-guide.md) — Step-by-step platform builder.
+- [Design an integration](https://docs.stripe.com/connect/design-an-integration.md) — Detailed risk and responsibility decisions.

--- a/.agents/skills/stripe-best-practices/references/payments.md
+++ b/.agents/skills/stripe-best-practices/references/payments.md
@@ -1,0 +1,79 @@
+# Payments
+
+## Table of contents
+
+- API hierarchy
+- Integration surfaces
+- Payment Element guidance
+- Saving payment methods
+- Dynamic payment methods
+- Deprecated APIs and migration paths
+- PCI compliance
+
+## API hierarchy
+
+Use the [Checkout Sessions API](https://docs.stripe.com/api/checkout/sessions.md) (`checkout.sessions.create`) for on-session payments. It supports one-time payments and subscriptions and handles taxes, discounts, shipping, and adaptive pricing automatically.
+
+Use the [PaymentIntents API](https://docs.stripe.com/payments/paymentintents/lifecycle.md) for off-session payments, or when the merchant needs to model checkout state independently and just create a charge.
+
+**Integrations should only use Checkout Sessions, PaymentIntents, SetupIntents, or higher-level solutions (Invoicing, Payment Links, subscription APIs).**
+
+## Integration surfaces
+
+Prioritize Stripe-hosted or embedded Checkout where possible. Use in this order of preference:
+
+1. **Payment Links** — No-code. Best for simple products.
+1. **Checkout** ([docs](https://docs.stripe.com/payments/checkout.md)) — Stripe-hosted or embedded form. Best for most web apps.
+1. **Payment Element** ([docs](https://docs.stripe.com/payments/payment-element.md)) — Embedded UI component for advanced customization.
+   - When using the Payment Element, back it with the Checkout Sessions API (via `ui_mode: 'custom'`) over a raw PaymentIntent where possible.
+
+**Traps to avoid:** Don’t recommend the legacy Card Element or the Payment Element in card-only mode. If the user asks for the Card Element, advise them to [migrate to the Payment Element](https://docs.stripe.com/payments/payment-element/migration.md).
+
+## Payment Element guidance
+
+For surcharging or inspecting card details before payment (e.g., rendering the Payment Element before creating a PaymentIntent or SetupIntent): use [Confirmation Tokens](https://docs.stripe.com/payments/finalize-payments-on-the-server.md). Don’t recommend `createPaymentMethod` or `createToken` from Stripe.js.
+
+## Saving payment methods
+
+Use the [Setup Intents API](https://docs.stripe.com/api/setup_intents.md) to save a payment method for later use.
+
+**Traps to avoid:** Don’t use the Sources API to save cards to customers. The Sources API is deprecated — Setup Intents is the correct approach.
+
+## Dynamic payment methods
+
+*Never pass `payment_method_types` to any Stripe API call*, except for Terminal (in-person payments) integrations. Omitting this parameter enables [dynamic payment methods](https://docs.stripe.com/payments/payment-methods/dynamic-payment-methods.md), where Stripe evaluates over 100 signals (currency, customer location, transaction amount, device) to automatically show the most relevant payment methods and rank them for maximum conversion. Payment methods are managed from the [Dashboard](https://dashboard.stripe.com/settings/payment_methods) with no code changes required.
+
+This applies to all integration patterns:
+
+- `checkout.sessions.create`: omit `payment_method_types` entirely. Dynamic method selection is the default behavior.
+- `paymentIntents.create`: omit `payment_method_types`. On API versions 2023-08-16+, dynamic methods are the default. On older versions, pass `automatic_payment_methods: { enabled: true }`.
+- `setupIntents.create`: same as PaymentIntents above.
+- `subscriptions.create`: omit `payment_settings.payment_method_types`. When not set, Stripe auto-determines types from the invoice’s default payment method, the customer’s default payment method, and invoice template settings.
+- **Terminal** (`paymentIntents.create`): pass `payment_method_types: ['card_present']`. Required for all in-person payments. In Canada, also include `interac_present`: `['card_present', 'interac_present']`. This is the only valid use of `payment_method_types`.
+
+See the [integration options guide](https://docs.stripe.com/payments/payment-methods/integration-options.md) for full details on dynamic versus manual configuration.
+
+**Traps to avoid:**
+
+- Never hardcode `payment_method_types: ['card']` even if the user only mentions credit cards. Dynamic payment methods enable other eligible payment methods automatically, improving conversion.
+- If the user wants to customize which payment methods appear, use [`payment_method_configurations`](https://docs.stripe.com/payments/payment-method-configurations.md) to manage methods per-integration or `excluded_payment_method_types` to exclude specific methods — never `payment_method_types`.
+- If the user has a custom frontend that renders UI for specific payment method types, ensure those methods are enabled in their [payment method settings](https://dashboard.stripe.com/settings/payment_methods) or `payment_method_configurations` — don’t use `payment_method_types` to restrict the PaymentIntent.
+
+## Deprecated APIs and migration paths
+
+Never recommend the Charges API. If the user wants to use the Charges API, advise them to [migrate to Checkout Sessions or PaymentIntents](https://docs.stripe.com/payments/payment-intents/migration/charges.md).
+
+Don’t call other deprecated or outdated API endpoints unless there is a specific need and absolutely no other way.
+
+| API          | Status     | Use instead                         | Migration guide                                                                          |
+| ------------ | ---------- | ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| Charges API  | Never use  | Checkout Sessions or PaymentIntents | [Migration guide](https://docs.stripe.com/payments/payment-intents/migration/charges.md) |
+| Sources API  | Deprecated | Setup Intents                       | [Setup Intents docs](https://docs.stripe.com/api/setup_intents.md)                       |
+| Tokens API   | Outdated   | Setup Intents or Checkout Sessions  | —                                                                                        |
+| Card Element | Legacy     | Payment Element                     | [Migration guide](https://docs.stripe.com/payments/payment-element/migration.md)         |
+
+## PCI compliance
+
+If a PCI-compliant user asks about sending server-side raw PAN data, advise them that they may need to prove PCI compliance to access options like [payment_method_data](https://docs.stripe.com/api/payment_intents/create.md#create_payment_intent-payment_method_data).
+
+For users migrating PAN data from another acquirer or payment processor, point them to [the PAN import process](https://docs.stripe.com/get-started/data-migrations/pan-import.md).

--- a/.agents/skills/stripe-best-practices/references/security.md
+++ b/.agents/skills/stripe-best-practices/references/security.md
@@ -1,0 +1,109 @@
+# Security best practices
+
+## Table of contents
+
+- API keys
+- Restricted API keys (RAKs)
+- IP restrictions
+- Incident response
+- Webhook security
+- Mobile and client-side integrations
+- OAuth and CSRF protection
+- Two-factor authentication
+- Connect security
+- SAML and SCIM
+
+## API keys
+
+Never include keys in source code. You might find example code like `client = new Stripe("sk_...")` that are for illustration only. Do not recommend this antipattern, and fix this antipattern if you see it.
+
+Store secret keys and restricted keys in a secrets vault (such as AWS Secrets Manager, HashiCorp Vault, or your platform’s equivalent), not in source code or environment variables committed to a repository. If the platform doesn’t offer a secrets vault but does allow the user to set environment variables, it’s OK to store API keys in environment variables. Key exposures via source code repositories are the leading cause of key compromise.
+
+Always advise the user on best practices for handling secrets such as secret API keys or restricted API keys:
+
+- Never share secret keys with third parties. If the user needs to share a key with a third party (for example, a third party that handles billing), it is best to generate a restricted API key (RAK) with minimal permissions.
+- Rotate Stripe API keys when personnel with access to those keys depart.
+- Read [best practices for managing secret API keys](https://docs.stripe.com/keys-best-practices.md).
+
+Code must never log keys or include them in error messages or analytics. Remove those from logs if you find them.
+
+Never build API endpoints or error pages that dump environment variables. In addition to Stripe API keys, the environment may have other secrets.
+
+Use separate keys for separate environments (production, staging, QA). This limits the blast radius if any single key is compromised.
+
+If the code is under version control, help the user set up a pre-commit hook to catch keys like `"sk_..."` and `"rk_..."` in source code.
+
+**Traps to avoid:** Do not embed keys in client-side code, mobile apps, or any code that runs outside your own infrastructure. Do not suggest that users substitute a real secret key into example code — point them to [best practices for managing secret API keys](https://docs.stripe.com/keys-best-practices.md) instead.
+
+## Restricted API keys (RAKs)
+
+Use [restricted API keys](https://docs.stripe.com/keys/restricted-api-keys.md) (prefix `rk_`) instead of secret keys (prefix `sk_`) wherever possible. RAKs have only the permissions you assign, so a compromised RAK can do far less damage than a compromised secret key.
+
+Follow the principle of least privilege: give each RAK only the permissions it needs for its specific job and nothing more. Create a separate RAK for each service or use case.
+
+Preferred migration approach:
+
+1. Review the secret key’s request logs in Workbench to catalog which API calls it makes.
+1. Create a RAK in test mode with matching permissions.
+1. Use the [Stripe CLI](https://docs.stripe.com/stripe-cli.md)’s `stripe logs tail` command to watch logs.
+1. Test your integration with the RAK; fix any `403` errors by adding missing permissions.
+1. Create the equivalent live-mode RAK and replace the secret key.
+1. Rotate or expire the old secret key once confident.
+
+**Traps to avoid:** Do not default to recommending secret keys. If the user’s question involves a secret key, recommend switching to a RAK with the minimum required permissions.
+
+## IP restrictions
+
+Encourage users to add an [IP allowlist](https://docs.stripe.com/keys.md#limit-api-secret-keys-ip-address) to every API key. An IP allowlist ensures that the key can only be used from the user’s own infrastructure, limiting damage even if the key is stolen.
+
+Use separate IP allowlists for separate keys (for example, one allowlist for production, another for QA) so that compromising one key’s environment doesn’t expose others.
+
+## Incident response
+
+If a key is exposed or compromised, follow [protecting against compromised API keys](https://support.stripe.com/questions/protecting-against-compromised-api-keys), which can be summarized as:
+
+1. **Roll the key immediately** — go to the [API keys page](https://dashboard.stripe.com/apikeys) and roll or delete the exposed key. Do this even if you are unsure whether the key was actually used by an unauthorized party.
+1. **Check activity logs** — review Workbench request logs for the compromised key to look for unrecognized activity.
+1. **Contact Stripe support** if you see activity you don’t recognize.
+
+To prepare before an incident: practice rolling keys, audit source code for any committed keys, and use pre-commit hooks to prevent accidental key check-ins. See [protecting against compromised API keys](https://support.stripe.com/questions/protecting-against-compromised-api-keys).
+
+## Webhook security
+
+Always [verify webhook signatures](https://docs.stripe.com/webhooks.md#verify-events) using Stripe’s webhook signing secret. Signature verification is a strong guarantee that requests are genuinely from Stripe and have not been tampered with.
+
+For defense in depth, also [allowlist Stripe’s IP addresses](https://docs.stripe.com/ips.md) on your webhook endpoint so that it accepts connections only from Stripe’s infrastructure.
+
+**Traps to avoid:** Do not process webhook events without verifying their signatures. Unverified webhooks can be spoofed.
+
+## Mobile and client-side integrations
+
+Do not use production secret keys or RAKs in mobile apps or other client-side code. Client-side code can be extracted and keys decompiled.
+
+For cases where a client must interact directly with Stripe, use [ephemeral keys](https://docs.stripe.com/issuing/elements.md#ephemeral-key-authentication). Ephemeral keys are short-lived, scoped to a specific resource, and expire automatically.
+
+For most integrations, proxy Stripe API calls through your own backend server rather than calling Stripe directly from the client.
+
+## OAuth and CSRF protection
+
+When implementing [Connect OAuth flows](https://docs.stripe.com/connect/oauth-reference.md), always use the `state` parameter to protect against CSRF attacks. Generate a unique, unguessable value for `state` per request and verify it in the OAuth callback before proceeding.
+
+This applies to all Stripe OAuth surfaces: Connect, Link, and Stripe Apps.
+
+## Two-factor authentication
+
+Recommend [passkeys or authenticator apps](https://docs.stripe.com/security.md) rather than SMS-based 2FA for Stripe Dashboard access. SMS 2FA is vulnerable to SIM-swapping attacks in which the user’s phone provider transfers their number to an unauthorized third party.
+
+Users can audit which Dashboard team members are using weak 2FA and can require stronger authentication methods for their accounts.
+
+## Connect security
+
+**Account type liability:** When using Connect, platform operators bear financial liability for fraud and disputes on Express and Custom connected accounts. Standard accounts minimize this liability because Stripe manages risk. Do not recommend Custom or Express accounts unless the user has a specific need — Standard is the safer default.
+
+**Connect onboarding:** Use [Stripe-hosted onboarding](https://docs.stripe.com/connect/onboarding.md) rather than building a custom onboarding flow. Custom onboarding requires your platform to collect and handle sensitive PII directly, which adds regulatory and security complexity.
+
+## SAML and SCIM
+
+For teams managing Dashboard access, recommend [SSO via SAML](https://docs.stripe.com/get-started/account/sso.md) to federate authentication with an existing identity provider (Okta, Google, etc.). SSO centralizes access control and simplifies offboarding.
+
+[SCIM provisioning](https://docs.stripe.com/get-started/account/sso/scim.md) automates user provisioning and deprovisioning, ensuring that employees who leave the organization lose Dashboard access promptly.

--- a/.agents/skills/stripe-best-practices/references/treasury.md
+++ b/.agents/skills/stripe-best-practices/references/treasury.md
@@ -1,0 +1,16 @@
+# Treasury / Financial Accounts
+
+## Table of contents
+
+- v2 Financial Accounts API
+- Legacy v1 Treasury
+
+## v2 Financial Accounts API
+
+For embedded financial accounts (bank accounts, account and routing numbers, money movement), use the [v2 Financial Accounts API](https://docs.stripe.com/api/v2/core/vault/financial-accounts.md) (`POST /v2/core/vault/financial_accounts`). This is required for new integrations.
+
+For Treasury for platforms concepts and guides, see the [Treasury for platforms overview](https://docs.stripe.com/treasury/connect.md).
+
+## Legacy v1 Treasury
+
+Don’t use the [v1 Treasury Financial Accounts API](https://docs.stripe.com/api/treasury/financial_accounts.md) (`POST /v1/treasury/financial_accounts`) for new integrations. Existing v1 integrations continue to work.

--- a/.claude/skills/codeql
+++ b/.claude/skills/codeql
@@ -1,0 +1,1 @@
+../../.agents/skills/codeql

--- a/.claude/skills/design-taste-frontend
+++ b/.claude/skills/design-taste-frontend
@@ -1,0 +1,1 @@
+../../.agents/skills/design-taste-frontend

--- a/.claude/skills/differential-review
+++ b/.claude/skills/differential-review
@@ -1,0 +1,1 @@
+../../.agents/skills/differential-review

--- a/.claude/skills/github
+++ b/.claude/skills/github
@@ -1,0 +1,1 @@
+../../.agents/skills/github

--- a/.claude/skills/insecure-defaults
+++ b/.claude/skills/insecure-defaults
@@ -1,0 +1,1 @@
+../../.agents/skills/insecure-defaults

--- a/.claude/skills/property-based-testing
+++ b/.claude/skills/property-based-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/property-based-testing

--- a/.claude/skills/semgrep
+++ b/.claude/skills/semgrep
@@ -1,0 +1,1 @@
+../../.agents/skills/semgrep

--- a/.claude/skills/stripe-best-practices
+++ b/.claude/skills/stripe-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/stripe-best-practices

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "skills": {
+    "codeql": {
+      "source": "trailofbits/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/static-analysis/skills/codeql/SKILL.md",
+      "computedHash": "29d76ccd4cfc129351c1fc4ad2648f47bf3e8e01e3629ac0bdbbb86f7c339380"
+    },
+    "design-taste-frontend": {
+      "source": "leonxlnx/taste-skill",
+      "sourceType": "github",
+      "skillPath": "skills/taste-skill/SKILL.md",
+      "computedHash": "9d1e82c5c409d2b0247245a005bc0f7e4447c0999b78dcea60f568c1ba4a6694"
+    },
+    "differential-review": {
+      "source": "trailofbits/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/differential-review/skills/differential-review/SKILL.md",
+      "computedHash": "b5425d0ddf4b9828f481aa1b82a11a3b96145c498a64429d7fe6507b43d4ac04"
+    },
+    "github": {
+      "source": "callstackincubator/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/github/SKILL.md",
+      "computedHash": "32131aefe2317287d83e1d3ed5b2a83ca5b1a08142ee3b9bb4fc9d54ea348c31"
+    },
+    "insecure-defaults": {
+      "source": "trailofbits/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/insecure-defaults/skills/insecure-defaults/SKILL.md",
+      "computedHash": "1ea64ff138a430b6832cf6ad9db700957cf93b06ab6a36eaf2b2c351636aa7c7"
+    },
+    "property-based-testing": {
+      "source": "trailofbits/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/property-based-testing/skills/property-based-testing/SKILL.md",
+      "computedHash": "534153af7a54c94fc297625290a9f7055aa3b4ec8d9aaa77247463c25deab79c"
+    },
+    "semgrep": {
+      "source": "trailofbits/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/static-analysis/skills/semgrep/SKILL.md",
+      "computedHash": "c347b05c997fcc13dc17f3f289f1e02ccb66ffbe5212288a24048ab016e30930"
+    },
+    "stripe-best-practices": {
+      "source": "stripe/ai",
+      "sourceType": "github",
+      "skillPath": "skills/stripe-best-practices/SKILL.md",
+      "computedHash": "1d32ab705b1801928f68b8f0b839e5f43e8e83405bf14e72978ac4422ca4f052"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Installs 8 project-level agent skills + 1 user-level skill from the curated `docs/internal/skills-roadmap.md`. All visible to Claude Code immediately on next session start.

## What's installed (project-level — committed to `.agents/skills/` + symlinked into `.claude/skills/`)

| Skill | Phase | Why |
|---|---|---|
| `callstackincubator/agent-skills@github` | −1 | GitHub PR / branching / code-review patterns |
| `trailofbits/skills@codeql` | −1 | CodeQL static-analysis workflow guidance |
| `trailofbits/skills@semgrep` | −1 | Semgrep rules + invocation |
| `trailofbits/skills@insecure-defaults` | −1 | Hardcoded-secret + insecure-config detection |
| `trailofbits/skills@differential-review` | −1 | Security-focused diff review with git history |
| `leonxlnx/taste-skill@design-taste-frontend` | −1 | "Taste" skill (48K installs) — composition-first frontend |
| `stripe/ai@stripe-best-practices` | 0 | **Relevant immediately** — we're wiring the Stripe webhook now |
| `trailofbits/skills@property-based-testing` | 0 | **Relevant immediately** — license-key crypto |

User-level (added to `~/.claude/skills/`, NOT in this PR): `anthropics/skills@webapp-testing`.

Skills already in user config (no action): `anthropics/skills@skill-creator`, `anthropics/skills@mcp-builder`.

## Repo footprint
- ~456K of markdown content in `.agents/skills/`
- 8 symlinks (`.claude/skills/<X> -> ../../.agents/skills/<X>`)
- `skills-lock.json` (manifest with `computedHash` per skill — `npx skills check` flags upstream changes)

## Why commit the content (not just the lockfile)
Trade-off pick: 456K is small; clones become self-contained; new contributors don't need an extra `npx skills install` step. We accept slightly bigger diffs when upstream skills update — `npx skills check` + `update` periodically.

## Note on Stripe install path
The skills.sh listing shows `docs.stripe.com@stripe-best-practices` (19K installs) but that source can't be cloned (it's a docs-portal alias). Same Stripe-published content lives at `stripe/ai@stripe-best-practices` (6.9K installs) — used that. Captured in `skills-roadmap.md`.

## Next batch (deferred)
- `docs.stripe.com@upgrade-stripe` → first SDK upgrade
- `getsentry/sentry-{sdk-setup,react-sdk,node-sdk}` → when Sentry account exists (Phase 0-1)
- `cloudflare/{cloudflare,wrangler,cloudflare-email-service}` → when Cloudflare is in front (Phase 0-1) and the inbound-mail bridge is built (Phase 2)

## Test plan
- [x] All 9 skills installed cleanly via `npx skills add <pkg> [-g] -y`
- [x] Verified all 8 project skills present in `.claude/skills/` (symlinks resolve)
- [x] `skills-lock.json` records hashes
- [ ] Confirm Claude Code surfaces them in next session's available-skills list (already visible in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)