### PR TITLE
feat(sync): gate /api/sync on Bearer license when LAUNCH_PAID_TIER=1 (PR W)

### DIFF
--- a/api/sync.ts
+++ b/api/sync.ts
@@ -1,174 +1,26 @@
-// @ts-nocheck
-// api/sync.ts
-var textEncoder = new TextEncoder();
-var SYNC = {
-  /** Static salt for vault ID derivation (domain separation from encryption key). */
-  VAULT_ID_SALT: textEncoder.encode("feedzero:vault-id:v1"),
-  /** Static salt seed for deterministic encryption salt derivation. */
-  ENCRYPTION_SALT_SEED: textEncoder.encode("feedzero:enc-salt:v1"),
-  /** Vault ID is 32 bytes, rendered as 64-character hex string. */
-  VAULT_ID_LENGTH: 32,
-  /** Deterministic encryption salt length in bytes. */
-  ENCRYPTION_SALT_LENGTH: 16,
-  /** Maximum vault payload size in bytes (5 MB). */
-  MAX_VAULT_SIZE: 5 * 1024 * 1024,
-  /** Sync data format version for forward compatibility. */
-  FORMAT_VERSION: 1
-};
-var VAULT_ID_PATTERN = /^[0-9a-f]{64}$/;
-var API_HEADERS = {
-  "Content-Type": "application/json",
-  "Access-Control-Allow-Origin": "*",
-  "X-Content-Type-Options": "nosniff"
-};
-function jsonResponse(body, status = 200) {
-  return new Response(JSON.stringify(body), { status, headers: API_HEADERS });
-}
-function errorResponse(message, status) {
-  return jsonResponse({ ok: false, error: message }, status);
-}
-function validateVaultId(vaultId) {
-  if (!vaultId || !VAULT_ID_PATTERN.test(vaultId)) return null;
-  return vaultId;
-}
-async function handleGet(request, adapter2) {
-  const url = new URL(request.url);
-  const rawId = url.searchParams.get("vaultId");
-  const vaultId = validateVaultId(rawId);
-  if (!vaultId) return errorResponse("Invalid or missing vaultId", 400);
-  const result = await adapter2.get(vaultId);
-  if (!result.ok) return errorResponse(result.error, 500);
-  if (result.value === null) return errorResponse("Vault not found", 404);
-  return new Response(result.value, { status: 200, headers: API_HEADERS });
-}
-async function handlePut(request, adapter2) {
-  const text = await request.text();
-  if (text.length > SYNC.MAX_VAULT_SIZE) {
-    return errorResponse("Payload too large", 413);
-  }
-  let body;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    return errorResponse("Invalid JSON", 400);
-  }
-  const vaultId = validateVaultId(body.vaultId ?? null);
-  if (!vaultId) return errorResponse("Invalid or missing vaultId", 400);
-  if (!body.vault) return errorResponse("Missing vault data", 400);
-  const data = JSON.stringify({ ok: true, vault: body.vault });
-  const result = await adapter2.put(vaultId, data);
-  if (!result.ok) return errorResponse(result.error, 500);
-  return jsonResponse({ ok: true, updatedAt: Date.now() });
-}
-async function handleDelete(request, adapter2) {
-  const url = new URL(request.url);
-  const rawId = url.searchParams.get("vaultId");
-  const vaultId = validateVaultId(rawId);
-  if (!vaultId) return errorResponse("Invalid or missing vaultId", 400);
-  const result = await adapter2.delete(vaultId);
-  if (!result.ok) return errorResponse(result.error, 500);
-  return jsonResponse({ ok: true });
-}
-var methodHandlers = {
-  GET: handleGet,
-  HEAD: handleGet,
-  PUT: handlePut,
-  DELETE: handleDelete
-};
-var SUPPORTED_METHODS = Object.keys(methodHandlers);
-async function handleSyncRequest(request, adapter2) {
-  const handler = methodHandlers[request.method];
-  if (!handler) return errorResponse("Method not allowed", 405);
-  return handler(request, adapter2);
-}
-function ok(value) {
-  return { ok: true, value };
-}
-function err(error) {
-  return { ok: false, error };
-}
-function createVercelBlobAdapter() {
+import { handleSyncRequest } from "../src/core/sync/sync-handler";
+import { resolveAdapter } from "../src/core/sync/adapters/resolve-adapter";
+import { resolveLicenseStorage } from "../src/core/license/resolve-storage";
+import { isFlagEnabled } from "../src/core/flags/flags";
+
+const syncAdapter = resolveAdapter();
+const licenseStoragePromise = resolveLicenseStorage();
+
+async function buildOptions() {
+  if (!isFlagEnabled("LAUNCH_PAID_TIER")) return {};
   return {
-    async get(vaultId) {
-      try {
-        const { head } = await import("@vercel/blob");
-        const pathname = `vaults/${vaultId}.json`;
-        let metadata;
-        try {
-          metadata = await head(pathname);
-        } catch {
-          return ok(null);
-        }
-        const response = await fetch(metadata.url);
-        if (!response.ok) return ok(null);
-        const data = await response.text();
-        return ok(data);
-      } catch (e) {
-        return err(`Vercel Blob get failed: ${e.message}`);
-      }
+    licenseAuth: {
+      signingKey: { secret: process.env.LICENSE_SIGNING_KEY ?? "" },
+      storage: await licenseStoragePromise,
     },
-    async put(vaultId, data) {
-      try {
-        const { put } = await import("@vercel/blob");
-        const pathname = `vaults/${vaultId}.json`;
-        await put(pathname, data, {
-          access: "public",
-          addRandomSuffix: false,
-          allowOverwrite: true,
-          contentType: "application/json"
-        });
-        return ok(true);
-      } catch (e) {
-        return err(`Vercel Blob put failed: ${e.message}`);
-      }
-    },
-    async delete(vaultId) {
-      try {
-        const { del } = await import("@vercel/blob");
-        const pathname = `vaults/${vaultId}.json`;
-        await del(pathname);
-        return ok(true);
-      } catch (e) {
-        return err(`Vercel Blob delete failed: ${e.message}`);
-      }
-    },
-    async count() {
-      try {
-        const { list } = await import("@vercel/blob");
-        let total = 0;
-        let cursor;
-        do {
-          const result = await list({
-            prefix: "vaults/",
-            limit: 1e3,
-            ...cursor ? { cursor } : {}
-          });
-          total += result.blobs.length;
-          cursor = result.hasMore ? result.cursor : void 0;
-        } while (cursor);
-        return ok(total);
-      } catch (e) {
-        return err(`Vercel Blob count failed: ${e.message}`);
-      }
-    }
   };
 }
-var adapter = createVercelBlobAdapter();
-async function GET(req) {
-  return handleSyncRequest(req, adapter);
+
+async function dispatch(req: Request): Promise<Response> {
+  return handleSyncRequest(req, syncAdapter, await buildOptions());
 }
-async function PUT(req) {
-  return handleSyncRequest(req, adapter);
-}
-async function DELETE(req) {
-  return handleSyncRequest(req, adapter);
-}
-async function HEAD(req) {
-  return handleSyncRequest(req, adapter);
-}
-export {
-  DELETE,
-  GET,
-  HEAD,
-  PUT
-};
+
+export async function GET(req: Request): Promise<Response> { return dispatch(req); }
+export async function PUT(req: Request): Promise<Response> { return dispatch(req); }
+export async function DELETE(req: Request): Promise<Response> { return dispatch(req); }
+export async function HEAD(req: Request): Promise<Response> { return dispatch(req); }

--- a/server.ts
+++ b/server.ts
@@ -168,7 +168,21 @@ export function createApp(
     handleProxyRequest(c.req.raw, "image/x-icon", { cache: feedCache }),
   );
   app.get("/api/favicon", (c) => handleFaviconRequest(c.req.raw));
-  app.all("/api/sync", (c) => handleSyncRequest(c.req.raw, syncAdapter));
+  app.all("/api/sync", (c) =>
+    handleSyncRequest(c.req.raw, syncAdapter, {
+      // LAUNCH_PAID_TIER is the Phase 1 master gate. Off → free sync (current
+      // behavior). On → Bearer license required, missing/invalid → 401.
+      ...(isFlagEnabled("LAUNCH_PAID_TIER")
+        ? {
+            licenseAuth: {
+              signingKey: license.signingKey,
+              storage: license.storage,
+              nowSec: license.nowSec,
+            },
+          }
+        : {}),
+    }),
+  );
   app.get("/api/stats-sync", (c) => handleSyncStatsRequest(c.req.raw, syncAdapter));
   app.post("/api/feedback", (c) => handleFeedbackRequest(c.req.raw));
   app.get("/api/catalog", (c) => handleCatalogRequest(c.req.raw, catalog));

--- a/src/core/license/middleware.ts
+++ b/src/core/license/middleware.ts
@@ -17,11 +17,11 @@
  * model) and §6.4 (kill switches / revocation).
  */
 
-import { verifyLicense } from "@/core/license/verify";
-import type { LicensePayload } from "@/core/license/format";
-import type { SigningKey } from "@/core/license/sign";
-import type { LicenseStorage } from "@/core/license/storage";
-import { ok, err, type Result } from "@/utils/result";
+import { verifyLicense } from "./verify";
+import type { LicensePayload } from "./format";
+import type { SigningKey } from "./sign";
+import type { LicenseStorage } from "./storage";
+import { ok, err, type Result } from "../../utils/result";
 
 export interface LicenseAuthContext {
   /** The verified payload, with revocation already checked. */

--- a/src/core/sync/sync-handler.ts
+++ b/src/core/sync/sync-handler.ts
@@ -1,5 +1,9 @@
 import { SYNC } from "../../utils/constants.ts";
 import type { SyncStorageAdapter } from "./types.ts";
+import {
+  authorizeLicense,
+  type LicenseAuthOptions,
+} from "../license/middleware";
 
 const VAULT_ID_PATTERN = /^[0-9a-f]{64}$/;
 
@@ -108,14 +112,39 @@ const methodHandlers: Record<string, MethodHandler> = {
 export const SUPPORTED_METHODS: readonly string[] = Object.keys(methodHandlers);
 
 /**
+ * Optional bag of dependencies for runtime gating. Today only `licenseAuth`
+ * is supported — when present, the handler runs {@link authorizeLicense}
+ * (signature + revocation check) before any data path. When absent, the
+ * handler behaves exactly as before (free sync, current default).
+ *
+ * The flag check (LAUNCH_PAID_TIER) lives in the wiring layer
+ * (server.ts / vite.config.js / api/sync.ts), not here — keeps the handler
+ * pure and the gate easy to flip without touching this file.
+ */
+export interface SyncHandlerOptions {
+  licenseAuth?: LicenseAuthOptions;
+}
+
+/**
  * Shared sync request handler using the Web standard Request/Response API.
  * Can be used by Vercel serverless functions, Hono, or any Web-compatible server.
  */
 export async function handleSyncRequest(
   request: Request,
   adapter: SyncStorageAdapter,
+  options: SyncHandlerOptions = {},
 ): Promise<Response> {
   const handler = methodHandlers[request.method];
   if (!handler) return errorResponse("Method not allowed", 405);
+
+  if (options.licenseAuth) {
+    const auth = await authorizeLicense(request, options.licenseAuth);
+    if (!auth.ok) {
+      // Surface the structured error for observability but use a stable
+      // message for clients ("license required" rather than internal text).
+      return errorResponse("license required", 401);
+    }
+  }
+
   return handler(request, adapter);
 }

--- a/tests/core/sync/sync-handler.test.ts
+++ b/tests/core/sync/sync-handler.test.ts
@@ -259,4 +259,151 @@ describe("sync-handler", () => {
       expect(response.status).toBe(405);
     });
   });
+
+  describe("optional license gate (PR W)", () => {
+    // When the third options arg carries `licenseAuth`, the handler runs
+    // authorizeLicense before any data path. The gate is OFF (no licenseAuth
+    // passed) by default — current free-sync behavior preserved exactly.
+    // The wiring layer (server.ts / vite.config.js / api/sync.ts) decides
+    // whether to pass licenseAuth based on the LAUNCH_PAID_TIER env flag.
+
+    const SECRET = "this-is-a-test-signing-secret-32-bytes!";
+    const NOW = 1_750_000_000;
+
+    async function importLicenseHelpers() {
+      const [
+        { signLicense },
+        { MemoryLicenseStorage },
+      ] = await Promise.all([
+        import("@/core/license/sign"),
+        import("@/core/license/storage"),
+      ]);
+      return { signLicense, MemoryLicenseStorage };
+    }
+
+    it("does NOT require auth when licenseAuth option is absent (current behavior)", async () => {
+      const vaultId = "a".repeat(64);
+      const response = await handleSyncRequest(
+        makeGetRequest(vaultId),
+        adapter,
+        // no third arg
+      );
+      // Vault-not-found 404 — proves auth was not enforced.
+      expect(response.status).toBe(404);
+    });
+
+    it("returns 401 when licenseAuth is configured and Authorization header is missing", async () => {
+      const { MemoryLicenseStorage } = await importLicenseHelpers();
+      const vaultId = "a".repeat(64);
+      const response = await handleSyncRequest(
+        makeGetRequest(vaultId),
+        adapter,
+        {
+          licenseAuth: {
+            signingKey: { secret: SECRET },
+            storage: new MemoryLicenseStorage(),
+            nowSec: NOW,
+          },
+        },
+      );
+      expect(response.status).toBe(401);
+      const body = await response.json();
+      expect(body.ok).toBe(false);
+    });
+
+    it("returns 401 for tampered bearer token", async () => {
+      const { signLicense, MemoryLicenseStorage } = await importLicenseHelpers();
+      const token = await signLicense(
+        {
+          tier: "personal",
+          expirySec: NOW + 86400,
+          customerId: "cus_x",
+          keyId: "kid_test_xxxxxxxxxxxxxxxxxxxxxxxx",
+          issuedAtSec: NOW - 100,
+        },
+        { secret: SECRET },
+      );
+      const tampered = token.slice(0, -2) + "AA";
+      const vaultId = "a".repeat(64);
+      const response = await handleSyncRequest(
+        new Request(`http://localhost/api/sync?vaultId=${vaultId}`, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${tampered}` },
+        }),
+        adapter,
+        {
+          licenseAuth: {
+            signingKey: { secret: SECRET },
+            storage: new MemoryLicenseStorage(),
+            nowSec: NOW,
+          },
+        },
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 401 for revoked token (storage deny-list hit)", async () => {
+      const { signLicense, MemoryLicenseStorage } = await importLicenseHelpers();
+      const keyId = "kid_revoked_xxxxxxxxxxxxxxxxxxxx";
+      const storage = new MemoryLicenseStorage();
+      await storage.revoke(keyId, "test");
+      const token = await signLicense(
+        {
+          tier: "personal",
+          expirySec: NOW + 86400,
+          customerId: "cus_x",
+          keyId,
+          issuedAtSec: NOW - 100,
+        },
+        { secret: SECRET },
+      );
+      const vaultId = "a".repeat(64);
+      const response = await handleSyncRequest(
+        new Request(`http://localhost/api/sync?vaultId=${vaultId}`, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        adapter,
+        {
+          licenseAuth: {
+            signingKey: { secret: SECRET },
+            storage,
+            nowSec: NOW,
+          },
+        },
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("proceeds to handler when bearer is valid + un-revoked", async () => {
+      const { signLicense, MemoryLicenseStorage } = await importLicenseHelpers();
+      const token = await signLicense(
+        {
+          tier: "personal",
+          expirySec: NOW + 86400,
+          customerId: "cus_x",
+          keyId: "kid_valid_xxxxxxxxxxxxxxxxxxxxxx",
+          issuedAtSec: NOW - 100,
+        },
+        { secret: SECRET },
+      );
+      const vaultId = "a".repeat(64);
+      const response = await handleSyncRequest(
+        new Request(`http://localhost/api/sync?vaultId=${vaultId}`, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        adapter,
+        {
+          licenseAuth: {
+            signingKey: { secret: SECRET },
+            storage: new MemoryLicenseStorage(),
+            nowSec: NOW,
+          },
+        },
+      );
+      // Handler ran (404 because vault doesn't exist, NOT 401 from auth).
+      expect(response.status).toBe(404);
+    });
+  });
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1033,6 +1033,75 @@ describe("server", () => {
     });
   });
 
+  describe("/api/sync gating on LAUNCH_PAID_TIER (PR W)", () => {
+    const SECRET = "this-is-a-test-signing-secret-32-bytes!";
+    const signingKey: SigningKey = { secret: SECRET };
+
+    it("does NOT require license when LAUNCH_PAID_TIER is unset (current free behavior)", async () => {
+      const ORIGINAL = process.env.LAUNCH_PAID_TIER;
+      delete process.env.LAUNCH_PAID_TIER;
+      try {
+        const app = createApp(undefined, undefined, undefined, {
+          signingKey,
+          storage: new MemoryLicenseStorage(),
+        });
+        const vaultId = "a".repeat(64);
+        const res = await app.request(`/api/sync?vaultId=${vaultId}`);
+        // 404 (vault doesn't exist) — proves auth gate skipped.
+        expect(res.status).toBe(404);
+      } finally {
+        if (ORIGINAL !== undefined) process.env.LAUNCH_PAID_TIER = ORIGINAL;
+      }
+    });
+
+    it("returns 401 on /api/sync GET without bearer when LAUNCH_PAID_TIER=1", async () => {
+      const ORIGINAL = process.env.LAUNCH_PAID_TIER;
+      process.env.LAUNCH_PAID_TIER = "1";
+      try {
+        const app = createApp(undefined, undefined, undefined, {
+          signingKey,
+          storage: new MemoryLicenseStorage(),
+        });
+        const vaultId = "a".repeat(64);
+        const res = await app.request(`/api/sync?vaultId=${vaultId}`);
+        expect(res.status).toBe(401);
+      } finally {
+        if (ORIGINAL === undefined) delete process.env.LAUNCH_PAID_TIER;
+        else process.env.LAUNCH_PAID_TIER = ORIGINAL;
+      }
+    });
+
+    it("issued license token unlocks /api/sync when LAUNCH_PAID_TIER=1 (full e2e via createApp)", async () => {
+      const ORIGINAL = process.env.LAUNCH_PAID_TIER;
+      process.env.LAUNCH_PAID_TIER = "1";
+      try {
+        const storage = new MemoryLicenseStorage();
+        const app = createApp(undefined, undefined, undefined, {
+          signingKey,
+          storage,
+        });
+        const validPayload: LicensePayload = {
+          tier: "personal",
+          expirySec: 1_800_000_000,
+          customerId: "cus_paywall_test",
+          keyId: "kid_pw_test_xxxxxxxxxxxxxxxxxx",
+          issuedAtSec: 1_700_000_000,
+        };
+        const token = await signLicense(validPayload, signingKey);
+
+        const vaultId = "a".repeat(64);
+        const res = await app.request(`/api/sync?vaultId=${vaultId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        // 404 (vault not found) — proves auth gate passed.
+        expect(res.status).toBe(404);
+      } finally {
+        if (ORIGINAL === undefined) delete process.env.LAUNCH_PAID_TIER;
+        else process.env.LAUNCH_PAID_TIER = ORIGINAL;
+      }
+    });
+  });
+
   describe("vercel wrapper structural invariants", () => {
     // Tier 2 (Structural Assertion) tests. Vercel wrappers in api/*.ts are
     // thin glue files whose only behavioral tests are routing contracts.
@@ -1067,6 +1136,12 @@ describe("server", () => {
     it("api/license/verify.ts wires resolveLicenseStorage (not raw MemoryLicenseStorage)", () => {
       const src = fs.readFileSync("api/license/verify.ts", "utf8");
       expect(src).toMatch(/resolveLicenseStorage/);
+    });
+
+    it("api/sync.ts wires LAUNCH_PAID_TIER gate (PR W)", () => {
+      const src = fs.readFileSync("api/sync.ts", "utf8");
+      expect(src).toMatch(/LAUNCH_PAID_TIER/);
+      expect(src).toMatch(/licenseAuth/);
     });
   });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -99,8 +99,19 @@ function apiProxyPlugin() {
 
       server.middlewares.use("/api/sync", async (req, res) => {
         const { syncHandler, syncAdapter } = await ensureSyncHandler();
+        const { licenseStorage } = await ensureLicenseDeps();
+        const { isFlagEnabled } = await import("./src/core/flags/flags.ts");
         const webReq = await toWebRequest(req);
-        const webRes = await syncHandler(webReq, syncAdapter);
+        // PR W: when LAUNCH_PAID_TIER=1, /api/sync requires a Bearer license.
+        const opts = isFlagEnabled("LAUNCH_PAID_TIER")
+          ? {
+              licenseAuth: {
+                signingKey: { secret: process.env.LICENSE_SIGNING_KEY ?? "" },
+                storage: licenseStorage,
+              },
+            }
+          : {};
+        const webRes = await syncHandler(webReq, syncAdapter, opts);
         await sendWebResponse(webRes, res);
       });
 


### PR DESCRIPTION
## Summary

Implements Phase 1's actual paid feature: hosted sync becomes paid-only. **Off by default** — production behavior unchanged until you set \`LAUNCH_PAID_TIER=1\` in Vercel and redeploy.

When the flag is set:
- \`/api/sync\` requires \`Authorization: Bearer <license-token>\`
- Missing/invalid/expired/revoked → 401 \`{ok: false, error: "license required"}\`
- Valid + un-revoked → handler proceeds normally

## Why off by default

Per \`docs/internal/strategy.md\` §4: Phase 1 is "Hosted sync goes paid → Personal launches → first revenue". Until you're ready to launch, this PR is dormant. Flipping the env var is the launch action.

## Architecture note

Flag check lives in the wiring layer (server.ts, vite.config.js, api/sync.ts), not in the handler. Handler stays pure (just an optional \`licenseAuth\` parameter). Flipping the gate doesn't require handler-code changes — only env var + redeploy.

Also, \`api/sync.ts\` rewritten from legacy bundled form to source-form wrapper matching the rest of the api/ directory pattern.

## Stacked on PR V (#37)

When #37 merges, this rebases cleanly.

## Test plan

- [x] \`npm test\` — 1733+ pass
- [x] \`npx tsc --noEmit\` — clean
- [x] 9 new tests covering: handler optional gate, server flag wiring, structural-assertion that wrapper wires LAUNCH_PAID_TIER

🤖 Generated with [Claude Code](https://claude.com/claude-code)