### PR TITLE
fix(ui): mobile soft keyboard no longer covers dialog inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
         <title>FeedZero</title>
         <meta name="description" content="Privacy-first RSS reader. Zero distractions. Zero friction. Zero tracking." />
         <meta name="theme-color" content="#ffffff" />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -59,7 +59,17 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
+          // Layout + animation (unchanged from shadcn baseline).
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          // Mobile keyboard handling. `100dvh` is the dynamic viewport
+          // height — it shrinks when the iOS Safari soft keyboard opens
+          // (iOS 15.4+, Chrome 108+, Firefox 101+). Combined with the
+          // `interactive-widget=resizes-content` viewport meta in
+          // index.html, this keeps centered dialogs above the keyboard
+          // line. `overflow-y-auto` guarantees focused inputs can still
+          // scroll into view on older browsers that don't shrink dvh.
+          // See tests/components/ui/dialog-mobile-keyboard.test.tsx.
+          "max-h-[calc(100dvh-2rem)] overflow-y-auto",
           className,
         )}
         {...props}

--- a/tests/components/ui/dialog-mobile-keyboard.test.tsx
+++ b/tests/components/ui/dialog-mobile-keyboard.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Structural assertions for DialogContent's mobile-keyboard handling.
+ *
+ * Background (2026-05-13 user report): on mobile, opening any dialog with a
+ * text input — sync setup, onboarding passphrase confirm, restore-from-cloud
+ * — caused the virtual keyboard to cover the input. Root cause: the shadcn
+ * primitive in `src/components/ui/dialog.tsx` uses `position: fixed` +
+ * `top: 50%` centered with no max-height. iOS Safari and Chrome Android
+ * don't shrink the layout viewport when the soft keyboard opens, and they
+ * don't auto-scroll fixed elements into view.
+ *
+ * Fix invariant: DialogContent's classNames must include
+ *   - `max-h-[calc(100dvh-2rem)]` — dvh shrinks with keyboard on supporting
+ *      browsers (iOS Safari 15.4+, Chrome 108+, Firefox 101+).
+ *   - `overflow-y-auto` — once max-height is hit, content scrolls so a
+ *      focused input can `scrollIntoView` even on older browsers.
+ *
+ * Why a Tier-2 structural test instead of a behavioral one: Playwright
+ * cannot reliably trigger the soft keyboard on real-device emulation, and
+ * jsdom/happy-dom don't simulate visual viewport at all. The next-best
+ * regression guard is asserting the CSS classes that produce the fix.
+ * If a future shadcn upgrade rewrites these classes, this test fails
+ * before any user notices the regression.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+function mountOpenDialog() {
+  return render(
+    <Dialog open>
+      <DialogContent>
+        <DialogTitle>Test</DialogTitle>
+      </DialogContent>
+    </Dialog>,
+  );
+}
+
+describe("DialogContent — mobile keyboard cover prevention", () => {
+  it("includes max-h based on dynamic viewport (dvh) so the dialog shrinks with the keyboard", () => {
+    const { baseElement } = mountOpenDialog();
+    const content = baseElement.querySelector('[role="dialog"]');
+    expect(content).toBeTruthy();
+    const className = content?.getAttribute("class") ?? "";
+    expect(className).toMatch(/max-h-\[calc\(100dvh-2rem\)\]/);
+  });
+
+  it("includes overflow-y-auto so focused inputs can scroll into view", () => {
+    const { baseElement } = mountOpenDialog();
+    const content = baseElement.querySelector('[role="dialog"]');
+    const className = content?.getAttribute("class") ?? "";
+    expect(className).toContain("overflow-y-auto");
+  });
+});

--- a/tests/index-html-viewport.test.ts
+++ b/tests/index-html-viewport.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Viewport meta tag contract test.
+ *
+ * Background (2026-05-13 user report): mobile dialog inputs were covered by
+ * the soft keyboard. Part of the fix is the `interactive-widget=resizes-content`
+ * directive in the viewport meta tag (Chrome Android 108+ honors it by
+ * resizing the visual viewport when the keyboard opens, which lets
+ * `top: 50%` reposition above the keyboard line).
+ *
+ * If a future edit to index.html drops this directive, every mobile dialog
+ * with an input regresses. This test guards the contract.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const INDEX_HTML = readFileSync(
+  resolve(__dirname, "..", "index.html"),
+  "utf-8",
+);
+
+describe("index.html viewport meta", () => {
+  it("declares interactive-widget=resizes-content for mobile-keyboard handling", () => {
+    expect(INDEX_HTML).toMatch(
+      /<meta[^>]*name=["']viewport["'][^>]*interactive-widget=resizes-content/,
+    );
+  });
+
+  it("keeps the existing viewport baseline (width, scale, viewport-fit)", () => {
+    // Pins the existing behavior so a future "just clean up the meta tag"
+    // edit can't accidentally drop the iOS notch handling.
+    expect(INDEX_HTML).toMatch(/width=device-width/);
+    expect(INDEX_HTML).toMatch(/initial-scale=1/);
+    expect(INDEX_HTML).toMatch(/viewport-fit=cover/);
+  });
+});


### PR DESCRIPTION
## Summary

- Mobile sync passphrase dialog was unusable — the soft keyboard covered the input field. Same root cause affected every dialog with a focusable input (onboarding, restore-from-cloud, etc.) because they all share the shadcn `DialogContent` primitive.
- Fix is two minimal changes to the shared primitive + viewport meta. No per-dialog edits.

## Why this happened

The shadcn `DialogContent` uses `fixed top-[50%] translate-y-[-50%]` with no max-height. On iOS Safari and Chrome Android, the *layout* viewport doesn't shrink when the soft keyboard opens — only the *visual* viewport does. A layout-centered dialog stays glued to its original position, behind the keyboard. iOS Safari's auto-scroll-into-view behavior doesn't apply to `position: fixed`, so focusing the input doesn't pull it above the fold either.

## Changes

1. **`src/components/ui/dialog.tsx`** — added `max-h-[calc(100dvh-2rem)]` and `overflow-y-auto` to `DialogContent`. `dvh` shrinks when the keyboard opens on iOS Safari 15.4+, Chrome 108+, Firefox 101+. Overflow makes focused inputs scrollable into view on older browsers.

2. **`index.html`** — added `interactive-widget=resizes-content` to the viewport meta. Chrome Android 108+ honors this directive by resizing the content area when the soft keyboard opens.

Belt-and-suspenders across both engines — Chrome Android responds best to `interactive-widget`, Safari iOS responds best to `dvh`, both apply globally.

## Test plan

- [x] 1801 unit/integration tests pass
- [x] `npx tsc --noEmit` clean
- [x] 4 new tests pin the fix (2 structural assertions on `DialogContent` classNames, 2 viewport-meta contract tests)
- [ ] **Real-device verification (the actual acceptance gate):** open the sync setup → passphrase entry on iOS Safari and on Chrome Android. The input must remain visible above the soft keyboard. Same check on the onboarding passphrase-confirm step.

Playwright cannot reliably trigger the soft keyboard on emulated viewports, and jsdom/happy-dom don't simulate the visual viewport at all — so real-device testing is the source of truth here. Structural assertions are the regression net.

## Notes

- Every dialog in the app inherits this fix since it's in the shared primitive.
- Risk: very tall dialogs (e.g. multi-step onboarding) now scroll inside the dialog instead of being clipped. That's a UX improvement, not a regression — but worth flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)