### PR TITLE
fix(e2e): isolate release-notes auto-subscribe from feed-endpoint mock

### DIFF
--- a/tests/e2e/feed-fixtures.ts
+++ b/tests/e2e/feed-fixtures.ts
@@ -147,6 +147,21 @@ export async function mockFeedEndpoint(page: Page, feedContent: string) {
     : "text/xml";
 
   await page.route("**/api/feed*", (route) => {
+    // The app auto-subscribes to the release-notes feed on first launch
+    // (`CHANGELOG_FEED_URL = https://feedzero.app/releases.xml`). It goes
+    // through the same `/api/feed?url=...` proxy as user-added feeds. If we
+    // respond with `feedContent` here too, the release-notes feed lands in
+    // the sidebar with the SAME title as the test feed — selectors that
+    // filter by title resolve to two elements and Playwright fails with
+    // strict-mode violations.
+    //
+    // Auto-subscribe is wrapped in try/catch (best-effort), so 404 here is
+    // silently swallowed and no rogue feed appears in the sidebar.
+    const url = route.request().url();
+    if (url.includes("releases.xml")) {
+      route.fulfill({ status: 404, body: "not found in test" });
+      return;
+    }
     route.fulfill({
       status: 200,
       contentType,


### PR DESCRIPTION
## Summary
- Resolves the duplicate \`menu-button\` rendering that was making 4 of 4 shards fail on PR #29 (e2e speedup) and was a latent flake in pre-existing single-job e2e runs.
- One-line fix in \`tests/e2e/feed-fixtures.ts\` — returns 404 for the release-notes URL inside \`mockFeedEndpoint\`.

## Root cause (one-liner)
\`mockFeedEndpoint\` matched \`**/api/feed*\` for every request including the first-launch auto-subscribe to \`https://feedzero.app/releases.xml\`. The mock served the same "Test Feed" content to both, so two feeds with the same title landed in the sidebar.

## Why this bug was latent until now
- The previous single-job e2e config used 2 retries; it sometimes scraped through
- PR #29 adds sharding + \`--max-failures=5\` which exposes the failure deterministically

## Test plan
- [x] Locally re-ran shard 1/4 with the fix: 19 passed (was 17). The remaining 2 failures (`mobile › feed selection shows article list`, `extracted content is cached on toggle`) are pre-existing local-environment flakes that also reproduce on \`main\` without this PR's changes — not introduced here.
- [ ] Watch this PR's own e2e run to confirm it's green on CI
- [ ] After merge: rebase #29 and confirm the 4 shards turn green

🤖 Generated with [Claude Code](https://claude.com/claude-code)