### PR TITLE
feat(billing): Subscribe UI + license token storage + Bearer on sync (PR Y)

### DIFF
--- a/src/components/billing/license-token-input.tsx
+++ b/src/components/billing/license-token-input.tsx
@@ -1,0 +1,123 @@
+/**
+ * License token input — paste-from-email landing pad.
+ *
+ * After Stripe Checkout, the customer receives an email with their
+ * `fz_<...>.<...>` license token. They paste it here. We:
+ *  1. Shape-validate (refuse obviously-wrong inputs locally — fast feedback)
+ *  2. Persist to localStorage
+ *  3. Call /api/license/verify to confirm the server accepts it
+ *  4. If server rejects (revoked, expired, forged): unset the storage so we
+ *     don't keep sending an invalid Bearer header on every sync request.
+ *
+ * Hidden by default — only renders when `paidTierVisible=true` (driven by
+ * `import.meta.env.VITE_PAID_TIER_VISIBLE` at the call site).
+ */
+
+import { useState } from "react";
+import {
+  setLicenseToken,
+  clearLicenseToken,
+  getLicenseToken,
+} from "@/core/license/license-token-store";
+
+export interface LicenseTokenInputProps {
+  paidTierVisible: boolean;
+}
+
+interface VerifiedLicense {
+  tier: string;
+  customerId: string;
+}
+
+export function LicenseTokenInput({ paidTierVisible }: LicenseTokenInputProps) {
+  const [token, setToken] = useState(() => getLicenseToken() ?? "");
+  const [verified, setVerified] = useState<VerifiedLicense | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  if (!paidTierVisible) return null;
+
+  async function onSave() {
+    setBusy(true);
+    setError(null);
+    setVerified(null);
+
+    // Local shape-check first — fast feedback before network round-trip.
+    const trimmed = token.trim();
+    if (
+      !trimmed.startsWith("fz_") ||
+      trimmed.split(".").length !== 2
+    ) {
+      setError(
+        'Invalid license token. Expected format: fz_<...>.<...>',
+      );
+      setBusy(false);
+      return;
+    }
+
+    // Persist optimistically — verify next.
+    setLicenseToken(trimmed);
+
+    try {
+      const res = await fetch("/api/license/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: trimmed }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok) {
+        // Server rejected — un-persist so we don't send a bad Bearer forever.
+        clearLicenseToken();
+        setError(body.error ?? `License verification failed (${res.status})`);
+        return;
+      }
+      setVerified({
+        tier: body.license.tier,
+        customerId: body.license.customerId,
+      });
+    } catch (e) {
+      clearLicenseToken();
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function onClear() {
+    clearLicenseToken();
+    setToken("");
+    setVerified(null);
+    setError(null);
+  }
+
+  return (
+    <div>
+      <label htmlFor="license-token-input">License token</label>
+      <input
+        id="license-token-input"
+        type="text"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        placeholder="fz_..."
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <button type="button" onClick={onSave} disabled={busy}>
+        Save
+      </button>
+      <button type="button" onClick={onClear} disabled={busy}>
+        Clear
+      </button>
+      {verified && (
+        <div role="status" aria-live="polite">
+          Active: {verified.tier} (customer {verified.customerId})
+        </div>
+      )}
+      {error && (
+        <div role="alert" aria-live="polite">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/billing/subscribe-button.tsx
+++ b/src/components/billing/subscribe-button.tsx
@@ -1,0 +1,85 @@
+/**
+ * Subscribe button — initiates Stripe Checkout flow.
+ *
+ * The button only renders when `paidTierVisible=true`. The launch wiring
+ * passes `paidTierVisible={import.meta.env.VITE_PAID_TIER_VISIBLE === "1"}`,
+ * so the entire surface stays hidden until the operator flips that env var
+ * at build time.
+ *
+ * On click:
+ *   1. POSTs to /api/checkout/create-session with priceId + success/cancel
+ *      URLs derived from window.location.origin
+ *   2. On 200 + {url}: redirects window.location to the Stripe-hosted page
+ *   3. On error: surfaces the error message inline (no toasts — pricing
+ *      problems should be unmissable, not auto-dismissed)
+ */
+
+import { useState } from "react";
+
+export interface SubscribeButtonProps {
+  /** Stripe price ID to subscribe to. Must be in the server's STRIPE_ALLOWED_PRICES. */
+  priceId: string;
+  /**
+   * Master visibility gate. Source: `import.meta.env.VITE_PAID_TIER_VISIBLE`.
+   * Passed in (rather than read here) so tests don't have to mock import.meta.
+   */
+  paidTierVisible: boolean;
+  /** Optional label override. Defaults to "Subscribe". */
+  label?: string;
+}
+
+export function SubscribeButton({
+  priceId,
+  paidTierVisible,
+  label = "Subscribe",
+}: SubscribeButtonProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!paidTierVisible) return null;
+
+  async function onClick() {
+    setBusy(true);
+    setError(null);
+    try {
+      const origin = window.location.origin;
+      const res = await fetch("/api/checkout/create-session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          priceId,
+          successUrl: `${origin}/billing/success?session_id={CHECKOUT_SESSION_ID}`,
+          cancelUrl: `${origin}/billing/cancelled`,
+        }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok) {
+        setError(body.error ?? `Checkout failed (${res.status})`);
+        return;
+      }
+      window.location.href = body.url;
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={busy}
+        aria-busy={busy}
+      >
+        {busy ? "Redirecting…" : label}
+      </button>
+      {error && (
+        <div role="alert" aria-live="polite">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/core/license/license-token-store.ts
+++ b/src/core/license/license-token-store.ts
@@ -1,0 +1,77 @@
+/**
+ * License token persistence in browser localStorage.
+ *
+ * The license token is the user's proof of paid status. They get it via
+ * email after Stripe Checkout completes (post-launch — for now, manually
+ * via the admin issue endpoint). They paste it into the app and it lives
+ * in localStorage from then on.
+ *
+ * Why localStorage (not IndexedDB / encrypted vault):
+ *  - The token is a Bearer credential — needs to be readable synchronously
+ *    by every fetch call to /api/sync.
+ *  - Already encrypted-by-design (HMAC-signed; impossible to forge without
+ *    LICENSE_SIGNING_KEY) so localStorage's lack of encryption is acceptable.
+ *  - Cross-tab same-origin behavior: localStorage is shared, which is what
+ *    we want (the user paid once; all open tabs get sync access).
+ *
+ * Defensive validation: only persist values that look like our token format
+ * (`fz_<base64url>.<base64url>`). A copy-paste of "Subject: Welcome to
+ * FeedZero" should not silently land in localStorage as the user's token.
+ */
+
+export const LICENSE_TOKEN_STORAGE_KEY = "feedzero:license-token";
+
+const TOKEN_PREFIX = "fz_";
+
+/**
+ * Read the stored token. Returns null when:
+ *   - No token has been stored
+ *   - The stored value doesn't pass validation (defensive — protects against
+ *     downgrade attacks where an attacker writes garbage to localStorage)
+ */
+export function getLicenseToken(): string | null {
+  if (typeof localStorage === "undefined") return null;
+  const raw = localStorage.getItem(LICENSE_TOKEN_STORAGE_KEY);
+  if (!raw) return null;
+  if (!isWellFormedToken(raw)) return null;
+  return raw;
+}
+
+/**
+ * Persist a token. Whitespace-trims (paste-from-email frequently picks up
+ * trailing newlines). Empty/invalid input clears the slot rather than
+ * leaving stale state.
+ */
+export function setLicenseToken(token: string): void {
+  if (typeof localStorage === "undefined") return;
+  const trimmed = token.trim();
+  if (!trimmed || !isWellFormedToken(trimmed)) {
+    localStorage.removeItem(LICENSE_TOKEN_STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(LICENSE_TOKEN_STORAGE_KEY, trimmed);
+}
+
+/** Remove the stored token. Used on explicit user action (logout/clear). */
+export function clearLicenseToken(): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.removeItem(LICENSE_TOKEN_STORAGE_KEY);
+}
+
+/** Cheap presence check for UI gating (e.g. "show Subscribe vs Manage"). */
+export function hasLicenseToken(): boolean {
+  return getLicenseToken() !== null;
+}
+
+/**
+ * Shape check, NOT cryptographic verification. The server is the only thing
+ * that can cryptographically verify a token (it has LICENSE_SIGNING_KEY).
+ * This guard prevents obviously-wrong values from polluting the store.
+ */
+function isWellFormedToken(value: string): boolean {
+  if (!value.startsWith(TOKEN_PREFIX)) return false;
+  const body = value.slice(TOKEN_PREFIX.length);
+  const parts = body.split(".");
+  if (parts.length !== 2) return false;
+  return parts[0].length > 0 && parts[1].length > 0;
+}

--- a/src/core/sync/sync-fetch.ts
+++ b/src/core/sync/sync-fetch.ts
@@ -1,0 +1,35 @@
+/**
+ * Wrapper around `fetch` for sync-related requests.
+ *
+ * When a license token is stored in localStorage (PR Y), automatically
+ * attaches `Authorization: Bearer <token>`. The server-side handler enforces
+ * the bearer requirement when LAUNCH_PAID_TIER=1 (PR W); otherwise it's a
+ * harmless no-op.
+ *
+ * Why a wrapper (and not e.g. service-worker request rewriting):
+ *  - The 4 sync fetch sites in src/core/sync/sync-service.ts share one
+ *    contract: include the Bearer when the user is paid, omit when free.
+ *  - A wrapper keeps that policy in ONE file. Changing it (e.g. adding
+ *    a request signature, adding a tracing header) touches one place.
+ *
+ * Caller-supplied Authorization wins. Useful for tests + for unusual
+ * flows (e.g. a one-off admin-token request) that must not be silently
+ * overridden by the stored license token.
+ */
+
+import { getLicenseToken } from "../license/license-token-store";
+
+export async function syncFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const headers = new Headers(init.headers);
+  const callerSetAuth = headers.has("Authorization");
+
+  if (!callerSetAuth) {
+    const token = getLicenseToken();
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  return fetch(input, { ...init, headers });
+}

--- a/src/core/sync/sync-service.ts
+++ b/src/core/sync/sync-service.ts
@@ -9,6 +9,7 @@ import {
   decryptVault,
 } from "./vault-crypto.ts";
 import type { VaultData, EncryptedVault } from "./types.ts";
+import { syncFetch } from "./sync-fetch.ts";
 
 /** Pre-derived sync credentials, avoiding the need to store the raw passphrase. */
 export interface SyncCredentials {
@@ -125,7 +126,7 @@ export async function pushVault(auth: SyncAuth): Promise<Result<number>> {
       }),
     );
 
-    const response = await fetch("/api/sync", {
+    const response = await syncFetch("/api/sync", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body,
@@ -152,7 +153,7 @@ export async function deleteVault(auth: SyncAuth): Promise<Result<boolean>> {
     const vaultIdResult = await resolveVaultId(auth);
     if (!vaultIdResult.ok) return vaultIdResult;
 
-    const response = await fetch(`/api/sync?vaultId=${vaultIdResult.value}`, {
+    const response = await syncFetch(`/api/sync?vaultId=${vaultIdResult.value}`, {
       method: "DELETE",
     });
 
@@ -178,7 +179,7 @@ export async function pullVault(auth: SyncAuth): Promise<Result<VaultData>> {
     if (!credsResult.ok) return credsResult;
     const { vaultId, vaultKey } = credsResult.value;
 
-    const response = await fetch(`/api/sync?vaultId=${vaultId}`);
+    const response = await syncFetch(`/api/sync?vaultId=${vaultId}`);
 
     if (!response.ok) {
       const text = await response.text();
@@ -208,7 +209,7 @@ export async function checkVaultExists(
     const vaultIdResult = await resolveVaultId(auth);
     if (!vaultIdResult.ok) return vaultIdResult;
 
-    const response = await fetch(`/api/sync?vaultId=${vaultIdResult.value}`, {
+    const response = await syncFetch(`/api/sync?vaultId=${vaultIdResult.value}`, {
       method: "HEAD",
     });
 

--- a/tests/components/billing/license-token-input.test.tsx
+++ b/tests/components/billing/license-token-input.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LicenseTokenInput } from "@/components/billing/license-token-input";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+describe("LicenseTokenInput", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            license: { tier: "pro", customerId: "cus_x" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+  });
+
+  it("renders nothing when paidTierVisible=false", () => {
+    const { container } = render(<LicenseTokenInput paidTierVisible={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an input + Save button when paidTierVisible=true", () => {
+    render(<LicenseTokenInput paidTierVisible={true} />);
+    expect(screen.getByPlaceholderText(/fz_/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
+  });
+
+  it("on Save with a valid-shape token, persists to localStorage and calls /api/license/verify", async () => {
+    render(<LicenseTokenInput paidTierVisible={true} />);
+    await userEvent.type(
+      screen.getByPlaceholderText(/fz_/i),
+      "fz_payload.signature",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(localStorageMock.getItem("feedzero:license-token")).toBe(
+      "fz_payload.signature",
+    );
+    const fetchMock = (globalThis.fetch as unknown) as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/license/verify",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(await screen.findByText(/active.*pro/i)).toBeInTheDocument();
+  });
+
+  it("on Save with a malformed token, does NOT persist and shows an error", async () => {
+    render(<LicenseTokenInput paidTierVisible={true} />);
+    await userEvent.type(
+      screen.getByPlaceholderText(/fz_/i),
+      "garbage-not-a-token",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(localStorageMock.getItem("feedzero:license-token")).toBeNull();
+    expect(
+      await screen.findByText(/invalid|format|fz_/i),
+    ).toBeInTheDocument();
+  });
+
+  it("Clear button removes the stored token", async () => {
+    localStorageMock.setItem("feedzero:license-token", "fz_existing.token");
+    render(<LicenseTokenInput paidTierVisible={true} />);
+    await userEvent.click(screen.getByRole("button", { name: /clear/i }));
+    expect(localStorageMock.getItem("feedzero:license-token")).toBeNull();
+  });
+
+  it("when /api/license/verify returns 401 revoked, surfaces the error AND removes the token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({ ok: false, error: "license revoked" }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    render(<LicenseTokenInput paidTierVisible={true} />);
+    await userEvent.type(
+      screen.getByPlaceholderText(/fz_/i),
+      "fz_revoked.token",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(await screen.findByText(/revoked/i)).toBeInTheDocument();
+    // Critical: a revoked token must NOT be persisted — otherwise the user
+    // would think it's good and we'd send invalid Bearer headers forever.
+    expect(localStorageMock.getItem("feedzero:license-token")).toBeNull();
+  });
+});

--- a/tests/components/billing/subscribe-button.test.tsx
+++ b/tests/components/billing/subscribe-button.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SubscribeButton } from "@/components/billing/subscribe-button";
+
+describe("SubscribeButton", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("renders nothing when paidTierVisible=false (default — production stays dormant)", () => {
+    const { container } = render(
+      <SubscribeButton priceId="price_x" paidTierVisible={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the button when paidTierVisible=true", () => {
+    render(<SubscribeButton priceId="price_x" paidTierVisible={true} />);
+    expect(screen.getByRole("button", { name: /subscribe/i })).toBeInTheDocument();
+  });
+
+  it("on click, POSTs to /api/checkout/create-session with the price ID and current origin URLs", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          url: "https://checkout.stripe.com/pay/cs_test_xyz",
+          sessionId: "cs_test_xyz",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    // Don't actually navigate during tests
+    const assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { origin: "https://test.example", assign: assignSpy, href: "" },
+      writable: true,
+    });
+
+    render(
+      <SubscribeButton priceId="price_personal_monthly" paidTierVisible={true} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /subscribe/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/checkout/create-session",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+      }),
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.priceId).toBe("price_personal_monthly");
+    expect(body.successUrl).toContain("https://test.example");
+    expect(body.cancelUrl).toContain("https://test.example");
+  });
+
+  it("redirects the user to the Stripe Checkout URL on success", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          url: "https://checkout.stripe.com/pay/cs_test_xyz",
+          sessionId: "cs_test_xyz",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const hrefSetter = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: {
+        origin: "https://test.example",
+        get href() {
+          return "";
+        },
+        set href(v) {
+          hrefSetter(v);
+        },
+      },
+      writable: true,
+    });
+
+    render(<SubscribeButton priceId="price_x" paidTierVisible={true} />);
+    await userEvent.click(screen.getByRole("button", { name: /subscribe/i }));
+
+    expect(hrefSetter).toHaveBeenCalledWith(
+      "https://checkout.stripe.com/pay/cs_test_xyz",
+    );
+  });
+
+  it("displays the error when the API returns ok:false", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ ok: false, error: "priceId not in allowlist" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    render(<SubscribeButton priceId="price_invalid" paidTierVisible={true} />);
+    await userEvent.click(screen.getByRole("button", { name: /subscribe/i }));
+
+    expect(
+      await screen.findByText(/priceId not in allowlist/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/core/license/license-token-store.test.ts
+++ b/tests/core/license/license-token-store.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getLicenseToken,
+  setLicenseToken,
+  clearLicenseToken,
+  hasLicenseToken,
+  LICENSE_TOKEN_STORAGE_KEY,
+} from "@/core/license/license-token-store";
+
+// localStorage mock — matches the pattern in tests/core/storage/key-material.test.ts
+// because happy-dom in this project's vitest setup doesn't expose localStorage globally.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+describe("license-token-store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("getLicenseToken returns null when no token is stored", () => {
+    expect(getLicenseToken()).toBeNull();
+  });
+
+  it("setLicenseToken persists the token to localStorage", () => {
+    setLicenseToken("fz_payload.sig");
+    expect(localStorage.getItem(LICENSE_TOKEN_STORAGE_KEY)).toBe("fz_payload.sig");
+  });
+
+  it("getLicenseToken reads back what was stored", () => {
+    setLicenseToken("fz_abc.def");
+    expect(getLicenseToken()).toBe("fz_abc.def");
+  });
+
+  it("clearLicenseToken removes the entry", () => {
+    setLicenseToken("fz_x.y");
+    clearLicenseToken();
+    expect(getLicenseToken()).toBeNull();
+    expect(localStorage.getItem(LICENSE_TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  it("hasLicenseToken returns true only when a non-empty token is stored", () => {
+    expect(hasLicenseToken()).toBe(false);
+    setLicenseToken("fz_x.y");
+    expect(hasLicenseToken()).toBe(true);
+    clearLicenseToken();
+    expect(hasLicenseToken()).toBe(false);
+  });
+
+  it("setLicenseToken with empty string is the same as clear (no half-state)", () => {
+    setLicenseToken("fz_x.y");
+    setLicenseToken("");
+    expect(getLicenseToken()).toBeNull();
+    expect(hasLicenseToken()).toBe(false);
+  });
+
+  it("trims whitespace before storing (paste from email often includes trailing newline)", () => {
+    setLicenseToken("  fz_payload.sig  \n");
+    expect(getLicenseToken()).toBe("fz_payload.sig");
+  });
+
+  it("rejects values that don't have the fz_ prefix (defensive)", () => {
+    setLicenseToken("not-a-feedzero-token");
+    expect(getLicenseToken()).toBeNull();
+  });
+});

--- a/tests/core/sync/sync-fetch.test.ts
+++ b/tests/core/sync/sync-fetch.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { syncFetch } from "@/core/sync/sync-fetch";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+describe("syncFetch — Bearer header attachment", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorageMock.clear();
+    fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("does NOT attach Authorization when no license token is stored (free path)", async () => {
+    await syncFetch("/api/sync");
+    const init = fetchMock.mock.calls[0][1] as RequestInit | undefined;
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBeNull();
+  });
+
+  it("attaches Authorization: Bearer <token> when a license token is stored", async () => {
+    localStorageMock.setItem("feedzero:license-token", "fz_payload.sig");
+    await syncFetch("/api/sync");
+    const init = fetchMock.mock.calls[0][1] as RequestInit | undefined;
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer fz_payload.sig");
+  });
+
+  it("preserves existing init (method, body, headers) when adding Authorization", async () => {
+    localStorageMock.setItem("feedzero:license-token", "fz_x.y");
+    await syncFetch("/api/sync", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "X-Custom": "v" },
+      body: '{"k":"v"}',
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("PUT");
+    expect(init.body).toBe('{"k":"v"}');
+    const headers = new Headers(init.headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("X-Custom")).toBe("v");
+    expect(headers.get("Authorization")).toBe("Bearer fz_x.y");
+  });
+
+  it("does not overwrite an explicitly-set Authorization header (caller intent wins)", async () => {
+    localStorageMock.setItem("feedzero:license-token", "fz_stored.sig");
+    await syncFetch("/api/sync", {
+      headers: { Authorization: "Bearer caller-supplied-override" },
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer caller-supplied-override");
+  });
+});

--- a/tests/core/sync/sync-service.test.ts
+++ b/tests/core/sync/sync-service.test.ts
@@ -139,7 +139,12 @@ describe("sync-service", () => {
       const [url, options] = fetchMock.mock.calls[0];
       expect(url).toMatch(/\/api\/sync$/);
       expect(options.method).toBe("PUT");
-      expect(options.headers["Content-Type"]).toBe("application/json");
+      // syncFetch wraps init.headers as a Headers instance — accept either shape.
+      const contentType =
+        options.headers instanceof Headers
+          ? options.headers.get("Content-Type")
+          : options.headers["Content-Type"];
+      expect(contentType).toBe("application/json");
 
       const body = JSON.parse(options.body);
       expect(body.vaultId).toMatch(/^[0-9a-f]{64}$/);


### PR DESCRIPTION
## Summary

The user-facing surface for the paid tier — Subscribe button + license token paste UI + automatic Bearer attachment on sync requests.

**Hidden by default.** Renders only when the build was made with \`VITE_PAID_TIER_VISIBLE=1\`. With that env unset (production default until launch), the bundle behavior is unchanged — invisible UI, no behavioral change to free users.

## Architecture

| Module | Responsibility |
|---|---|
| \`license-token-store.ts\` | localStorage helpers for the license token. Shape-validates on read/write so a stray copy-paste of email subject lines doesn't pollute storage. |
| \`sync-fetch.ts\` | Tiny fetch wrapper that auto-attaches \`Authorization: Bearer <stored-token>\` when present. All 4 sync fetch sites in sync-service.ts now route through it. |
| \`SubscribeButton\` | POSTs \`/api/checkout/create-session\`, redirects to Stripe-hosted checkout. Errors inline. |
| \`LicenseTokenInput\` | Paste-from-email pad. Local shape check → persist → server verify → un-persist on server reject. |

## Stacked on PR X (#39)

When #39 merges, this rebases cleanly.

## Test plan

- [x] \`npm test\` → 1775 pass
- [x] \`npx tsc --noEmit\` → clean
- [x] 23 new tests across token store, sync-fetch, Subscribe button, License input

## To activate Phase 1 launch (multiple env flags must coincide)

| Where | Env var | Effect |
|---|---|---|
| Vercel | \`STRIPE_ALLOWED_PRICES=price_a,price_b,...\` | Server-controlled allowlist for /api/checkout |
| Vercel | \`LAUNCH_PAID_TIER=1\` | /api/sync requires Bearer license |
| Build | \`VITE_PAID_TIER_VISIBLE=1\` | Frontend reveals Subscribe + License input UI |

All three off → invisible feature. Any one on → partial state (e.g. visible UI but free sync). All three on → live paid tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)