### PR TITLE
fix(sync): auto-detect vercel-blob via BLOB_READ_WRITE_TOKEN

### DIFF
--- a/src/core/sync/adapters/resolve-adapter.ts
+++ b/src/core/sync/adapters/resolve-adapter.ts
@@ -4,19 +4,36 @@ import { createMemoryAdapter } from "./memory-adapter.ts";
 import { createVercelBlobAdapter } from "./vercel-blob-adapter.ts";
 
 /**
- * Resolve the sync storage adapter based on the SYNC_STORAGE env var.
- * Defaults to filesystem for self-hosting.
+ * Resolve the sync storage adapter based on the runtime environment.
  *
- * Supported values:
- * - "filesystem" (default) — stores vaults as JSON files on disk
- * - "vercel-blob" — uses Vercel Blob (requires BLOB_READ_WRITE_TOKEN)
- * - "memory" — in-memory storage (for dev/testing only)
+ * Resolution order (first match wins):
+ *  1. Explicit `storage` arg (caller-provided — test/server.ts pass this)
+ *  2. `process.env.SYNC_STORAGE` (operator override)
+ *  3. **Auto-detect**: `process.env.BLOB_READ_WRITE_TOKEN` present → `vercel-blob`
+ *     Vercel auto-injects this env var when Vercel Blob is wired up to the
+ *     project, so its presence is a reliable production signal.
+ *  4. Fallback → `filesystem` (correct for self-hosters without Blob)
+ *
+ * Supported values for `storage` / `SYNC_STORAGE`:
+ *  - "vercel-blob" — uses Vercel Blob (requires BLOB_READ_WRITE_TOKEN)
+ *  - "filesystem" — stores vaults as JSON files on disk
+ *  - "memory" — in-memory storage (dev/testing only)
+ *
+ * Why auto-detect rather than relying solely on SYNC_STORAGE: the prior
+ * implementation required SYNC_STORAGE to be exactly "vercel-blob", which
+ * created a production fragility — any typo, whitespace, or missing value
+ * silently fell through to the filesystem adapter, which then fails to
+ * `mkdir` in Vercel's read-only function filesystem.
  */
 export function resolveAdapter(
   storage?: string,
   dataDir?: string,
 ): SyncStorageAdapter {
-  const mode = storage ?? process.env.SYNC_STORAGE ?? "filesystem";
+  const explicitMode = storage ?? process.env.SYNC_STORAGE;
+  const autoDetectMode = process.env.BLOB_READ_WRITE_TOKEN
+    ? "vercel-blob"
+    : undefined;
+  const mode = explicitMode ?? autoDetectMode ?? "filesystem";
 
   switch (mode) {
     case "vercel-blob":

--- a/tests/core/sync/adapters/resolve-adapter.test.ts
+++ b/tests/core/sync/adapters/resolve-adapter.test.ts
@@ -20,6 +20,7 @@ describe("resolveAdapter", () => {
     process.env = { ...originalEnv };
     delete process.env.SYNC_STORAGE;
     delete process.env.DATA_DIR;
+    delete process.env.BLOB_READ_WRITE_TOKEN;
   });
 
   afterEach(() => {
@@ -73,5 +74,44 @@ describe("resolveAdapter", () => {
     );
     resolveAdapter("filesystem");
     expect(createFilesystemAdapter).toHaveBeenCalledWith("/env/data");
+  });
+
+  describe("auto-detect via BLOB_READ_WRITE_TOKEN (hotfix for prod regression)", () => {
+    // Context: Vercel auto-injects BLOB_READ_WRITE_TOKEN when the project has
+    // Vercel Blob configured. Its presence IS the production signal that we
+    // want the blob adapter. Previously we required SYNC_STORAGE to be
+    // exactly "vercel-blob" — a string the operator had to remember to set.
+    // PR W's source-form `api/sync.ts` exposed this fragility; if
+    // SYNC_STORAGE was anything other than the exact string, we silently
+    // fell through to filesystem, which can't mkdir in a Vercel Lambda.
+
+    it("auto-detects vercel-blob when BLOB_READ_WRITE_TOKEN is set and SYNC_STORAGE is unset", () => {
+      process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_test_token";
+      const adapter = resolveAdapter() as unknown as { type: string };
+      expect(adapter.type).toBe("vercel-blob");
+    });
+
+    it("explicit SYNC_STORAGE=filesystem overrides auto-detect", () => {
+      // Self-hoster on Vercel who wants the FS adapter anyway (unlikely but
+      // legitimate): explicit env wins over auto-detect.
+      process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_test_token";
+      process.env.SYNC_STORAGE = "filesystem";
+      const adapter = resolveAdapter() as unknown as { type: string };
+      expect(adapter.type).toBe("filesystem");
+    });
+
+    it("explicit storage arg overrides auto-detect", () => {
+      // Tests pass storage arg directly; auto-detect must not intrude.
+      process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_test_token";
+      const adapter = resolveAdapter("memory") as unknown as { type: string };
+      expect(adapter.type).toBe("memory");
+    });
+
+    it("self-hosted (no BLOB token, no SYNC_STORAGE) still defaults to filesystem", () => {
+      // Regression guard: the autodetect must not change behavior for
+      // self-hosters who run without Vercel Blob.
+      const adapter = resolveAdapter() as unknown as { type: string };
+      expect(adapter.type).toBe("filesystem");
+    });
   });
 });


### PR DESCRIPTION
## Summary

**Production regression** — every PUT /api/sync returns 500 ENOENT \`mkdir 'data/vaults'\`. Reported by user \`kenkiller\` 14h ago; runtime logs confirm 100% PUT failure rate in the last hour.

## Root cause

PR W (#38) rewrote \`api/sync.ts\` from a legacy bundled wrapper (which hardcoded \`createVercelBlobAdapter()\`) to a source-form wrapper calling \`resolveAdapter()\`. That function required \`SYNC_STORAGE\` to be exactly \`"vercel-blob"\` — any other value silently fell through to filesystem, which can't mkdir in Vercel's read-only Lambda FS.

## Fix

Add auto-detect: if \`BLOB_READ_WRITE_TOKEN\` env is present (Vercel auto-injects when Blob is configured), use vercel-blob regardless of \`SYNC_STORAGE\`. Self-hosters without the token correctly default to filesystem. Explicit override preserved.

## Test plan

- [x] \`npm test\` → 1788 pass + 4 new tests covering autodetect path
- [x] \`npx tsc --noEmit\` → clean
- [ ] After merge + auto-deploy: \`curl -X PUT https://my.feedzero.app/api/sync -d '{"vaultId":"...","vault":{...}}'\` → 200, not 500
- [ ] Confirm \`kenkiller\` can sync again

## Follow-up

Observability PR (coming next) — adds module-load adapter logging so this class of regression surfaces in deploy logs immediately rather than via user reports 14h later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)