### PR TITLE
fix(dev-proxy): forward all request headers, not just Content-Type

### DIFF
--- a/tests/vite-dev-proxy.test.ts
+++ b/tests/vite-dev-proxy.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { Readable } from "node:stream";
+import { toWebRequest } from "../vite-dev-proxy.js";
+
+/**
+ * Minimal IncomingMessage stand-in: a Readable stream that yields the body
+ * and exposes the metadata fields toWebRequest reads (method, url, headers).
+ */
+function fakeIncomingMessage(opts: {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[]>;
+  body?: string;
+}): Readable & { method: string; url: string; headers: Record<string, string | string[]> } {
+  const stream = Readable.from(opts.body ? [Buffer.from(opts.body)] : []) as Readable & {
+    method: string;
+    url: string;
+    headers: Record<string, string | string[]>;
+  };
+  stream.method = opts.method;
+  stream.url = opts.url;
+  stream.headers = opts.headers;
+  return stream;
+}
+
+describe("toWebRequest — header forwarding", () => {
+  it("forwards Stripe-Signature header (the bug that triggered this test)", async () => {
+    const req = fakeIncomingMessage({
+      method: "POST",
+      url: "/api/stripe/webhook",
+      headers: {
+        "content-type": "application/json",
+        "stripe-signature": "t=1700000000,v1=abc123",
+      },
+      body: '{"type":"x"}',
+    });
+    const webReq = await toWebRequest(req);
+    expect(webReq.headers.get("stripe-signature")).toBe("t=1700000000,v1=abc123");
+  });
+
+  it("forwards Authorization header (license-bearer endpoints depend on this)", async () => {
+    const req = fakeIncomingMessage({
+      method: "POST",
+      url: "/api/license/verify",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer fz_payload.sig",
+      },
+      body: "{}",
+    });
+    const webReq = await toWebRequest(req);
+    expect(webReq.headers.get("authorization")).toBe("Bearer fz_payload.sig");
+  });
+
+  it("preserves Content-Type (regression of original behavior)", async () => {
+    const req = fakeIncomingMessage({
+      method: "POST",
+      url: "/api/feedback",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    const webReq = await toWebRequest(req);
+    expect(webReq.headers.get("content-type")).toBe("application/json");
+  });
+
+  it("collapses array-valued headers to a comma-joined string", async () => {
+    // Node IncomingMessage represents some duplicated headers as arrays.
+    // Web Request headers store them as comma-joined per RFC 7230.
+    const req = fakeIncomingMessage({
+      method: "POST",
+      url: "/api/x",
+      headers: {
+        "content-type": "application/json",
+        "x-multi": ["a", "b", "c"],
+      },
+    });
+    const webReq = await toWebRequest(req);
+    expect(webReq.headers.get("x-multi")).toBe("a, b, c");
+  });
+
+  it("skips HTTP/2 pseudo-headers (would crash Web Request constructor)", async () => {
+    const req = fakeIncomingMessage({
+      method: "GET",
+      url: "/api/health",
+      headers: {
+        ":path": "/api/health",
+        ":method": "GET",
+        "user-agent": "test",
+      },
+    });
+    // Should not throw; pseudo-headers (`:path`, `:method`) silently skipped,
+    // legitimate headers preserved.
+    const webReq = await toWebRequest(req);
+    expect(webReq.headers.get("user-agent")).toBe("test");
+    expect(webReq.headers.get(":path")).toBeNull();
+  });
+
+  it("does not forward a body for GET requests", async () => {
+    const req = fakeIncomingMessage({
+      method: "GET",
+      url: "/api/health",
+      headers: { "content-type": "application/json" },
+    });
+    const webReq = await toWebRequest(req);
+    expect(webReq.body).toBeNull();
+  });
+
+  it("forwards the body for POST", async () => {
+    const req = fakeIncomingMessage({
+      method: "POST",
+      url: "/api/x",
+      headers: { "content-type": "application/json" },
+      body: '{"hello":"world"}',
+    });
+    const webReq = await toWebRequest(req);
+    const body = await webReq.text();
+    expect(body).toBe('{"hello":"world"}');
+  });
+});

--- a/vite-dev-proxy.d.ts
+++ b/vite-dev-proxy.d.ts
@@ -1,0 +1,18 @@
+import type { ServerResponse } from "node:http";
+
+/**
+ * Structural subset of Node IncomingMessage that {@link toWebRequest} actually reads.
+ * Defined narrowly here so test fakes (and any future caller) only need to
+ * satisfy what the function uses, not the full Node type surface.
+ */
+export interface IncomingMessageLike extends AsyncIterable<Buffer> {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+export function toWebRequest(req: IncomingMessageLike): Promise<Request>;
+export function sendWebResponse(
+  webRes: Response,
+  res: ServerResponse,
+): Promise<void>;

--- a/vite-dev-proxy.js
+++ b/vite-dev-proxy.js
@@ -1,0 +1,51 @@
+/**
+ * Helpers for the Vite dev-server API proxy plugin.
+ *
+ * Extracted from vite.config.js so the request/response translation can be
+ * unit-tested independently of running the full Vite server. The dev-proxy
+ * has historically been a source of bugs that only surface end-to-end (e.g.
+ * the Stripe webhook signature dropped because Content-Type was the only
+ * header forwarded). Pinning these helpers in tests/vite-dev-proxy.test.ts
+ * catches that class of regression locally rather than in a manual smoke run.
+ */
+
+/**
+ * Convert a Node IncomingMessage to a Web standard Request.
+ *
+ * Forwards every request header (with HTTP/2 pseudo-headers like `:path`
+ * skipped because the Web Request constructor rejects them). The body is
+ * read and re-attached for non-GET/HEAD methods so handlers can call
+ * `request.text()` / `request.json()` once.
+ */
+export async function toWebRequest(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const bodyStr = Buffer.concat(chunks).toString();
+
+  const url = new URL(req.url, "http://localhost");
+  const hasBody = req.method !== "GET" && req.method !== "HEAD";
+
+  const headers = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (name.startsWith(":")) continue;
+    if (Array.isArray(value)) headers[name] = value.join(", ");
+    else if (typeof value === "string") headers[name] = value;
+  }
+
+  return new Request(url, {
+    method: req.method,
+    headers,
+    ...(hasBody ? { body: bodyStr } : {}),
+  });
+}
+
+/**
+ * Pipe a Web standard Response into a Node ServerResponse.
+ */
+export async function sendWebResponse(webRes, res) {
+  res.statusCode = webRes.status;
+  for (const [key, value] of webRes.headers.entries()) {
+    res.setHeader(key, value);
+  }
+  res.end(Buffer.from(await webRes.arrayBuffer()));
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,34 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
-
-/**
- * Converts a Node IncomingMessage to a Web Request object.
- */
-async function toWebRequest(req) {
-  const chunks = [];
-  for await (const chunk of req) chunks.push(chunk);
-  const bodyStr = Buffer.concat(chunks).toString();
-
-  const url = new URL(req.url, "http://localhost");
-  const hasBody = req.method !== "GET" && req.method !== "HEAD";
-  return new Request(url, {
-    method: req.method,
-    headers: { "Content-Type": req.headers["content-type"] || "" },
-    ...(hasBody ? { body: bodyStr } : {}),
-  });
-}
-
-/**
- * Sends a Web Response through a Node ServerResponse.
- */
-async function sendWebResponse(webRes, res) {
-  res.statusCode = webRes.status;
-  for (const [key, value] of webRes.headers.entries()) {
-    res.setHeader(key, value);
-  }
-  res.end(Buffer.from(await webRes.arrayBuffer()));
-}
+import { toWebRequest, sendWebResponse } from "./vite-dev-proxy.js";
 
 /**
  * Dev server API proxy plugin.


### PR DESCRIPTION
## Summary

Found while running the Phase 0 end-to-end smoke test (Stripe CLI → local Vite dev → license issuer). The dev-proxy's \`toWebRequest()\` was only forwarding \`Content-Type\` and dropping every other header — including \`Stripe-Signature\` — so locally every Stripe webhook test returned 400 "Missing Stripe-Signature header" while production (Vercel) worked fine.

This is exactly the kind of three-entry-point divergence CLAUDE.md warns about. Production behavior was correct; dev was silently broken.

## Closes

- Implicit blocker on local Stripe-CLI testing of the PR #33 webhook endpoint

## Test plan

- [x] \`npm test\` — 1671 pass, 2 skipped (no regressions)
- [x] \`npx tsc --noEmit\` — clean
- [x] **End-to-end smoke**: \`stripe listen\` + \`npm run dev\` + \`stripe trigger customer.subscription.created\`. Before fix: 12 events all 400. After fix: 12 events all 200, including \`customer.subscription.created\` correctly dispatching to \`LicenseIssuerImpl.issue()\`.
- [x] New unit tests in \`tests/vite-dev-proxy.test.ts\` pin 7 contracts on the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)