### PR TITLE
feat(billing): success + cancelled pages for Stripe Checkout redirects

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,6 +9,8 @@ import { Toaster } from "@/components/ui/sonner.tsx";
 import { SyncSetupDialog } from "@/components/sync/sync-setup-dialog.tsx";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { FeedsPage } from "@/pages/feeds-page.tsx";
+import { BillingSuccess } from "@/pages/billing-success.tsx";
+import { BillingCancelled } from "@/pages/billing-cancelled.tsx";
 import { Button } from "@/components/ui/button.tsx";
 
 function AppInit({ children }: { children: React.ReactNode }) {
@@ -129,6 +131,8 @@ export function App() {
             />
             <Route path="/explore" element={<FeedsPage />} />
             <Route path="/stats" element={<FeedsPage />} />
+            <Route path="/billing/success" element={<BillingSuccess />} />
+            <Route path="/billing/cancelled" element={<BillingCancelled />} />
             <Route path="*" element={<Navigate to="/feeds" replace />} />
           </Routes>
         </AppInit>

--- a/src/pages/billing-cancelled.tsx
+++ b/src/pages/billing-cancelled.tsx
@@ -1,0 +1,32 @@
+/**
+ * Stripe Checkout cancellation redirect target.
+ *
+ * Stripe sends customers here when they back out of the hosted Checkout
+ * page (close the tab, click the back arrow, etc.). No charge happens —
+ * Stripe doesn't process anything until the customer hits Confirm.
+ *
+ * UX contract: explicit reassurance that no charge was made + a clear way
+ * back to the reader. Intentionally minimal — there's nothing for the user
+ * to do here other than navigate away.
+ */
+
+export function BillingCancelled() {
+  return (
+    <div className="mx-auto max-w-xl p-8 space-y-6">
+      <h1 className="text-2xl font-semibold">No problem — no charge made</h1>
+
+      <p>
+        You backed out of the Stripe checkout page before confirming. No
+        payment was processed and no subscription was created.
+      </p>
+
+      <p>
+        You can subscribe again any time from the FeedZero app.
+      </p>
+
+      <p>
+        <a href="/feeds">Back to FeedZero</a>
+      </p>
+    </div>
+  );
+}

--- a/src/pages/billing-success.tsx
+++ b/src/pages/billing-success.tsx
@@ -1,0 +1,60 @@
+/**
+ * Stripe Checkout success redirect target.
+ *
+ * Stripe sends customers here after a completed Checkout. The `session_id`
+ * query param is set by Stripe when our `success_url` includes the
+ * `{CHECKOUT_SESSION_ID}` template — see SubscribeButton's URL construction.
+ *
+ * UX contract:
+ *  - Confirmation heading so the customer knows the payment landed.
+ *  - LicenseTokenInput inline so they can paste their token without
+ *    navigating elsewhere. Once email delivery is wired, the email will
+ *    contain a deep-link OR the token will arrive in a webhook-driven
+ *    cookie/localStorage push — until then, manual paste is the path.
+ *  - Stripe session ID echoed in plain text for support debugging.
+ *  - A clear way back to the reader.
+ *
+ * The page renders unconditionally — there's no point gating it behind
+ * VITE_PAID_TIER_VISIBLE because users only land here AFTER going through
+ * the Subscribe → Checkout flow, which itself is gated. If they navigate
+ * here directly with no context, we still render it (the content is
+ * harmless) so a copy-pasted email link works regardless of build flag.
+ */
+
+import { useSearchParams } from "react-router";
+import { LicenseTokenInput } from "@/components/billing/license-token-input";
+
+export function BillingSuccess() {
+  const [searchParams] = useSearchParams();
+  const sessionId = searchParams.get("session_id");
+
+  return (
+    <div className="mx-auto max-w-xl p-8 space-y-6">
+      <h1 className="text-2xl font-semibold">
+        Thanks for subscribing to FeedZero
+      </h1>
+
+      <p>
+        Your payment has been processed. Check your email for your license
+        token, then paste it below to activate sync on this device.
+      </p>
+
+      {/*
+       * Always pass paidTierVisible=true here. The component itself is
+       * imported from PR Y where it's gated for the homepage; on the
+       * post-purchase page there's no reason to hide the input.
+       */}
+      <LicenseTokenInput paidTierVisible={true} />
+
+      {sessionId && (
+        <p className="text-sm text-muted-foreground">
+          Stripe session: <code>{sessionId}</code>
+        </p>
+      )}
+
+      <p>
+        <a href="/feeds">Back to FeedZero</a>
+      </p>
+    </div>
+  );
+}

--- a/tests/pages/billing-cancelled.test.tsx
+++ b/tests/pages/billing-cancelled.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { BillingCancelled } from "@/pages/billing-cancelled";
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/billing/cancelled"]}>
+      <BillingCancelled />
+    </MemoryRouter>,
+  );
+}
+
+describe("BillingCancelled page", () => {
+  it("renders a heading explaining no charge happened", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /cancel|no charge|no problem/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("includes a link back to the app", () => {
+    renderPage();
+    const link = screen.getByRole("link", {
+      name: /back to feedzero|continue|home|reader|feeds/i,
+    });
+    expect(link).toHaveAttribute("href", "/feeds");
+  });
+
+  it("does NOT render the license token input (no successful purchase to enter token for)", () => {
+    renderPage();
+    expect(screen.queryByPlaceholderText(/fz_/i)).not.toBeInTheDocument();
+  });
+});

--- a/tests/pages/billing-success.test.tsx
+++ b/tests/pages/billing-success.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { BillingSuccess } from "@/pages/billing-success";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+function renderWithRoute(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <BillingSuccess />
+    </MemoryRouter>,
+  );
+}
+
+describe("BillingSuccess page", () => {
+  it("renders a confirmation heading", () => {
+    renderWithRoute("/billing/success");
+    expect(
+      screen.getByRole("heading", { name: /thanks|welcome|success/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("includes the LicenseTokenInput so the user can paste their token", () => {
+    renderWithRoute("/billing/success?session_id=cs_test_xyz");
+    // The input is the LicenseTokenInput from PR Y, which renders a labeled
+    // text input with placeholder "fz_..." and a Save button.
+    expect(screen.getByPlaceholderText(/fz_/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /save/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the masked Stripe session_id when present (lets the user confirm Stripe acked)", () => {
+    renderWithRoute("/billing/success?session_id=cs_test_a1b2c3d4e5f6");
+    // Expose enough of the session id to verify, but not in a UX-heavy way —
+    // matters mostly for support debugging.
+    expect(screen.getByText(/cs_test_a1b2c3d4e5f6/)).toBeInTheDocument();
+  });
+
+  it("renders a link back to the app", () => {
+    renderWithRoute("/billing/success");
+    const link = screen.getByRole("link", {
+      name: /back to feedzero|continue|home|reader/i,
+    });
+    expect(link).toHaveAttribute("href", "/feeds");
+  });
+
+  it("renders without the session_id query param (defensive — direct nav)", () => {
+    renderWithRoute("/billing/success");
+    expect(
+      screen.getByRole("heading", { name: /thanks|welcome|success/i }),
+    ).toBeInTheDocument();
+    // No session_id text should appear when the param is absent
+    expect(screen.queryByText(/cs_/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Stripe Checkout sends customers to \`/billing/success\` and \`/billing/cancelled\` after the hosted checkout. Previously both URLs hit the SPA's catch-all → /feeds redirect, so users lost the Stripe context entirely. PR Y's SubscribeButton already wires those URLs in \`success_url\`/\`cancel_url\`, but the destination pages didn't exist.

## What you can now do that you couldn't before

Run the full Subscribe → Stripe Checkout → return-to-app flow without hitting a 404. The success page renders a \`LicenseTokenInput\` inline so users can paste the token they receive via email (once email is wired) and activate sync immediately.

## Companion docs (gitignored, local-only)

I dropped two operator references in \`docs/internal/\`:
- **\`test-e2e-payment-flow.md\`** — step-by-step walkthrough to test the full Subscribe → Checkout → webhook → license → sync chain locally with \`stripe listen\` + sandbox card \`4242\`
- **\`silent-launch-checklist.md\`** (from prior session) — operator activation steps for production silent launch

## Test plan

- [x] \`npm test\` — 1784 pass, 2 skipped
- [x] \`npx tsc --noEmit\` — clean
- [x] 8 new tests across success + cancelled pages
- [ ] Local e2e: follow \`docs/internal/test-e2e-payment-flow.md\` to verify the redirect actually lands cleanly + LicenseTokenInput accepts the paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)