### PR TITLE
feat(stripe): event-id idempotency + LAUNCH_PAID_TIER flag (PR V)

### DIFF
--- a/api/stripe/webhook.ts
+++ b/api/stripe/webhook.ts
@@ -1,15 +1,17 @@
 import { handleStripeWebhook } from "../../src/core/stripe/webhook-handler";
 import { LicenseIssuerImpl } from "../../src/core/license/issuer";
 import { resolveLicenseStorage } from "../../src/core/license/resolve-storage";
+import { resolveSeenEventStore } from "../../src/core/stripe/resolve-seen-event-store";
 import { isFlagEnabled } from "../../src/core/flags/flags";
 
 const signingSecret = process.env.LICENSE_SIGNING_KEY ?? "";
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET ?? "";
 
-// Resolve storage once at module load — Vercel keeps the function instance
-// warm across invocations so this isn't repeated per request. Upstash when
-// env vars are present, MemoryLicenseStorage otherwise (dev/preview).
+// Resolve storage and dedup store once at module load — Vercel keeps the
+// function instance warm across invocations so this isn't repeated per
+// request. Upstash when env vars are present, in-memory otherwise.
 const storagePromise = resolveLicenseStorage();
+const eventStorePromise = resolveSeenEventStore();
 const issuerPromise = storagePromise.then(
   (storage) =>
     new LicenseIssuerImpl({
@@ -19,10 +21,14 @@ const issuerPromise = storagePromise.then(
 );
 
 export async function POST(req: Request): Promise<Response> {
-  const issuer = await issuerPromise;
+  const [issuer, eventStore] = await Promise.all([
+    issuerPromise,
+    eventStorePromise,
+  ]);
   return handleStripeWebhook(req, {
     signingSecret: webhookSecret,
     issuer,
+    eventStore,
     killSignups: () => isFlagEnabled("KILL_SIGNUPS"),
   });
 }

--- a/server.ts
+++ b/server.ts
@@ -9,6 +9,7 @@ import { handleHealthRequest } from "./src/core/health/health-handler";
 import { handleStripeWebhook } from "./src/core/stripe/webhook-handler";
 import { handleLicenseVerifyRequest } from "./src/core/license/verify-handler";
 import { handleLicenseIssueRequest } from "./src/core/license/issue-handler";
+import type { SeenEventStore } from "./src/core/stripe/seen-event-store";
 import { LicenseIssuerImpl } from "./src/core/license/issuer";
 import {
   MemoryLicenseStorage,
@@ -37,6 +38,12 @@ export interface LicenseDeps {
   webhookSigningSecret?: string;
   /** Caller-injected for the verify handler in tests. Defaults to wallclock. */
   nowSec?: number;
+  /**
+   * Optional Stripe event-id dedup store. If present, the webhook handler
+   * skips re-dispatch on duplicate `event.id`. Tests typically pass a
+   * MemorySeenEventStore; production wires Upstash via resolveSeenEventStore.
+   */
+  eventStore?: SeenEventStore;
 }
 
 function buildLicenseDeps(): LicenseDeps {
@@ -171,6 +178,7 @@ export function createApp(
     handleStripeWebhook(c.req.raw, {
       signingSecret: license.webhookSigningSecret ?? "",
       issuer,
+      eventStore: license.eventStore,
       killSignups: () => isFlagEnabled("KILL_SIGNUPS"),
     }),
   );
@@ -201,18 +209,25 @@ async function startServer(): Promise<void> {
   const { resolveLicenseStorage } = await import(
     "./src/core/license/resolve-storage"
   );
+  const { resolveSeenEventStore } = await import(
+    "./src/core/stripe/resolve-seen-event-store"
+  );
 
   const adapter = resolveAdapter();
   const cache = createFeedCache();
   const catalog = createMemoryCatalogAdapter();
-  // Pre-resolve the license storage so createApp stays synchronous.
-  // Picks UpstashLicenseStorage when UPSTASH_REDIS_REST_URL+TOKEN are set,
-  // MemoryLicenseStorage otherwise (dev / self-hosted without Redis).
-  const licenseStorage = await resolveLicenseStorage();
+  // Pre-resolve the license storage and Stripe-event dedup store so
+  // createApp stays synchronous. Both pick Upstash when UPSTASH_*/KV_* env
+  // vars are set, in-memory otherwise.
+  const [licenseStorage, eventStore] = await Promise.all([
+    resolveLicenseStorage(),
+    resolveSeenEventStore(),
+  ]);
   const licenseDeps: LicenseDeps = {
     signingKey: { secret: process.env.LICENSE_SIGNING_KEY ?? "" },
     storage: licenseStorage,
     webhookSigningSecret: process.env.STRIPE_WEBHOOK_SECRET ?? "",
+    eventStore,
   };
   const app = createApp(adapter, cache, catalog, licenseDeps);
 

--- a/src/core/flags/flags.ts
+++ b/src/core/flags/flags.ts
@@ -26,7 +26,18 @@ export type FlagName =
   | "KILL_ALERTS"
   | "KILL_FETCHERS"
   | "KILL_SIGNUPS"
-  | "READONLY_SYNC";
+  | "READONLY_SYNC"
+  /**
+   * Master pre-launch gate for Phase 1 (paid tier). When unset/0, the paid
+   * features ship dormant: /api/sync stays free, frontend hides Subscribe.
+   * When set to "1", /api/sync requires a Bearer license (PR W) and the
+   * frontend reveals the Subscribe surface (PR Y, via VITE_*).
+   *
+   * Intentionally distinct from KILL_SIGNUPS, which is operational
+   * (turn off NEW signups during incident, paid tier still active for
+   * existing customers).
+   */
+  | "LAUNCH_PAID_TIER";
 
 /**
  * Returns true iff the named flag is enabled.

--- a/src/core/license/storage-upstash.ts
+++ b/src/core/license/storage-upstash.ts
@@ -40,9 +40,15 @@ export interface UpstashClient {
   // record at the call site via the generic.
   get<T = unknown>(key: string): Promise<T | null>;
   // Upstash returns `"OK"` on success but the SDK types it `Promise<unknown>`
-  // because of optional NX/XX flags. We don't read the return value, so the
-  // permissive type is fine.
-  set(key: string, value: unknown): Promise<unknown>;
+  // because of optional NX/XX flags. The optional `opts` bag (nx, ex) is
+  // unused by the license adapter itself but matches the wider Upstash SDK
+  // signature so the same Redis client can be passed to other adapters
+  // (e.g. seen-event-store).
+  set(
+    key: string,
+    value: unknown,
+    opts?: { nx?: boolean; ex?: number },
+  ): Promise<unknown>;
   sadd(key: string, ...members: string[]): Promise<number>;
   smembers(key: string): Promise<string[]>;
   exists(key: string): Promise<number>;

--- a/src/core/stripe/resolve-seen-event-store.ts
+++ b/src/core/stripe/resolve-seen-event-store.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolve the SeenEventStore based on environment.
+ *
+ * Mirrors `src/core/license/resolve-storage.ts` — same env-var precedence
+ * (UPSTASH_* canonical first, KV_REST_API_* Vercel-Marketplace legacy second),
+ * same fallback to in-memory for dev/test/self-hosted-without-Redis.
+ *
+ * In production, the underlying Upstash REST client used here is *the same*
+ * Redis as the one used by `UpstashLicenseStorage` — we just open another
+ * connection. If we wanted to share one connection later, we'd extract a
+ * single `createUpstashClient()` factory; for now the SDK's connection
+ * pooling makes this a non-issue.
+ */
+
+import {
+  MemorySeenEventStore,
+  UpstashSeenEventStore,
+  type SeenEventStore,
+} from "./seen-event-store";
+import { hasUpstashCredentials } from "../license/storage-upstash";
+
+export async function resolveSeenEventStore(
+  env: Record<string, string | undefined> = process.env,
+): Promise<SeenEventStore> {
+  if (!hasUpstashCredentials(env)) {
+    return new MemorySeenEventStore();
+  }
+  const url = env.UPSTASH_REDIS_REST_URL ?? env.KV_REST_API_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN ?? env.KV_REST_API_TOKEN;
+  // Dynamic import — keeps the SDK out of dev/test bundles when Upstash
+  // is not configured.
+  const { Redis } = await import("@upstash/redis");
+  return new UpstashSeenEventStore(
+    new Redis({ url: url as string, token: token as string }),
+  );
+}

--- a/src/core/stripe/seen-event-store.ts
+++ b/src/core/stripe/seen-event-store.ts
@@ -1,0 +1,100 @@
+/**
+ * Stripe webhook event-id deduplication.
+ *
+ * Stripe documents that "webhook endpoints occasionally receive the same
+ * event multiple times" — primarily from automatic retries on non-2xx
+ * responses (up to 3 days in live mode) and manual resends from the
+ * dashboard or CLI. Without dedup, our LicenseIssuer would mint a second
+ * license token for the same Stripe subscription on every retry.
+ *
+ * Pattern (per Stripe docs and Redis distributed-lock best practice):
+ *   - Atomic SET NX (set-if-not-exists) on `stripe:event:<event.id>`
+ *   - TTL ≥ 3 days (Stripe's longest retry window). We use 7 days for headroom.
+ *   - Returns true on first sight (caller proceeds with dispatch),
+ *     false on duplicate (caller skips with 200 alreadyProcessed).
+ *
+ * Why a Redis SET NX (not a check-then-write):
+ *   - Concurrent retries hit different function instances on Vercel.
+ *     Without atomicity, two simultaneous retries both read "not seen",
+ *     both write, both dispatch — issuer mints two tokens.
+ *   - SET NX is the canonical Redis primitive for "atomic create-if-absent".
+ *
+ * The store is intentionally Stripe-event-shaped, not a generic
+ * "have-i-seen-this-string" key-value. Keeping it scoped means we can
+ * specialize key shape, TTL, and behavior independently of license storage.
+ */
+
+import { type Result, ok, err } from "../../utils/result";
+
+/**
+ * Subset of the Upstash Redis client used by {@link UpstashSeenEventStore}.
+ * Defined here narrowly so test fakes don't need to satisfy the full SDK.
+ */
+export interface UpstashClientForEvents {
+  set(
+    key: string,
+    value: unknown,
+    opts?: { nx?: boolean; ex?: number },
+  ): Promise<unknown>;
+}
+
+export interface SeenEventStore {
+  /**
+   * Atomically mark `eventId` as seen.
+   *
+   * @returns ok(true)  if the eventId is new (caller should dispatch).
+   *          ok(false) if the eventId was already seen (caller should skip
+   *                     and respond 200 alreadyProcessed).
+   *          err(...)  on storage failure (caller returns 500 so Stripe retries).
+   */
+  markSeenIfNew(eventId: string): Promise<Result<boolean>>;
+}
+
+const KEY_PREFIX = "stripe:event:";
+/** 7 days — comfortably past Stripe's 3-day live-mode retry window. */
+const DEFAULT_TTL_SEC = 7 * 24 * 60 * 60;
+
+/**
+ * In-memory implementation. Used by tests, the dev server, and as the
+ * reference implementation that pins the contract. Production uses
+ * {@link UpstashSeenEventStore}.
+ *
+ * Memory has no TTL — entries live until process restart. That's acceptable
+ * for dev because a process-local restart effectively "expires" everything.
+ */
+export class MemorySeenEventStore implements SeenEventStore {
+  private readonly seen = new Set<string>();
+
+  async markSeenIfNew(eventId: string): Promise<Result<boolean>> {
+    if (this.seen.has(eventId)) return ok(false);
+    this.seen.add(eventId);
+    return ok(true);
+  }
+}
+
+/**
+ * Upstash Redis-backed implementation. Uses SET NX EX for atomic
+ * check-and-set. Concurrent retries to different Vercel function instances
+ * see consistent dedup because Upstash operations are atomic at the
+ * Redis-key level.
+ */
+export class UpstashSeenEventStore implements SeenEventStore {
+  constructor(
+    private readonly client: UpstashClientForEvents,
+    private readonly ttlSec: number = DEFAULT_TTL_SEC,
+  ) {}
+
+  async markSeenIfNew(eventId: string): Promise<Result<boolean>> {
+    try {
+      const result = await this.client.set(KEY_PREFIX + eventId, "1", {
+        nx: true,
+        ex: this.ttlSec,
+      });
+      // Upstash returns "OK" on success, null when NX condition failed.
+      return ok(result === "OK");
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return err(`upstash seen-event-store error: ${message}`);
+    }
+  }
+}

--- a/src/core/stripe/webhook-handler.ts
+++ b/src/core/stripe/webhook-handler.ts
@@ -3,18 +3,19 @@
  *
  * Verifies the `Stripe-Signature` header against the raw request body using
  * HMAC-SHA256 (per Stripe's manual verification spec [1]), parses the event,
- * and dispatches to per-event methods on a {@link LicenseIssuer} collaborator.
+ * deduplicates by `event.id` if a {@link SeenEventStore} is configured, and
+ * dispatches to per-event methods on a {@link LicenseIssuer} collaborator.
  *
- * Idempotency is the responsibility of the {@link LicenseIssuer}
- * implementation. The natural idempotency key is `subscriptionId` for
- * issue/renewal flows. A future PR can add an
- * `event:processed:<event.id>` set if duplicate-delivery becomes a problem
- * in production.
+ * Stripe sends each event up to 3 days (live mode) on retry — without
+ * idempotency the issuer mints a duplicate license token on every retry.
+ * The dedup check happens AFTER signature verification so an attacker
+ * cannot fill the dedup store with garbage event IDs from unsigned probes.
  *
  * [1] https://stripe.com/docs/webhooks#verify-manually
  */
 
 import type { Result } from "../../utils/result";
+import type { SeenEventStore } from "./seen-event-store";
 
 export interface LicenseIssuer {
   issue(args: {
@@ -55,6 +56,14 @@ export interface WebhookConfig {
    * always-allow.
    */
   killSignups?: () => boolean;
+  /**
+   * Optional event-id dedup store. When configured, duplicate deliveries
+   * (Stripe retries the same `event.id`) return 200 without re-dispatching.
+   * When absent (e.g. tests, or if KV is unavailable), the handler falls
+   * back to always-dispatch — relying on the issuer's own per-subscription
+   * idempotency for safety.
+   */
+  eventStore?: SeenEventStore;
 }
 
 const DEFAULT_TOLERANCE_SEC = 300;
@@ -381,6 +390,22 @@ export async function handleStripeWebhook(
     return jsonResponse({ ok: false, error: "signups disabled" }, 503);
   }
 
-  const outcome = await dispatchEvent(verified.value.event, config.issuer);
+  // Event-id dedup. Runs after signature verification (so unsigned probes
+  // cannot pollute the dedup store) and after KILL_SIGNUPS (so a kill-switch
+  // 503 still makes Stripe retry without burning the eventId).
+  const event = verified.value.event;
+  if (config.eventStore && event.id) {
+    const newSeen = await config.eventStore.markSeenIfNew(event.id);
+    if (!newSeen.ok) {
+      // Storage failure — return 500 so Stripe retries.
+      return jsonResponse({ ok: false, error: newSeen.error }, 500);
+    }
+    if (!newSeen.value) {
+      // Duplicate delivery — Stripe doc: return 200 immediately, do not re-dispatch.
+      return jsonResponse({ ok: true, alreadyProcessed: true }, 200);
+    }
+  }
+
+  const outcome = await dispatchEvent(event, config.issuer);
   return jsonResponse(outcome.body, outcome.status);
 }

--- a/tests/core/stripe/resolve-seen-event-store.test.ts
+++ b/tests/core/stripe/resolve-seen-event-store.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { resolveSeenEventStore } from "@/core/stripe/resolve-seen-event-store";
+import {
+  MemorySeenEventStore,
+  UpstashSeenEventStore,
+} from "@/core/stripe/seen-event-store";
+
+describe("resolveSeenEventStore", () => {
+  it("returns MemorySeenEventStore when Upstash env is missing", async () => {
+    const store = await resolveSeenEventStore({});
+    expect(store).toBeInstanceOf(MemorySeenEventStore);
+  });
+
+  it("returns UpstashSeenEventStore when canonical UPSTASH_* env is set", async () => {
+    const store = await resolveSeenEventStore({
+      UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+      UPSTASH_REDIS_REST_TOKEN: "tok",
+    });
+    expect(store).toBeInstanceOf(UpstashSeenEventStore);
+  });
+
+  it("returns UpstashSeenEventStore when only Vercel-Marketplace KV_REST_API_* is set", async () => {
+    // Same shape as resolveLicenseStorage — Vercel's Marketplace integration
+    // injects the legacy KV_REST_API_* names instead of canonical UPSTASH_*.
+    const store = await resolveSeenEventStore({
+      KV_REST_API_URL: "https://example.upstash.io",
+      KV_REST_API_TOKEN: "tok",
+    });
+    expect(store).toBeInstanceOf(UpstashSeenEventStore);
+  });
+});

--- a/tests/core/stripe/seen-event-store.test.ts
+++ b/tests/core/stripe/seen-event-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  MemorySeenEventStore,
+  UpstashSeenEventStore,
+  type UpstashClientForEvents,
+} from "@/core/stripe/seen-event-store";
+
+describe("MemorySeenEventStore", () => {
+  it("first call for an eventId returns ok(true) (newly inserted)", async () => {
+    const store = new MemorySeenEventStore();
+    const result = await store.markSeenIfNew("evt_abc");
+    expect(result.ok && result.value).toBe(true);
+  });
+
+  it("second call for the same eventId returns ok(false) (duplicate)", async () => {
+    const store = new MemorySeenEventStore();
+    await store.markSeenIfNew("evt_abc");
+    const second = await store.markSeenIfNew("evt_abc");
+    expect(second.ok && second.value).toBe(false);
+  });
+
+  it("different eventIds are tracked independently", async () => {
+    const store = new MemorySeenEventStore();
+    const a = await store.markSeenIfNew("evt_a");
+    const b = await store.markSeenIfNew("evt_b");
+    const aDup = await store.markSeenIfNew("evt_a");
+    expect(a.ok && a.value).toBe(true);
+    expect(b.ok && b.value).toBe(true);
+    expect(aDup.ok && aDup.value).toBe(false);
+  });
+});
+
+describe("UpstashSeenEventStore", () => {
+  /**
+   * Fake Upstash client modeling SET NX EX semantics. Returns "OK" when the
+   * key was newly set (NX condition met), null when the key already existed
+   * (NX condition failed). Mirrors Upstash REST API behavior.
+   */
+  function fakeClient(): UpstashClientForEvents & { _store: Map<string, unknown> } {
+    const store = new Map<string, unknown>();
+    return {
+      _store: store,
+      async set(key, value, opts) {
+        if (opts?.nx && store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      },
+    };
+  }
+
+  it("first call for an eventId returns ok(true) (Upstash returned 'OK')", async () => {
+    const store = new UpstashSeenEventStore(fakeClient());
+    const result = await store.markSeenIfNew("evt_abc");
+    expect(result.ok && result.value).toBe(true);
+  });
+
+  it("second call for the same eventId returns ok(false) (Upstash returned null)", async () => {
+    const store = new UpstashSeenEventStore(fakeClient());
+    await store.markSeenIfNew("evt_abc");
+    const second = await store.markSeenIfNew("evt_abc");
+    expect(second.ok && second.value).toBe(false);
+  });
+
+  it("uses key prefix 'stripe:event:' so dedup keys don't collide with license records", async () => {
+    const fake = fakeClient();
+    const store = new UpstashSeenEventStore(fake);
+    await store.markSeenIfNew("evt_abc");
+    expect(fake._store.has("stripe:event:evt_abc")).toBe(true);
+  });
+
+  it("calls SET with NX (atomic) and EX (TTL) per Stripe's 3-day retry window", async () => {
+    const calls: Array<{ opts?: { nx?: boolean; ex?: number } }> = [];
+    const store = new UpstashSeenEventStore({
+      async set(_key, _value, opts) {
+        calls.push({ opts });
+        return "OK";
+      },
+    });
+    await store.markSeenIfNew("evt_abc");
+    expect(calls[0].opts?.nx).toBe(true);
+    // Must be at least 3 days (Stripe's retry window) — we use 7 for headroom.
+    expect(calls[0].opts?.ex).toBeGreaterThanOrEqual(3 * 24 * 60 * 60);
+  });
+
+  it("returns err on storage exception (e.g. Upstash unreachable)", async () => {
+    const store = new UpstashSeenEventStore({
+      async set() {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    const result = await store.markSeenIfNew("evt_abc");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/upstash|ECONNREFUSED/i);
+  });
+});

--- a/tests/core/stripe/webhook-handler.test.ts
+++ b/tests/core/stripe/webhook-handler.test.ts
@@ -13,6 +13,7 @@ import {
   type StripeFixture,
 } from "@/core/stripe/test-fixtures";
 import { ok, err } from "@/utils/result";
+import { MemorySeenEventStore } from "@/core/stripe/seen-event-store";
 
 const ENDPOINT = "http://localhost/api/stripe/webhook";
 const SECRET = "whsec_test_secret_value";
@@ -308,6 +309,130 @@ describe("handleStripeWebhook", () => {
         postFixture(fixture, nowSec()),
         makeConfig(issuer, { killSignups: () => false }),
       );
+      expect(res.status).toBe(200);
+      expect(issuer.issue).toHaveBeenCalled();
+    });
+  });
+
+  describe("event idempotency", () => {
+    it("dispatches first delivery of an event to the issuer", async () => {
+      const eventStore = new MemorySeenEventStore();
+      const fixture = subscriptionCreatedEvent({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        tier: "personal",
+      });
+      const res = await handleStripeWebhook(
+        postFixture(fixture, nowSec()),
+        makeConfig(issuer, { eventStore }),
+      );
+      expect(res.status).toBe(200);
+      expect(issuer.issue).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns 200 alreadyProcessed on duplicate delivery and does NOT re-dispatch", async () => {
+      // Simulates Stripe's automatic retry after a missed 2xx response.
+      // The issuer must be called exactly once across both deliveries.
+      const eventStore = new MemorySeenEventStore();
+      const fixture = subscriptionCreatedEvent({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        tier: "personal",
+      });
+
+      const ts = nowSec();
+      const first = await handleStripeWebhook(
+        postFixture(fixture, ts),
+        makeConfig(issuer, { eventStore }),
+      );
+      expect(first.status).toBe(200);
+
+      const second = await handleStripeWebhook(
+        postFixture(fixture, ts),
+        makeConfig(issuer, { eventStore }),
+      );
+      expect(second.status).toBe(200);
+      const body = await second.json();
+      expect(body).toMatchObject({ ok: true, alreadyProcessed: true });
+
+      expect(issuer.issue).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns 500 when eventStore returns Result.err so Stripe retries", async () => {
+      const failingStore = {
+        markSeenIfNew: async () => err("upstash unreachable"),
+      };
+      const fixture = subscriptionCreatedEvent({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        tier: "personal",
+      });
+      const res = await handleStripeWebhook(
+        postFixture(fixture, nowSec()),
+        makeConfig(issuer, { eventStore: failingStore }),
+      );
+      expect(res.status).toBe(500);
+      expect(issuer.issue).not.toHaveBeenCalled();
+    });
+
+    it("dispatches normally when no eventStore is configured (backward compat)", async () => {
+      // Existing call sites (and any future ones) that don't pass eventStore
+      // must keep working — no idempotency, but no crash either.
+      const fixture = subscriptionCreatedEvent({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        tier: "personal",
+      });
+      const res = await handleStripeWebhook(
+        postFixture(fixture, nowSec()),
+        makeConfig(issuer),
+      );
+      expect(res.status).toBe(200);
+      expect(issuer.issue).toHaveBeenCalled();
+    });
+
+    it("dedup happens AFTER signature verification (auth-not-bypassable)", async () => {
+      // An attacker probing webhook behavior with bad signatures must not
+      // be able to fill the dedup store with garbage event IDs.
+      const calls: string[] = [];
+      const eventStore = {
+        markSeenIfNew: async (id: string) => {
+          calls.push(id);
+          return ok(true);
+        },
+      };
+      const req = new Request(ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Stripe-Signature": "t=1,v1=deadbeef",
+        },
+        body: JSON.stringify({ id: "evt_attacker", type: "x" }),
+      });
+      const res = await handleStripeWebhook(
+        req,
+        makeConfig(issuer, { eventStore }),
+      );
+      expect(res.status).toBe(400);
+      expect(calls).toEqual([]); // store never touched
+    });
+
+    it("skips dedup for events without an id (defensive)", async () => {
+      // Stripe always sends event.id, but we guard against malformed input
+      // so a missing id doesn't crash the store call.
+      const eventStore = new MemorySeenEventStore();
+      const fixture = subscriptionCreatedEvent({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        tier: "personal",
+      });
+      // Strip the id from the fixture event
+      delete (fixture.event as { id?: string }).id;
+      const res = await handleStripeWebhook(
+        postFixture(fixture, nowSec()),
+        makeConfig(issuer, { eventStore }),
+      );
+      // Should still process (no crash); we just don't dedup.
       expect(res.status).toBe(200);
       expect(issuer.issue).toHaveBeenCalled();
     });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1033,6 +1033,43 @@ describe("server", () => {
     });
   });
 
+  describe("vercel wrapper structural invariants", () => {
+    // Tier 2 (Structural Assertion) tests. Vercel wrappers in api/*.ts are
+    // thin glue files whose only behavioral tests are routing contracts.
+    // But a wrapper can silently drop a critical option (e.g. eventStore for
+    // Stripe idempotency, adminApiKey for /api/license/issue) and still
+    // export POST cleanly — the routing contract passes, the handler tests
+    // pass, but production silently runs without that option. These tests
+    // assert the wrapper SOURCE references the options, catching that bug.
+    const fs = require("node:fs") as typeof import("node:fs");
+
+    it("api/stripe/webhook.ts wires eventStore for idempotency", () => {
+      const src = fs.readFileSync("api/stripe/webhook.ts", "utf8");
+      expect(src).toMatch(/resolveSeenEventStore/);
+      expect(src).toMatch(/eventStore/);
+    });
+
+    it("api/stripe/webhook.ts wires KILL_SIGNUPS gate", () => {
+      const src = fs.readFileSync("api/stripe/webhook.ts", "utf8");
+      expect(src).toMatch(/KILL_SIGNUPS/);
+    });
+
+    it("api/license/issue.ts wires ADMIN_API_KEY", () => {
+      const src = fs.readFileSync("api/license/issue.ts", "utf8");
+      expect(src).toMatch(/ADMIN_API_KEY/);
+    });
+
+    it("api/license/issue.ts wires KILL_SIGNUPS gate", () => {
+      const src = fs.readFileSync("api/license/issue.ts", "utf8");
+      expect(src).toMatch(/KILL_SIGNUPS/);
+    });
+
+    it("api/license/verify.ts wires resolveLicenseStorage (not raw MemoryLicenseStorage)", () => {
+      const src = fs.readFileSync("api/license/verify.ts", "utf8");
+      expect(src).toMatch(/resolveLicenseStorage/);
+    });
+  });
+
   describe("stripe webhook routing contract", () => {
     it("STRIPE_SUPPORTED_METHODS lists POST", () => {
       expect(STRIPE_SUPPORTED_METHODS).toContain("POST");

--- a/vite.config.js
+++ b/vite.config.js
@@ -129,32 +129,35 @@ function apiProxyPlugin() {
         await sendWebResponse(webRes, res);
       });
 
-      // License + Stripe wiring. We share one resolved storage across both
+      // License + Stripe wiring. We share one resolved storage across all
       // endpoints so revocations performed via the webhook are immediately
-      // visible to /api/license/verify in the same dev session. The resolver
-      // picks Upstash if UPSTASH_REDIS_REST_URL+TOKEN are set, otherwise an
-      // in-memory store — dev typically runs without Upstash so this defaults
-      // to memory. Either way, both endpoints share the same instance.
+      // visible to /api/license/verify in the same dev session. The resolvers
+      // pick Upstash if UPSTASH_*/KV_REST_API_* env vars are set, otherwise
+      // in-memory — dev typically runs without Upstash so this defaults to
+      // memory. Same shape across all wrappers.
       let licenseStorage = null;
       let licenseIssuer = null;
+      let stripeEventStore = null;
 
       async function ensureLicenseDeps() {
         if (!licenseStorage) {
-          const [resolverMod, issuerMod] = await Promise.all([
+          const [resolverMod, issuerMod, eventResolverMod] = await Promise.all([
             import("./src/core/license/resolve-storage.ts"),
             import("./src/core/license/issuer.ts"),
+            import("./src/core/stripe/resolve-seen-event-store.ts"),
           ]);
           licenseStorage = await resolverMod.resolveLicenseStorage();
+          stripeEventStore = await eventResolverMod.resolveSeenEventStore();
           licenseIssuer = new issuerMod.LicenseIssuerImpl({
             signingKey: { secret: process.env.LICENSE_SIGNING_KEY ?? "" },
             storage: licenseStorage,
           });
         }
-        return { licenseStorage, licenseIssuer };
+        return { licenseStorage, licenseIssuer, stripeEventStore };
       }
 
       server.middlewares.use("/api/stripe/webhook", async (req, res) => {
-        const { licenseIssuer } = await ensureLicenseDeps();
+        const { licenseIssuer, stripeEventStore } = await ensureLicenseDeps();
         const [{ handleStripeWebhook }, { isFlagEnabled }] = await Promise.all([
           import("./src/core/stripe/webhook-handler.ts"),
           import("./src/core/flags/flags.ts"),
@@ -163,6 +166,7 @@ function apiProxyPlugin() {
         const webRes = await handleStripeWebhook(webReq, {
           signingSecret: process.env.STRIPE_WEBHOOK_SECRET ?? "",
           issuer: licenseIssuer,
+          eventStore: stripeEventStore,
           killSignups: () => isFlagEnabled("KILL_SIGNUPS"),
         });
         await sendWebResponse(webRes, res);


### PR DESCRIPTION
## Summary

Stripe sends each webhook event up to 3 days (live mode) on retry. Without dedup, our LicenseIssuer would mint a duplicate license token on every retry. PR V adds atomic event-id dedup via Upstash \`SET NX EX\` (7-day TTL — comfortably past Stripe's 3-day window).

Also scaffolds the \`LAUNCH_PAID_TIER\` master flag (no consumers yet — PR W gates \`/api/sync\` on it; PR Y exposes the Subscribe surface in the frontend).

## Stripe doc references consulted

Per the new \`feedback_stripe_consult_authoritative_sources\` memory:
- https://docs.stripe.com/webhooks — confirmed: dedup by \`event.id\`, ≥3-day TTL, return 200 on duplicate, atomic SET NX as race-condition mitigation
- \`.agents/skills/stripe-best-practices/references/security.md\` — confirmed signature-verify-before-anything-else ordering

## Stacked on PR T

This PR sits on top of #36 (PR T). Once #36 merges, GitHub will let me retarget this PR to \`main\` cleanly (or I rebase locally and force-push).

## Test plan

- [x] \`npm test\` — 1721+ pass, 2 skipped (no regressions; +22 new tests)
- [x] \`npx tsc --noEmit\` — clean
- [x] 5 new structural-assertion tests catch a class of bug where Vercel wrappers silently drop critical config (caught a real revert during dev)

## What's NOT done by this PR

- \`LAUNCH_PAID_TIER\` is scaffolding-only — no behavior change yet (PR W consumes it)
- No frontend changes (PR Y)
- No Stripe Checkout integration (PR X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)