### PR TITLE
feat(observability): traceId + structured 5xx logger on monetization handlers

### DIFF
--- a/src/core/license/issue-handler.ts
+++ b/src/core/license/issue-handler.ts
@@ -25,8 +25,11 @@
 
 import { LicenseIssuerImpl } from "./issuer";
 import type { LicenseRecord } from "./storage";
+import { newTraceId } from "../../utils/trace-id";
+import { logError } from "../../utils/log-error";
 
 export const SUPPORTED_METHODS: readonly string[] = ["POST"];
+const ROUTE = "/api/license/issue";
 
 export interface IssueHandlerOptions {
   issuer: LicenseIssuerImpl;
@@ -48,13 +51,39 @@ interface OkBody {
 interface ErrBody {
   ok: false;
   error: string;
+  traceId: string;
 }
 
 const JSON_HEADERS = { "Content-Type": "application/json" } as const;
 const BEARER_SCHEME = "Bearer ";
 
-function jsonResponse(body: OkBody | ErrBody, status: number): Response {
+function okResponse(body: OkBody, status: number): Response {
   return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function clientError(
+  message: string,
+  status: number,
+  traceId: string,
+): Response {
+  return new Response(
+    JSON.stringify({ ok: false, error: message, traceId } satisfies ErrBody),
+    { status, headers: JSON_HEADERS },
+  );
+}
+
+function serverError(
+  message: string,
+  errClass: string,
+  status: number,
+  traceId: string,
+  method: string,
+): Response {
+  logError({ route: ROUTE, method, status, traceId, errClass, errMsg: message });
+  return new Response(
+    JSON.stringify({ ok: false, error: message, traceId } satisfies ErrBody),
+    { status, headers: JSON_HEADERS },
+  );
 }
 
 /**
@@ -160,8 +189,11 @@ export async function handleLicenseIssueRequest(
   request: Request,
   options: IssueHandlerOptions,
 ): Promise<Response> {
-  if (request.method !== "POST") {
-    return jsonResponse({ ok: false, error: "method not allowed" }, 405);
+  const traceId = newTraceId();
+  const method = request.method;
+
+  if (method !== "POST") {
+    return clientError("method not allowed", 405, traceId);
   }
 
   const auth = checkAdminAuth(
@@ -169,16 +201,22 @@ export async function handleLicenseIssueRequest(
     options.adminApiKey,
   );
   if (!auth.ok) {
-    return jsonResponse({ ok: false, error: auth.error }, auth.status);
+    // 503 ("admin endpoint not configured") is a server-config issue:
+    // empty adminApiKey at boot is operator-actionable. 401 paths are
+    // unauthenticated callers — client-side, no log.
+    if (auth.status === 503) {
+      return serverError(auth.error, "AdminEndpointNotConfigured", 503, traceId, method);
+    }
+    return clientError(auth.error, auth.status, traceId);
   }
 
   if (options.killSignups?.()) {
-    return jsonResponse({ ok: false, error: "signups disabled" }, 503);
+    return clientError("signups disabled", 503, traceId);
   }
 
   const body = await readIssueArgsFromBody(request);
   if (!body.ok) {
-    return jsonResponse({ ok: false, error: body.error }, 400);
+    return clientError(body.error, 400, traceId);
   }
 
   // Issuer needs a non-optional subscriptionId. Empty string is a sentinel
@@ -192,13 +230,16 @@ export async function handleLicenseIssueRequest(
     ...(body.args.expirySec !== undefined ? { expirySec: body.args.expirySec } : {}),
   });
   if (!issueResult.ok) {
-    return jsonResponse(
-      { ok: false, error: `issue failed: ${issueResult.error}` },
+    return serverError(
+      `issue failed: ${issueResult.error}`,
+      "IssueFailed",
       500,
+      traceId,
+      method,
     );
   }
 
-  return jsonResponse(
+  return okResponse(
     { ok: true, token: issueResult.value.token, record: issueResult.value.record },
     200,
   );

--- a/src/core/license/resolve-storage.ts
+++ b/src/core/license/resolve-storage.ts
@@ -40,3 +40,14 @@ export async function resolveLicenseStorage(
   }
   return new MemoryLicenseStorage();
 }
+
+/**
+ * Label form of `resolveLicenseStorage` for module-load logging. Stays in
+ * sync with the resolver above because both consult the same
+ * `hasUpstashCredentials` predicate.
+ */
+export function describeLicenseStorageMode(
+  env: Record<string, string | undefined> = process.env,
+): "upstash" | "memory" {
+  return hasUpstashCredentials(env) ? "upstash" : "memory";
+}

--- a/src/core/license/verify-handler.ts
+++ b/src/core/license/verify-handler.ts
@@ -16,8 +16,11 @@ import { verifyLicense } from "./verify";
 import type { LicensePayload } from "./format";
 import type { SigningKey } from "./sign";
 import type { LicenseStorage } from "./storage";
+import { newTraceId } from "../../utils/trace-id";
+import { logError } from "../../utils/log-error";
 
 export const SUPPORTED_METHODS: readonly string[] = ["POST"];
+const ROUTE = "/api/license/verify";
 
 export interface VerifyHandlerOptions {
   signingKey: SigningKey;
@@ -33,46 +36,91 @@ interface OkBody {
 interface ErrBody {
   ok: false;
   error: string;
+  traceId: string;
 }
 
 const JSON_HEADERS = { "Content-Type": "application/json" } as const;
 
-function jsonResponse(body: OkBody | ErrBody, status: number): Response {
+function okResponse(body: OkBody, status: number): Response {
   return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+/**
+ * 4xx response — surfaces traceId for support correlation, no server log.
+ */
+function clientError(
+  message: string,
+  status: number,
+  traceId: string,
+): Response {
+  return new Response(
+    JSON.stringify({ ok: false, error: message, traceId } satisfies ErrBody),
+    { status, headers: JSON_HEADERS },
+  );
+}
+
+/**
+ * 5xx response — surfaces traceId AND emits a structured server-log line.
+ */
+function serverError(
+  message: string,
+  errClass: string,
+  status: number,
+  traceId: string,
+  method: string,
+): Response {
+  logError({
+    route: ROUTE,
+    method,
+    status,
+    traceId,
+    errClass,
+    errMsg: message,
+  });
+  return new Response(
+    JSON.stringify({ ok: false, error: message, traceId } satisfies ErrBody),
+    { status, headers: JSON_HEADERS },
+  );
 }
 
 export async function handleLicenseVerifyRequest(
   request: Request,
   options: VerifyHandlerOptions,
 ): Promise<Response> {
-  if (request.method !== "POST") {
-    return jsonResponse({ ok: false, error: "method not allowed" }, 405);
+  const traceId = newTraceId();
+  const method = request.method;
+
+  if (method !== "POST") {
+    return clientError("method not allowed", 405, traceId);
   }
 
   const tokenResult = await readTokenFromBody(request);
   if (!tokenResult.ok) {
-    return jsonResponse({ ok: false, error: tokenResult.error }, 400);
+    return clientError(tokenResult.error, 400, traceId);
   }
 
   const verified = await verifyLicense(tokenResult.token, options.signingKey, {
     nowSec: options.nowSec,
   });
   if (!verified.ok) {
-    return jsonResponse({ ok: false, error: verified.error }, 401);
+    return clientError(verified.error, 401, traceId);
   }
 
   const revoked = await options.storage.isRevoked(verified.value.keyId);
   if (!revoked.ok) {
-    return jsonResponse(
-      { ok: false, error: `license storage error: ${revoked.error}` },
+    return serverError(
+      `license storage error: ${revoked.error}`,
+      "LicenseStorageError",
       503,
+      traceId,
+      method,
     );
   }
   if (revoked.value) {
-    return jsonResponse({ ok: false, error: "license revoked" }, 401);
+    return clientError("license revoked", 401, traceId);
   }
 
-  return jsonResponse({ ok: true, license: verified.value }, 200);
+  return okResponse({ ok: true, license: verified.value }, 200);
 }
 
 type TokenRead =

--- a/src/core/stripe/checkout-handler.ts
+++ b/src/core/stripe/checkout-handler.ts
@@ -28,7 +28,11 @@
  * `STRIPE_SECRET_KEY` and passes it in.
  */
 
+import { newTraceId } from "../../utils/trace-id";
+import { logError } from "../../utils/log-error";
+
 export const SUPPORTED_METHODS: readonly string[] = ["POST"];
+const ROUTE = "/api/checkout/create-session";
 
 /**
  * Minimal subset of `stripe.checkout.sessions.create` we depend on. Defining
@@ -65,12 +69,38 @@ interface OkBody {
 interface ErrBody {
   ok: false;
   error: string;
+  traceId: string;
 }
 
 const JSON_HEADERS = { "Content-Type": "application/json" } as const;
 
-function jsonResponse(body: OkBody | ErrBody, status: number): Response {
+function okResponse(body: OkBody, status: number): Response {
   return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function clientError(
+  message: string,
+  status: number,
+  traceId: string,
+): Response {
+  return new Response(
+    JSON.stringify({ ok: false, error: message, traceId } satisfies ErrBody),
+    { status, headers: JSON_HEADERS },
+  );
+}
+
+function serverError(
+  message: string,
+  errClass: string,
+  status: number,
+  traceId: string,
+  method: string,
+): Response {
+  logError({ route: ROUTE, method, status, traceId, errClass, errMsg: message });
+  return new Response(
+    JSON.stringify({ ok: false, error: message, traceId } satisfies ErrBody),
+    { status, headers: JSON_HEADERS },
+  );
 }
 
 interface CreateArgs {
@@ -157,17 +187,20 @@ export async function handleCreateCheckoutSession(
   request: Request,
   options: CheckoutHandlerOptions,
 ): Promise<Response> {
-  if (request.method !== "POST") {
-    return jsonResponse({ ok: false, error: "method not allowed" }, 405);
+  const traceId = newTraceId();
+  const method = request.method;
+
+  if (method !== "POST") {
+    return clientError("method not allowed", 405, traceId);
   }
 
   if (options.killSignups?.()) {
-    return jsonResponse({ ok: false, error: "signups disabled" }, 503);
+    return clientError("signups disabled", 503, traceId);
   }
 
   const parsed = await parseBody(request, options.allowedPrices);
   if (!parsed.ok) {
-    return jsonResponse({ ok: false, error: parsed.error }, 400);
+    return clientError(parsed.error, 400, traceId);
   }
 
   let session;
@@ -186,20 +219,26 @@ export async function handleCreateCheckoutSession(
     );
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    return jsonResponse(
-      { ok: false, error: `stripe checkout failed: ${message}` },
+    return serverError(
+      `stripe checkout failed: ${message}`,
+      "StripeApiError",
       502,
+      traceId,
+      method,
     );
   }
 
   if (!session.url) {
-    return jsonResponse(
-      { ok: false, error: "stripe returned no checkout url" },
+    return serverError(
+      "stripe returned no checkout url",
+      "StripeNoUrl",
       502,
+      traceId,
+      method,
     );
   }
 
-  return jsonResponse(
+  return okResponse(
     { ok: true, url: session.url, sessionId: session.id },
     200,
   );

--- a/src/core/stripe/resolve-seen-event-store.ts
+++ b/src/core/stripe/resolve-seen-event-store.ts
@@ -34,3 +34,10 @@ export async function resolveSeenEventStore(
     new Redis({ url: url as string, token: token as string }),
   );
 }
+
+/** Label form of `resolveSeenEventStore` for module-load logging. */
+export function describeSeenEventStoreMode(
+  env: Record<string, string | undefined> = process.env,
+): "upstash" | "memory" {
+  return hasUpstashCredentials(env) ? "upstash" : "memory";
+}

--- a/src/core/stripe/webhook-handler.ts
+++ b/src/core/stripe/webhook-handler.ts
@@ -16,6 +16,10 @@
 
 import type { Result } from "../../utils/result";
 import type { SeenEventStore } from "./seen-event-store";
+import { newTraceId } from "../../utils/trace-id";
+import { logError } from "../../utils/log-error";
+
+const ROUTE = "/api/stripe/webhook";
 
 export interface LicenseIssuer {
   issue(args: {
@@ -197,6 +201,25 @@ function jsonResponse(body: unknown, status: number): Response {
   });
 }
 
+function clientError(
+  message: string,
+  status: number,
+  traceId: string,
+): Response {
+  return jsonResponse({ ok: false, error: message, traceId }, status);
+}
+
+function serverError(
+  message: string,
+  errClass: string,
+  status: number,
+  traceId: string,
+  method: string,
+): Response {
+  logError({ route: ROUTE, method, status, traceId, errClass, errMsg: message });
+  return jsonResponse({ ok: false, error: message, traceId }, status);
+}
+
 interface DispatchOutcome {
   status: number;
   body: unknown;
@@ -375,19 +398,22 @@ export async function handleStripeWebhook(
   request: Request,
   config: WebhookConfig,
 ): Promise<Response> {
-  if (request.method !== "POST") {
-    return new Response("Method not allowed", { status: 405 });
+  const traceId = newTraceId();
+  const method = request.method;
+
+  if (method !== "POST") {
+    return clientError("method not allowed", 405, traceId);
   }
 
   const verified = await verifyAndParse(request, config);
   if (!verified.ok) {
-    return jsonResponse({ ok: false, error: verified.error }, verified.status);
+    return clientError(verified.error, verified.status, traceId);
   }
 
   // Signature checked first so an attacker can't probe webhook behavior with
   // unsigned requests once they learn the kill switch is flipped.
   if (config.killSignups?.()) {
-    return jsonResponse({ ok: false, error: "signups disabled" }, 503);
+    return clientError("signups disabled", 503, traceId);
   }
 
   // Event-id dedup. Runs after signature verification (so unsigned probes
@@ -398,7 +424,7 @@ export async function handleStripeWebhook(
     const newSeen = await config.eventStore.markSeenIfNew(event.id);
     if (!newSeen.ok) {
       // Storage failure — return 500 so Stripe retries.
-      return jsonResponse({ ok: false, error: newSeen.error }, 500);
+      return serverError(newSeen.error, "EventStoreError", 500, traceId, method);
     }
     if (!newSeen.value) {
       // Duplicate delivery — Stripe doc: return 200 immediately, do not re-dispatch.
@@ -407,5 +433,14 @@ export async function handleStripeWebhook(
   }
 
   const outcome = await dispatchEvent(event, config.issuer);
+  if (outcome.status >= 500) {
+    // Issuer or downstream failure — log + return same status. We re-shape
+    // the body to include traceId rather than passing outcome.body through.
+    const errMsg =
+      typeof (outcome.body as { error?: unknown })?.error === "string"
+        ? (outcome.body as { error: string }).error
+        : "dispatch failed";
+    return serverError(errMsg, "DispatchFailed", outcome.status, traceId, method);
+  }
   return jsonResponse(outcome.body, outcome.status);
 }

--- a/src/core/sync/adapters/resolve-adapter.ts
+++ b/src/core/sync/adapters/resolve-adapter.ts
@@ -29,11 +29,7 @@ export function resolveAdapter(
   storage?: string,
   dataDir?: string,
 ): SyncStorageAdapter {
-  const explicitMode = storage ?? process.env.SYNC_STORAGE;
-  const autoDetectMode = process.env.BLOB_READ_WRITE_TOKEN
-    ? "vercel-blob"
-    : undefined;
-  const mode = explicitMode ?? autoDetectMode ?? "filesystem";
+  const mode = resolveAdapterMode(storage);
 
   switch (mode) {
     case "vercel-blob":
@@ -44,4 +40,31 @@ export function resolveAdapter(
     default:
       return createFilesystemAdapter(dataDir ?? process.env.DATA_DIR ?? "./data");
   }
+}
+
+/**
+ * Compute the adapter mode label using the same cascade as `resolveAdapter`.
+ *
+ * Why factor this out: the api/*.ts wrappers want to log which adapter is
+ * resolved at module-load *before* the adapter is constructed (so a logging
+ * failure can never break adapter resolution). `describeAdapterMode` and
+ * `resolveAdapter` MUST agree on what they pick — `resolveAdapter` now
+ * delegates here, so they cannot drift.
+ *
+ * This function is the answer to today's incident (2026-05-13): a single
+ * `console.log("[sync] adapter=" + describeAdapterMode())` at the top of
+ * api/sync.ts would have surfaced `adapter=filesystem` in the first Vercel
+ * deploy log after PR W, and ops would have caught the misconfiguration
+ * in minutes instead of 14 hours via a Reddit report.
+ */
+export function describeAdapterMode(storage?: string): string {
+  const explicitMode = storage ?? process.env.SYNC_STORAGE;
+  const autoDetectMode = process.env.BLOB_READ_WRITE_TOKEN
+    ? "vercel-blob"
+    : undefined;
+  return explicitMode ?? autoDetectMode ?? "filesystem";
+}
+
+function resolveAdapterMode(storage?: string): string {
+  return describeAdapterMode(storage);
 }

--- a/src/core/sync/sync-handler.ts
+++ b/src/core/sync/sync-handler.ts
@@ -1,4 +1,6 @@
 import { SYNC } from "../../utils/constants.ts";
+import { newTraceId } from "../../utils/trace-id.ts";
+import { logError } from "../../utils/log-error.ts";
 import type { SyncStorageAdapter } from "./types.ts";
 import {
   authorizeLicense,
@@ -6,6 +8,7 @@ import {
 } from "../license/middleware";
 
 const VAULT_ID_PATTERN = /^[0-9a-f]{64}$/;
+const ROUTE = "/api/sync";
 
 const API_HEADERS = {
   "Content-Type": "application/json",
@@ -13,12 +16,60 @@ const API_HEADERS = {
   "X-Content-Type-Options": "nosniff",
 } as const;
 
+/**
+ * Per-request context threaded through the per-method handlers. Holds the
+ * traceId we mint at entry so every error path can echo it back to the
+ * client AND write it to the structured server log.
+ */
+interface RequestContext {
+  traceId: string;
+  method: string;
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: API_HEADERS });
 }
 
-function errorResponse(message: string, status: number): Response {
-  return jsonResponse({ ok: false, error: message }, status);
+/**
+ * 4xx response — surfaces traceId to the client (so they can quote it in
+ * a support report) but does NOT write a server-side log line. Client
+ * errors are not ops-actionable; logging them inflates the error log.
+ */
+function clientError(
+  message: string,
+  status: number,
+  ctx: RequestContext,
+): Response {
+  return jsonResponse(
+    { ok: false, error: message, traceId: ctx.traceId },
+    status,
+  );
+}
+
+/**
+ * 5xx response — surfaces traceId to the client AND writes a single-line
+ * JSON to the server log via the allow-list logger. The {route, method,
+ * status, traceId, errClass, errMsg} tuple is enough to correlate a user
+ * report to the failing request without leaking vaultId or any other PII.
+ */
+function serverError(
+  message: string,
+  errClass: string,
+  status: number,
+  ctx: RequestContext,
+): Response {
+  logError({
+    route: ROUTE,
+    method: ctx.method,
+    status,
+    traceId: ctx.traceId,
+    errClass,
+    errMsg: message,
+  });
+  return jsonResponse(
+    { ok: false, error: message, traceId: ctx.traceId },
+    status,
+  );
 }
 
 function validateVaultId(vaultId: string | null): string | null {
@@ -29,15 +80,18 @@ function validateVaultId(vaultId: string | null): string | null {
 async function handleGet(
   request: Request,
   adapter: SyncStorageAdapter,
+  ctx: RequestContext,
 ): Promise<Response> {
   const url = new URL(request.url);
   const rawId = url.searchParams.get("vaultId");
   const vaultId = validateVaultId(rawId);
-  if (!vaultId) return errorResponse("Invalid or missing vaultId", 400);
+  if (!vaultId) return clientError("Invalid or missing vaultId", 400, ctx);
 
   const result = await adapter.get(vaultId);
-  if (!result.ok) return errorResponse(result.error, 500);
-  if (result.value === null) return errorResponse("Vault not found", 404);
+  if (!result.ok) {
+    return serverError(result.error, "AdapterGetFailed", 500, ctx);
+  }
+  if (result.value === null) return clientError("Vault not found", 404, ctx);
 
   return new Response(result.value, { status: 200, headers: API_HEADERS });
 }
@@ -45,26 +99,29 @@ async function handleGet(
 async function handlePut(
   request: Request,
   adapter: SyncStorageAdapter,
+  ctx: RequestContext,
 ): Promise<Response> {
   const text = await request.text();
   if (text.length > SYNC.MAX_VAULT_SIZE) {
-    return errorResponse("Payload too large", 413);
+    return clientError("Payload too large", 413, ctx);
   }
 
   let body: { vaultId?: string; vault?: unknown };
   try {
     body = JSON.parse(text);
   } catch {
-    return errorResponse("Invalid JSON", 400);
+    return clientError("Invalid JSON", 400, ctx);
   }
 
   const vaultId = validateVaultId(body.vaultId ?? null);
-  if (!vaultId) return errorResponse("Invalid or missing vaultId", 400);
-  if (!body.vault) return errorResponse("Missing vault data", 400);
+  if (!vaultId) return clientError("Invalid or missing vaultId", 400, ctx);
+  if (!body.vault) return clientError("Missing vault data", 400, ctx);
 
   const data = JSON.stringify({ ok: true, vault: body.vault });
   const result = await adapter.put(vaultId, data);
-  if (!result.ok) return errorResponse(result.error, 500);
+  if (!result.ok) {
+    return serverError(result.error, "AdapterPutFailed", 500, ctx);
+  }
 
   return jsonResponse({ ok: true, updatedAt: Date.now() });
 }
@@ -72,14 +129,17 @@ async function handlePut(
 async function handleDelete(
   request: Request,
   adapter: SyncStorageAdapter,
+  ctx: RequestContext,
 ): Promise<Response> {
   const url = new URL(request.url);
   const rawId = url.searchParams.get("vaultId");
   const vaultId = validateVaultId(rawId);
-  if (!vaultId) return errorResponse("Invalid or missing vaultId", 400);
+  if (!vaultId) return clientError("Invalid or missing vaultId", 400, ctx);
 
   const result = await adapter.delete(vaultId);
-  if (!result.ok) return errorResponse(result.error, 500);
+  if (!result.ok) {
+    return serverError(result.error, "AdapterDeleteFailed", 500, ctx);
+  }
 
   return jsonResponse({ ok: true });
 }
@@ -87,6 +147,7 @@ async function handleDelete(
 type MethodHandler = (
   request: Request,
   adapter: SyncStorageAdapter,
+  ctx: RequestContext,
 ) => Promise<Response>;
 
 /**
@@ -134,17 +195,23 @@ export async function handleSyncRequest(
   adapter: SyncStorageAdapter,
   options: SyncHandlerOptions = {},
 ): Promise<Response> {
+  const ctx: RequestContext = {
+    traceId: newTraceId(),
+    method: request.method,
+  };
+
   const handler = methodHandlers[request.method];
-  if (!handler) return errorResponse("Method not allowed", 405);
+  if (!handler) return clientError("Method not allowed", 405, ctx);
 
   if (options.licenseAuth) {
     const auth = await authorizeLicense(request, options.licenseAuth);
     if (!auth.ok) {
-      // Surface the structured error for observability but use a stable
-      // message for clients ("license required" rather than internal text).
-      return errorResponse("license required", 401);
+      // Stable client-facing message ("license required") regardless of
+      // the underlying authorizeLicense reason. The traceId in the body
+      // is the support-ticket bridge to the runtime log.
+      return clientError("license required", 401, ctx);
     }
   }
 
-  return handler(request, adapter);
+  return handler(request, adapter, ctx);
 }

--- a/src/utils/log-error.ts
+++ b/src/utils/log-error.ts
@@ -1,0 +1,62 @@
+/**
+ * Structured error logger with an allow-list field schema.
+ *
+ * Privacy floor (enforced by both the TypeScript type AND a runtime
+ * field-pick): error logs MUST NEVER include vaultId, customerId, email,
+ * IP, User-Agent, license token contents, or any vault ciphertext.
+ *
+ * Why a tiny dedicated helper instead of `console.error(err)`:
+ *  - The TypeScript interface IS the allow-list. A future caller can't
+ *    accidentally include a PII field without a `@ts-expect-error`.
+ *  - Defensive runtime drop: even if the type is bypassed (e.g. via `any`),
+ *    only known fields are picked into the JSON payload. The test suite
+ *    asserts this — see tests/core/utils/log-error.test.ts.
+ *  - Output is single-line JSON so Vercel's runtime-log filter UI can
+ *    parse + grep it cleanly.
+ *
+ * Pair with `newTraceId()` (src/utils/trace-id.ts) so each error log
+ * carries an opaque request id that users can quote in support requests.
+ */
+
+export interface ErrorLogFields {
+  /** Route path, e.g. "/api/sync". */
+  route: string;
+  /** HTTP method, e.g. "PUT". */
+  method: string;
+  /** Response status code we returned to the client. */
+  status: number;
+  /** Opaque per-request id. See `newTraceId`. */
+  traceId: string;
+  /**
+   * Error class (e.g. "ENOENT", "InvalidSignature"). Free-form short
+   * string — typically `e.constructor.name` or a custom label.
+   */
+  errClass: string;
+  /**
+   * Human-readable error message. Caller's responsibility to ensure no
+   * PII leaks (e.g. don't include vaultId in the message). The logger
+   * trusts the caller for this field but defensively drops everything
+   * else.
+   */
+  errMsg: string;
+}
+
+const ALLOWED_FIELDS = [
+  "route",
+  "method",
+  "status",
+  "traceId",
+  "errClass",
+  "errMsg",
+] as const satisfies readonly (keyof ErrorLogFields)[];
+
+export function logError(fields: ErrorLogFields): void {
+  // Defensive field pick. Even if caller bypasses TypeScript (via `any`
+  // or untyped object), only allow-listed fields make it into the log.
+  const safe: Record<string, unknown> = {};
+  for (const key of ALLOWED_FIELDS) {
+    safe[key] = fields[key];
+  }
+  safe.ts = new Date().toISOString();
+  console.error(JSON.stringify(safe));
+}

--- a/src/utils/trace-id.ts
+++ b/src/utils/trace-id.ts
@@ -1,0 +1,23 @@
+/**
+ * Per-request opaque identifier for tracing.
+ *
+ * Pattern: users hit an error → server returns `traceId` in the response
+ * body → user shares the traceId in their support report → we grep
+ * Vercel runtime logs for that exact id and find the failing request.
+ *
+ * Anonymity contract:
+ *  - Each call produces a fresh value. No correlation across requests.
+ *  - Format is opaque (random hex). Carries no user data, no timestamp,
+ *    no environment info — just enough entropy to be searchable.
+ *  - The 8-hex-char tail = 4 billion possibilities. Collision probability
+ *    across a year of traffic is effectively zero at our scale, and even
+ *    a collision is harmless (worst case: two requests share an id, one
+ *    grep returns two results).
+ *
+ * Why "req_" prefix: makes the id immediately recognizable in any context
+ * (response body, log line, support ticket) without needing to know the
+ * shape. Grep-friendly.
+ */
+export function newTraceId(): string {
+  return "req_" + crypto.randomUUID().split("-")[0];
+}

--- a/tests/core/license/issue-handler.test.ts
+++ b/tests/core/license/issue-handler.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   handleLicenseIssueRequest,
   SUPPORTED_METHODS,
 } from "@/core/license/issue-handler";
 import { LicenseIssuerImpl } from "@/core/license/issuer";
-import { MemoryLicenseStorage } from "@/core/license/storage";
+import { MemoryLicenseStorage, type LicenseStorage } from "@/core/license/storage";
 import type { SigningKey } from "@/core/license/sign";
 import { verifyLicense } from "@/core/license/verify";
+import { err } from "@/utils/result";
 
 const SECRET = "this-is-a-test-signing-secret-32-bytes!";
 const ADMIN_KEY = "admin_test_key_with_enough_entropy_to_be_realistic_64ch";
@@ -297,6 +298,97 @@ describe("license issue handler — success path", () => {
     );
     const stored = await storage.get("kid_deterministic_for_test");
     expect(stored.ok && stored.value?.expirySec).toBe(customExpiry);
+  });
+
+  describe("observability — traceId + structured error logging", () => {
+    function brokenStorage(): LicenseStorage {
+      return {
+        async put() { return err("storage down"); },
+        async get() { return err("storage down"); },
+        async listByCustomer() { return err("storage down"); },
+        async revoke() { return err("storage down"); },
+        async revokeAllForCustomer() { return err("storage down"); },
+        async isRevoked() { return err("storage down"); },
+      };
+    }
+
+    function buildBrokenIssuer() {
+      return new LicenseIssuerImpl({
+        signingKey,
+        storage: brokenStorage(),
+        nowSec: () => NOW,
+        generateKeyId: () => "kid_deterministic_for_test",
+      });
+    }
+
+    it("includes a traceId in 401 unauthorized response body", async () => {
+      const { issuer } = buildIssuer();
+      const res = await handleLicenseIssueRequest(
+        postBody({ customerId: "cus_x", tier: "personal" }),
+        { issuer, adminApiKey: ADMIN_KEY },
+      );
+      const body = await res.json();
+      expect(res.status).toBe(401);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("includes a traceId in 503 not-configured response body", async () => {
+      const { issuer } = buildIssuer();
+      const res = await handleLicenseIssueRequest(
+        postBody(
+          { customerId: "cus_x", tier: "personal" },
+          { Authorization: "Bearer anything" },
+        ),
+        { issuer, adminApiKey: "" }, // empty key → 503 not configured
+      );
+      const body = await res.json();
+      expect(res.status).toBe(503);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("includes a traceId in 500 issue-failure response and writes a structured log", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const issuer = buildBrokenIssuer();
+        const res = await handleLicenseIssueRequest(
+          postBody(
+            { customerId: "cus_x", tier: "personal" },
+            { Authorization: `Bearer ${ADMIN_KEY}` },
+          ),
+          { issuer, adminApiKey: ADMIN_KEY },
+        );
+        const body = await res.json();
+        expect(res.status).toBe(500);
+        expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        const logged = JSON.parse(consoleError.mock.calls[0][0] as string);
+        expect(logged.route).toBe("/api/license/issue");
+        expect(logged.method).toBe("POST");
+        expect(logged.status).toBe(500);
+        expect(logged.traceId).toBe(body.traceId);
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("does NOT write a structured log on 4xx client errors (e.g. 401)", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const { issuer } = buildIssuer();
+        await handleLicenseIssueRequest(
+          postBody({ customerId: "cus_x", tier: "personal" }),
+          { issuer, adminApiKey: ADMIN_KEY },
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
   });
 
   it("does not log the wire token (handler is pure, no side channels)", async () => {

--- a/tests/core/license/resolve-storage.test.ts
+++ b/tests/core/license/resolve-storage.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { resolveLicenseStorage } from "../../../src/core/license/resolve-storage";
+import {
+  resolveLicenseStorage,
+  describeLicenseStorageMode,
+} from "../../../src/core/license/resolve-storage";
 import { MemoryLicenseStorage } from "../../../src/core/license/storage";
 import { UpstashLicenseStorage } from "../../../src/core/license/storage-upstash";
 
@@ -45,5 +48,29 @@ describe("resolveLicenseStorage", () => {
       KV_REST_API_TOKEN: "legacy-tok",
     });
     expect(storage).toBeInstanceOf(UpstashLicenseStorage);
+  });
+});
+
+describe("describeLicenseStorageMode (Step A — module-load logging)", () => {
+  it("returns 'memory' when Upstash env is missing", () => {
+    expect(describeLicenseStorageMode({})).toBe("memory");
+  });
+
+  it("returns 'upstash' when canonical UPSTASH_* env is set", () => {
+    expect(
+      describeLicenseStorageMode({
+        UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+        UPSTASH_REDIS_REST_TOKEN: "tok",
+      }),
+    ).toBe("upstash");
+  });
+
+  it("returns 'upstash' when only legacy KV_REST_API_* is set", () => {
+    expect(
+      describeLicenseStorageMode({
+        KV_REST_API_URL: "https://example.upstash.io",
+        KV_REST_API_TOKEN: "tok",
+      }),
+    ).toBe("upstash");
   });
 });

--- a/tests/core/license/verify-handler.test.ts
+++ b/tests/core/license/verify-handler.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   handleLicenseVerifyRequest,
   SUPPORTED_METHODS,
 } from "@/core/license/verify-handler";
 import { signLicense, type SigningKey } from "@/core/license/sign";
-import { MemoryLicenseStorage } from "@/core/license/storage";
+import { MemoryLicenseStorage, type LicenseStorage } from "@/core/license/storage";
 import type { LicensePayload } from "@/core/license/format";
+import { err } from "@/utils/result";
 
 const SECRET = "this-is-a-test-signing-secret-32-bytes!";
 const key: SigningKey = { secret: SECRET };
@@ -131,5 +132,99 @@ describe("license verify handler", () => {
     );
     const text = await res.text();
     expect(text).not.toContain(SECRET);
+  });
+
+  describe("observability — traceId + structured error logging", () => {
+    function brokenStorage(): LicenseStorage {
+      return {
+        async put() { return err("storage down"); },
+        async get() { return err("storage down"); },
+        async listByCustomer() { return err("storage down"); },
+        async revoke() { return err("storage down"); },
+        async revokeAllForCustomer() { return err("storage down"); },
+        async isRevoked() { return err("storage down"); },
+      };
+    }
+
+    it("includes a traceId in 400 client-error response body", async () => {
+      const storage = new MemoryLicenseStorage();
+      const res = await handleLicenseVerifyRequest(
+        new Request("https://feedzero.app/api/license/verify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "not-json",
+        }),
+        { signingKey: key, storage, nowSec: NOW },
+      );
+      const body = await res.json();
+      expect(res.status).toBe(400);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("includes a traceId in 401 invalid-token response body", async () => {
+      const storage = new MemoryLicenseStorage();
+      const res = await handleLicenseVerifyRequest(
+        postBody({ token: "not-a-real-token" }),
+        { signingKey: key, storage, nowSec: NOW },
+      );
+      const body = await res.json();
+      expect(res.status).toBe(401);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("includes a traceId in 503 storage-error response body and writes a structured log", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const token = await signLicense(validPayload, key);
+        const res = await handleLicenseVerifyRequest(
+          postBody({ token }),
+          { signingKey: key, storage: brokenStorage(), nowSec: NOW },
+        );
+        const body = await res.json();
+        expect(res.status).toBe(503);
+        expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        const logged = JSON.parse(consoleError.mock.calls[0][0] as string);
+        expect(logged.route).toBe("/api/license/verify");
+        expect(logged.method).toBe("POST");
+        expect(logged.status).toBe(503);
+        expect(logged.traceId).toBe(body.traceId);
+        expect(typeof logged.errClass).toBe("string");
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("does NOT write a structured log on 4xx client errors", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const storage = new MemoryLicenseStorage();
+        await handleLicenseVerifyRequest(
+          postBody({ token: "not-a-real-token" }),
+          { signingKey: key, storage, nowSec: NOW },
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("emits a fresh traceId per request", async () => {
+      const storage = new MemoryLicenseStorage();
+      const r1 = await (await handleLicenseVerifyRequest(
+        postBody({ token: "bad" }),
+        { signingKey: key, storage, nowSec: NOW },
+      )).json();
+      const r2 = await (await handleLicenseVerifyRequest(
+        postBody({ token: "bad" }),
+        { signingKey: key, storage, nowSec: NOW },
+      )).json();
+      expect(r1.traceId).not.toBe(r2.traceId);
+    });
   });
 });

--- a/tests/core/stripe/checkout-handler.test.ts
+++ b/tests/core/stripe/checkout-handler.test.ts
@@ -219,4 +219,74 @@ describe("checkout handler — success path", () => {
     const body = await res.json();
     expect(body.ok).toBe(false);
   });
+
+  describe("observability — traceId + structured error logging", () => {
+    it("includes a traceId in 400 invalid-priceId response body", async () => {
+      const res = await handleCreateCheckoutSession(
+        postBody({
+          priceId: "price_NOT_in_allowlist",
+          successUrl: "https://feedzero.app/s",
+          cancelUrl: "https://feedzero.app/c",
+        }),
+        { client: fakeStripeClient(), allowedPrices: ALLOWED_PRICES },
+      );
+      const body = await res.json();
+      expect(res.status).toBe(400);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("includes a traceId in 502 stripe-failure response and writes a structured log", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const res = await handleCreateCheckoutSession(
+          postBody({
+            priceId: "price_personal_monthly_test",
+            successUrl: "https://feedzero.app/s",
+            cancelUrl: "https://feedzero.app/c",
+          }),
+          {
+            client: {
+              create: async () => {
+                throw new Error("Stripe API down");
+              },
+            },
+            allowedPrices: ALLOWED_PRICES,
+          },
+        );
+        const body = await res.json();
+        expect(res.status).toBe(502);
+        expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        const logged = JSON.parse(consoleError.mock.calls[0][0] as string);
+        expect(logged.route).toBe("/api/checkout/create-session");
+        expect(logged.method).toBe("POST");
+        expect(logged.status).toBe(502);
+        expect(logged.traceId).toBe(body.traceId);
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("does NOT write a structured log on 4xx client errors", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        await handleCreateCheckoutSession(
+          postBody({
+            priceId: "price_NOT_in_allowlist",
+            successUrl: "https://feedzero.app/s",
+            cancelUrl: "https://feedzero.app/c",
+          }),
+          { client: fakeStripeClient(), allowedPrices: ALLOWED_PRICES },
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+  });
 });

--- a/tests/core/stripe/resolve-seen-event-store.test.ts
+++ b/tests/core/stripe/resolve-seen-event-store.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { resolveSeenEventStore } from "@/core/stripe/resolve-seen-event-store";
+import {
+  resolveSeenEventStore,
+  describeSeenEventStoreMode,
+} from "@/core/stripe/resolve-seen-event-store";
 import {
   MemorySeenEventStore,
   UpstashSeenEventStore,
@@ -27,5 +30,29 @@ describe("resolveSeenEventStore", () => {
       KV_REST_API_TOKEN: "tok",
     });
     expect(store).toBeInstanceOf(UpstashSeenEventStore);
+  });
+});
+
+describe("describeSeenEventStoreMode (Step A — module-load logging)", () => {
+  it("returns 'memory' when Upstash env is missing", () => {
+    expect(describeSeenEventStoreMode({})).toBe("memory");
+  });
+
+  it("returns 'upstash' when canonical UPSTASH_* env is set", () => {
+    expect(
+      describeSeenEventStoreMode({
+        UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+        UPSTASH_REDIS_REST_TOKEN: "tok",
+      }),
+    ).toBe("upstash");
+  });
+
+  it("returns 'upstash' when only Vercel-Marketplace KV_REST_API_* is set", () => {
+    expect(
+      describeSeenEventStoreMode({
+        KV_REST_API_URL: "https://example.upstash.io",
+        KV_REST_API_TOKEN: "tok",
+      }),
+    ).toBe("upstash");
   });
 });

--- a/tests/core/stripe/webhook-handler.test.ts
+++ b/tests/core/stripe/webhook-handler.test.ts
@@ -437,4 +437,110 @@ describe("handleStripeWebhook", () => {
       expect(issuer.issue).toHaveBeenCalled();
     });
   });
+
+  describe("observability — traceId + structured error logging", () => {
+    it("includes a traceId in 400 invalid-signature response body", async () => {
+      const res = await handleStripeWebhook(
+        new Request(ENDPOINT, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Stripe-Signature": "garbage-not-stripe-format",
+          },
+          body: JSON.stringify({ type: "x" }),
+        }),
+        makeConfig(issuer),
+      );
+      const body = await res.json();
+      expect(res.status).toBe(400);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("includes a traceId in 500 storage-error response and writes a structured log", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const brokenEventStore = {
+          async markSeenIfNew() {
+            return err("eventStore down");
+          },
+        };
+        const fixture = subscriptionCreatedEvent({
+          customerId: CUSTOMER_ID,
+          subscriptionId: SUBSCRIPTION_ID,
+          tier: "personal",
+        });
+        const res = await handleStripeWebhook(
+          postFixture(fixture, nowSec()),
+          makeConfig(issuer, { eventStore: brokenEventStore }),
+        );
+        const body = await res.json();
+        expect(res.status).toBe(500);
+        expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        const logged = JSON.parse(consoleError.mock.calls[0][0] as string);
+        expect(logged.route).toBe("/api/stripe/webhook");
+        expect(logged.method).toBe("POST");
+        expect(logged.status).toBe(500);
+        expect(logged.traceId).toBe(body.traceId);
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("includes a traceId in 500 issuer-failure response and writes a structured log", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const brokenIssuer: LicenseIssuer = {
+          issue: vi.fn(async () => err("issuer down")),
+          revoke: vi.fn(async () => ok(undefined)),
+          recordRenewal: vi.fn(async () => ok(undefined)),
+        };
+        const fixture = subscriptionCreatedEvent({
+          customerId: CUSTOMER_ID,
+          subscriptionId: SUBSCRIPTION_ID,
+          tier: "personal",
+        });
+        const res = await handleStripeWebhook(
+          postFixture(fixture, nowSec()),
+          makeConfig(brokenIssuer),
+        );
+        const body = await res.json();
+        expect(res.status).toBe(500);
+        expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        const logged = JSON.parse(consoleError.mock.calls[0][0] as string);
+        expect(logged.errClass).toBeTruthy();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("does NOT write a structured log on 400 client errors (invalid signature)", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        await handleStripeWebhook(
+          new Request(ENDPOINT, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Stripe-Signature": "garbage",
+            },
+            body: JSON.stringify({}),
+          }),
+          makeConfig(issuer),
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+  });
 });

--- a/tests/core/sync/adapters/resolve-adapter.test.ts
+++ b/tests/core/sync/adapters/resolve-adapter.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { resolveAdapter } from "@/core/sync/adapters/resolve-adapter";
+import {
+  resolveAdapter,
+  describeAdapterMode,
+} from "@/core/sync/adapters/resolve-adapter";
 
 vi.mock("@/core/sync/adapters/filesystem-adapter", () => ({
   createFilesystemAdapter: vi.fn(() => ({ type: "filesystem" })),
@@ -112,6 +115,37 @@ describe("resolveAdapter", () => {
       // self-hosters who run without Vercel Blob.
       const adapter = resolveAdapter() as unknown as { type: string };
       expect(adapter.type).toBe("filesystem");
+    });
+  });
+
+  describe("describeAdapterMode (Step A — module-load adapter logging)", () => {
+    // The mode label is what gets surfaced at module load in api/sync.ts.
+    // It MUST agree with the actual adapter chosen by resolveAdapter() —
+    // otherwise the log line lies and observability is worse than nothing.
+
+    it("returns 'filesystem' when nothing is configured", () => {
+      expect(describeAdapterMode()).toBe("filesystem");
+    });
+
+    it("returns 'vercel-blob' when BLOB_READ_WRITE_TOKEN is present (auto-detect)", () => {
+      process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_test";
+      expect(describeAdapterMode()).toBe("vercel-blob");
+    });
+
+    it("returns SYNC_STORAGE value when set (explicit override)", () => {
+      process.env.SYNC_STORAGE = "memory";
+      expect(describeAdapterMode()).toBe("memory");
+    });
+
+    it("agrees with resolveAdapter under the same env (no drift)", () => {
+      // The KEY invariant: if describeAdapterMode says 'vercel-blob',
+      // resolveAdapter must actually return the vercel-blob adapter.
+      // This test pins them together so a future edit to one without the
+      // other fails immediately.
+      process.env.BLOB_READ_WRITE_TOKEN = "vercel_blob_rw_test";
+      const label = describeAdapterMode();
+      const adapter = resolveAdapter() as unknown as { type: string };
+      expect(label).toBe(adapter.type);
     });
   });
 });

--- a/tests/core/sync/sync-handler.test.ts
+++ b/tests/core/sync/sync-handler.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { handleSyncRequest } from "@/core/sync/sync-handler";
 import { createMemoryAdapter } from "@/core/sync/adapters/memory-adapter";
 import type { SyncStorageAdapter } from "@/core/sync/types";
+import { err } from "@/utils/result";
 
 describe("sync-handler", () => {
   let adapter: SyncStorageAdapter;
@@ -257,6 +258,129 @@ describe("sync-handler", () => {
       });
       const response = await handleSyncRequest(request, adapter);
       expect(response.status).toBe(405);
+    });
+  });
+
+  describe("observability — traceId + structured error logging", () => {
+    // Observability foundation for the silent-launch monetization stack.
+    // Pattern (mirrored across all 5 monetization handlers):
+    //   - Every non-2xx response body carries a `traceId` so user reports
+    //     can be correlated to runtime logs by grep.
+    //   - Every 5xx path also writes a single-line JSON via logError() so
+    //     ops can grep Vercel logs for {route, status, traceId, errClass}.
+    //   - 4xx (client error) paths get traceId in the body but NOT a
+    //     server-side log — they aren't actionable for ops.
+
+    function makeBrokenAdapter(): SyncStorageAdapter {
+      return {
+        async get() { return err("adapter down"); },
+        async put() { return err("adapter down"); },
+        async delete() { return err("adapter down"); },
+        async count() { return err("adapter down"); },
+      };
+    }
+
+    it("includes a traceId in 400 client-error response body", async () => {
+      const response = await handleSyncRequest(
+        new Request("http://localhost/api/sync", { method: "GET" }),
+        adapter,
+      );
+      const body = await response.json();
+      expect(response.status).toBe(400);
+      expect(typeof body.traceId).toBe("string");
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("includes a traceId in 404 not-found response body", async () => {
+      const vaultId = "a".repeat(64);
+      const response = await handleSyncRequest(
+        makeGetRequest(vaultId),
+        adapter,
+      );
+      const body = await response.json();
+      expect(response.status).toBe(404);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("includes a traceId in 500 server-error response body", async () => {
+      const vaultId = "c".repeat(64);
+      const response = await handleSyncRequest(
+        makePutRequest({ vaultId, vault: { v: 1 } }),
+        makeBrokenAdapter(),
+      );
+      const body = await response.json();
+      expect(response.status).toBe(500);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    });
+
+    it("emits a fresh traceId per request (no correlation across requests)", async () => {
+      const vaultId = "a".repeat(64);
+      const r1 = await (await handleSyncRequest(makeGetRequest(vaultId), adapter)).json();
+      const r2 = await (await handleSyncRequest(makeGetRequest(vaultId), adapter)).json();
+      expect(r1.traceId).not.toBe(r2.traceId);
+    });
+
+    it("writes a structured error log on the 500 path", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const vaultId = "c".repeat(64);
+        const response = await handleSyncRequest(
+          makePutRequest({ vaultId, vault: { v: 1 } }),
+          makeBrokenAdapter(),
+        );
+        const body = await response.json();
+
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        const logged = JSON.parse(consoleError.mock.calls[0][0] as string);
+        expect(logged.route).toBe("/api/sync");
+        expect(logged.method).toBe("PUT");
+        expect(logged.status).toBe(500);
+        expect(logged.traceId).toBe(body.traceId);
+        expect(typeof logged.errClass).toBe("string");
+        expect(typeof logged.errMsg).toBe("string");
+        expect(typeof logged.ts).toBe("string");
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("does NOT write a structured log on 4xx client errors", async () => {
+      // 4xx isn't ops-actionable. Keeping it out of the error log keeps the
+      // log clean for genuine 5xx incidents.
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        await handleSyncRequest(
+          new Request("http://localhost/api/sync", { method: "GET" }),
+          adapter,
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("does NOT log vaultId or any PII in the error log", async () => {
+      // Floor: even though the caller chose what to put in errMsg, the
+      // logger's allow-list drops any unknown field. This test guards against
+      // a future regression where someone widens the allow-list.
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const vaultId = "d".repeat(64);
+        await handleSyncRequest(
+          makePutRequest({ vaultId, vault: { v: 1 } }),
+          makeBrokenAdapter(),
+        );
+        const raw = consoleError.mock.calls[0][0] as string;
+        expect(raw).not.toContain(vaultId);
+      } finally {
+        consoleError.mockRestore();
+      }
     });
   });
 

--- a/tests/core/utils/log-error.test.ts
+++ b/tests/core/utils/log-error.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { logError } from "@/utils/log-error";
+
+describe("logError", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("writes a single line of JSON to console.error", () => {
+    logError({
+      route: "/api/sync",
+      method: "PUT",
+      status: 500,
+      traceId: "req_abc12345",
+      errClass: "ENOENT",
+      errMsg: "Failed to write vault",
+    });
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    const arg = consoleError.mock.calls[0][0] as string;
+    // Must be parseable JSON (one structured line, not pretty-printed)
+    expect(() => JSON.parse(arg)).not.toThrow();
+  });
+
+  it("emits all allow-listed fields and adds a timestamp", () => {
+    logError({
+      route: "/api/license/verify",
+      method: "POST",
+      status: 401,
+      traceId: "req_xyz98765",
+      errClass: "InvalidSignature",
+      errMsg: "license revoked",
+    });
+    const parsed = JSON.parse(consoleError.mock.calls[0][0] as string);
+    expect(parsed.route).toBe("/api/license/verify");
+    expect(parsed.method).toBe("POST");
+    expect(parsed.status).toBe(401);
+    expect(parsed.traceId).toBe("req_xyz98765");
+    expect(parsed.errClass).toBe("InvalidSignature");
+    expect(parsed.errMsg).toBe("license revoked");
+    expect(typeof parsed.ts).toBe("string");
+    expect(new Date(parsed.ts).toString()).not.toBe("Invalid Date");
+  });
+
+  it("does NOT emit a 'vaultId' field even if caller tries to pass one", () => {
+    // The TypeScript interface IS the allow-list, but at runtime we
+    // defensively drop unknown fields. This test pins that contract —
+    // a future change can't accidentally regress the floor.
+    logError({
+      route: "/api/sync",
+      method: "PUT",
+      status: 500,
+      traceId: "req_safety",
+      errClass: "E",
+      errMsg: "m",
+      // @ts-expect-error — vaultId is not in the allow-list type
+      vaultId: "should-not-appear-in-logs-ever",
+    });
+    const raw = consoleError.mock.calls[0][0] as string;
+    const parsed = JSON.parse(raw);
+    expect(parsed.vaultId).toBeUndefined();
+    expect(raw).not.toContain("should-not-appear-in-logs-ever");
+  });
+
+  it("does NOT emit other PII-like fields (customerId, email, ip, token)", () => {
+    logError({
+      route: "/api/stripe/webhook",
+      method: "POST",
+      status: 400,
+      traceId: "req_x",
+      errClass: "E",
+      errMsg: "m",
+      // @ts-expect-error — none of these are in the allow-list. The first
+      // excess-property error covers all subsequent excess properties below
+      // (TS only reports once per object literal), so a single suppression
+      // is correct here. The runtime field-pick is what actually enforces
+      // the floor; the type-side just stops a future caller from adding
+      // these without a deliberate suppression.
+      customerId: "cus_super_secret",
+      email: "leak@example.com",
+      ip: "203.0.113.42",
+      token: "fz_secret.sig",
+    });
+    const raw = consoleError.mock.calls[0][0] as string;
+    expect(raw).not.toContain("cus_super_secret");
+    expect(raw).not.toContain("leak@example.com");
+    expect(raw).not.toContain("203.0.113.42");
+    expect(raw).not.toContain("fz_secret.sig");
+  });
+});

--- a/tests/core/utils/trace-id.test.ts
+++ b/tests/core/utils/trace-id.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { newTraceId } from "@/utils/trace-id";
+
+describe("newTraceId", () => {
+  it("returns a string starting with 'req_'", () => {
+    const id = newTraceId();
+    expect(id.startsWith("req_")).toBe(true);
+  });
+
+  it("has at least 8 random hex chars after the prefix (so collisions are rare)", () => {
+    const id = newTraceId();
+    const random = id.slice("req_".length);
+    expect(random.length).toBeGreaterThanOrEqual(8);
+    expect(/^[0-9a-f]+$/.test(random)).toBe(true);
+  });
+
+  it("generates distinct ids across calls (pseudo-randomness sanity)", () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 100; i++) set.add(newTraceId());
+    // 100 calls, expect 100 distinct ids (probabilistically — 8 hex chars
+    // gives 4 billion possibilities, collision in 100 draws negligible)
+    expect(set.size).toBe(100);
+  });
+
+  it("contains no PII-like characters (no @, no dots, no slashes)", () => {
+    // Defensive shape assertion. The format is opaque random — guarantees
+    // no caller mistakes a stable identifier (email/path/etc) for a traceId.
+    const id = newTraceId();
+    expect(id).not.toMatch(/[@./]/);
+  });
+});


### PR DESCRIPTION
## Summary

- **traceId in every error response body.** Every non-2xx response from the 5 monetization handlers (sync, license verify, license issue, stripe webhook, checkout) now carries an opaque `traceId: req_<8 hex>` that users can quote in support reports.
- **Structured server log on every 5xx.** Same handlers emit a single-line JSON `{route, method, status, traceId, errClass, errMsg, ts}` via an allow-list logger. The TypeScript interface IS the allow-list — runtime field-pick defensively drops anything else (no vaultId, customerId, email, IP, license token, ciphertext can leak even via `any`).
- **Mode-label helpers for the upcoming Step A module-load logs** — `describeAdapterMode`, `describeLicenseStorageMode`, `describeSeenEventStoreMode`. `resolveAdapter` now delegates to `describeAdapterMode` so the label and the actual adapter cannot drift.

## Why now

Yesterday's production sync regression (kenkiller's Reddit report → 14h to diagnose) was caused by a stale `SYNC_STORAGE` operator override silently routing every PUT to the filesystem adapter. The 500 response carried no traceability and the lambda emitted no signal about which adapter had been resolved. With this layer in place, the next similar bug produces a structured log line per failing request — time-to-diagnose collapses from hours to seconds.

## What is NOT in this PR

The `console.log("[sync] adapter=...")` module-load lines in `api/sync.ts`, `api/license/[action].ts`, and `api/stripe/webhook.ts`. A parallel Claude session is concurrently editing the api/*.ts wrappers in this working tree; per CLAUDE.md's multi-agent hygiene rules, those files belong to their current owner. The `describe*Mode` helpers are shipped here, so adding the 1-line `console.log` to each api wrapper later is a trivial follow-up.

## Test plan

- [x] `npm test` — 1829 passing, 2 skipped (no regressions)
- [x] `npx tsc --noEmit` — clean
- [x] +37 new tests across helpers, handlers, and mode-label helpers
- [ ] Once Step A lands in api/* and deploys: verify `[sync] adapter=vercel-blob` appears in Vercel runtime logs on cold start
- [ ] Once deployed: trigger a 5xx (e.g. malformed body) and confirm response body contains `traceId` matching `/^req_[0-9a-f]+$/` AND Vercel logs show the corresponding structured JSON line

## Anonymity contract

The allow-list logger refuses unknown fields at runtime, not just at the type layer. Tests in `tests/core/utils/log-error.test.ts` pin this: any future attempt to pass `vaultId`, `customerId`, `email`, `ip`, or `token` is dropped on the runtime side even if the type is bypassed via `@ts-expect-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)