### PR TITLE
fix(mobile-nav): drawer bottom no longer occluded by iOS Safari toolbar

### DIFF
--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -95,7 +95,19 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
           <SidebarProvider defaultOpen={false} className="block min-h-0">
             <div
               data-testid="drawer-scroll"
-              className="overflow-y-auto overflow-x-hidden pb-[calc(env(safe-area-inset-bottom)_+_2rem)]"
+              // Padding-bottom = home-indicator inset + iOS toolbar slack + breathing room.
+              // - `env(safe-area-inset-bottom)`: iPhone home-indicator strip (~34px on
+              //   modern iPhones in PWA / no-toolbar contexts).
+              // - `calc(100vh - 100dvh)`: iOS Safari's dynamic bottom toolbar
+              //   (~70-80px on iPhones). Zero when the toolbar is collapsed. The
+              //   prior fix omitted this — leaving the last drawer row occluded
+              //   when the toolbar was up. See `tests/components/layout/mobile-nav-drawer.test.tsx`
+              //   for the regression guard.
+              // - `2rem`: visual breathing room so the last row isn't pressed against
+              //   the very edge.
+              // Vaul positions the outer Drawer.Content itself; the only place we
+              // can reliably enforce safe-area is here on the inner scroll.
+              className="overflow-y-auto overflow-x-hidden pb-[calc(env(safe-area-inset-bottom)_+_(100vh_-_100dvh)_+_2rem)]"
               style={{ height: "calc(85dvh - 1.25rem)" }}
             >
               <div data-testid="drawer-section" className="w-full py-1 px-3">

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -196,6 +196,73 @@ describe("MobileNavDrawer", () => {
     expect(scroll.className).toContain("overflow-x-hidden");
   });
 
+  describe("browser-chrome occlusion fix (permanent regression guard)", () => {
+    // Context (2026-05-13 second mobile bug report): on iOS Safari with the
+    // bottom toolbar visible, the drawer's bottom content was hidden behind
+    // the toolbar. The outer Drawer.Content is positioned by vaul (which
+    // overrides any inline `bottom`/`height` style we pass), so the fix
+    // lives on the INNER scroll container's `padding-bottom`. The previous
+    // fix used `env(safe-area-inset-bottom) + 2rem` — that covers the
+    // home-indicator strip but the fixed `2rem` is too small for iOS
+    // Safari's dynamic bottom toolbar (~70-80px on iPhones).
+    //
+    // Permanent fix: extend the padding-bottom to include
+    //   `calc(100vh - 100dvh)`
+    // which evaluates to the toolbar height when the iOS Safari toolbar is
+    // visible and 0 when it isn't. Combined with the existing
+    // `env(safe-area-inset-bottom)` for the home indicator and the visual
+    // `2rem` breathing room, the last scrollable item is always reachable.
+    //
+    // These tests pin the CSS expression shape structurally. happy-dom
+    // doesn't compute the visual viewport, so we assert the expression is
+    // present rather than the resolved pixel offset.
+
+    async function getDrawerScroll(): Promise<HTMLElement> {
+      const { container } = renderDrawer();
+      await userEvent.click(screen.getByTestId("drawer-handle-strip"));
+      const scroll = await waitFor(() => {
+        const s = container.ownerDocument.querySelector(
+          "[data-testid='drawer-scroll']",
+        );
+        if (!s) throw new Error("drawer scroll not mounted");
+        return s as HTMLElement;
+      });
+      return scroll;
+    }
+
+    it("inner scroll padding-bottom includes env(safe-area-inset-bottom) for the iOS home indicator", async () => {
+      const scroll = await getDrawerScroll();
+      expect(scroll.getAttribute("class") ?? "").toContain(
+        "safe-area-inset-bottom",
+      );
+    });
+
+    it("inner scroll padding-bottom includes (100vh - 100dvh) for the iOS Safari bottom toolbar", async () => {
+      // The bug we're preventing: a previous version used only
+      // `env(safe-area-inset-bottom) + 2rem` which left the last drawer
+      // item occluded by the iOS Safari toolbar (~75px). The fix adds
+      // `(100vh - 100dvh)` so the padding grows with the toolbar.
+      // Tailwind arbitrary values use `_` to escape spaces in className
+      // tokens — the regex tolerates either separator.
+      const scroll = await getDrawerScroll();
+      expect(scroll.getAttribute("class") ?? "").toMatch(
+        /100vh[\s_]*-[\s_]*100dvh/,
+      );
+    });
+
+    it("padding-bottom is delivered via Tailwind arbitrary-value `pb-[calc(...)]` (not split into multiple utilities)", async () => {
+      // Pins the single-source-of-truth shape: the entire expression is in
+      // ONE `pb-[calc(…)]` token. A future "let's split this into a CSS
+      // var" refactor would still need to surface the safe-area + toolbar
+      // expressions somewhere; this test fails if the `pb-[calc(...)]`
+      // token disappears entirely so the reviewer is forced to confirm
+      // the alternative form covers both insets.
+      const scroll = await getDrawerScroll();
+      const className = scroll.getAttribute("class") ?? "";
+      expect(className).toMatch(/pb-\[calc\(/);
+    });
+  });
+
   it("toggles open when feedzero:toggle-sidebar event is dispatched", async () => {
     const { container } = renderDrawer();
     const doc = container.ownerDocument;


### PR DESCRIPTION
## Summary

On iOS Safari with the bottom toolbar visible, the bottom of the mobile-nav drawer was hidden behind browser chrome — making the last settings rows unreachable. Recurrence of a previously-fixed bug; the prior fix handled the home-indicator inset but the fixed `2rem` slack was too small to cover the dynamic toolbar (~70-80px on iPhones).

## Why the fix lives on the inner scroll, not the outer drawer

`vaul` (the drawer library) controls `Drawer.Content`'s outer positioning and strips inline `style.bottom`/`height` we pass — verified empirically by inspecting the rendered DOM. The reliable place to enforce safe-area is the inner scroll container, which we fully control.

## Change

```diff
- pb-[calc(env(safe-area-inset-bottom) + 2rem)]
+ pb-[calc(env(safe-area-inset-bottom) + (100vh - 100dvh) + 2rem)]
```

`100vh - 100dvh` evaluates to the iOS Safari toolbar height when the toolbar is visible and `0` when it isn't. Combined with the existing home-indicator inset and the `2rem` breathing room, the last scrollable item is always reachable.

## Test plan

- [x] 1874 unit/integration tests pass (3 new structural assertions for this fix)
- [x] `npx tsc --noEmit` clean
- [x] Regression guard: a new test asserts `(100vh - 100dvh)` is present in the padding expression. If a future refactor drops it back to "+2rem", this test fails before the bug reaches users.
- [ ] **Real-device verification (the actual acceptance gate):** open the bottom drawer on iOS Safari with the bottom toolbar visible. The last settings row must be tappable without scrolling the page.

## Why this is "permanent"

The previous fix added safe-area padding but used a fixed `2rem` slack — which silently broke as soon as Safari's toolbar grew taller than 32px. This version uses the algebraic identity `100vh - 100dvh` that dynamically tracks the actual toolbar height, AND a structural test that fails the moment a future refactor drops the toolbar term. The next time someone tries to "clean up" the padding expression, the test forces them to confirm they're covering both insets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)