### PR TITLE
feat(catalog): persistent Upstash-backed feed catalog (fixes stats showing zero)

### DIFF
--- a/api/catalog.ts
+++ b/api/catalog.ts
@@ -1,109 +1,16 @@
-// @ts-nocheck
-// api/catalog.ts
-var API_HEADERS = {
-  "Content-Type": "application/json",
-  "Access-Control-Allow-Origin": "*",
-  "X-Content-Type-Options": "nosniff"
-};
-function jsonResponse(body, status = 200) {
-  return new Response(JSON.stringify(body), { status, headers: API_HEADERS });
+import { handleCatalogRequest } from "../src/core/catalog/catalog-handler";
+import {
+  resolveCatalogStorage,
+  describeCatalogStorageMode,
+} from "../src/core/catalog/resolve-catalog-storage";
+
+// Module-load logging. Surfaces which storage backend resolved so a
+// regression to memory mode (which silently zeroes the stats on every cold
+// start) is visible in the first Vercel deploy log entry.
+console.log(`[catalog] storage=${describeCatalogStorageMode()}`);
+
+const adapterPromise = resolveCatalogStorage();
+
+export async function GET(req: Request): Promise<Response> {
+  return handleCatalogRequest(req, await adapterPromise);
 }
-function errorResponse(message, status) {
-  return jsonResponse({ ok: false, error: message }, status);
-}
-async function handleGet(request, adapter2) {
-  const url = new URL(request.url);
-  const action = url.searchParams.get("action");
-  if (action === "popular") {
-    return handlePopular(url, adapter2);
-  }
-  if (action === "count") {
-    return handleCount(adapter2);
-  }
-  return handleGetFeed(url, adapter2);
-}
-async function handleGetFeed(url, adapter2) {
-  const feedUrl = url.searchParams.get("url");
-  if (!feedUrl) return errorResponse("Missing url parameter", 400);
-  const result = await adapter2.get(feedUrl);
-  if (!result.ok) return errorResponse(result.error, 500);
-  if (result.value === null) return errorResponse("Feed not found", 404);
-  return jsonResponse({ ok: true, feed: result.value });
-}
-async function handlePopular(url, adapter2) {
-  const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 200);
-  const result = await adapter2.popular(limit);
-  if (!result.ok) return errorResponse(result.error, 500);
-  return jsonResponse({ ok: true, feeds: result.value });
-}
-async function handleCount(adapter2) {
-  const result = await adapter2.count();
-  if (!result.ok) return errorResponse(result.error, 500);
-  return jsonResponse({ ok: true, count: result.value });
-}
-var methodHandlers = {
-  GET: handleGet
-};
-var SUPPORTED_METHODS = Object.keys(methodHandlers);
-async function handleCatalogRequest(request, adapter2) {
-  const handler = methodHandlers[request.method];
-  if (!handler) return errorResponse("Method not allowed", 405);
-  return handler(request, adapter2);
-}
-function ok(value) {
-  return { ok: true, value };
-}
-function createMemoryCatalogAdapter() {
-  const store = /* @__PURE__ */ new Map();
-  return {
-    async upsert(url) {
-      const now = (/* @__PURE__ */ new Date()).toISOString();
-      const existing = store.get(url);
-      if (existing) {
-        existing.requestCount += 1;
-        existing.lastRequestedAt = now;
-      } else {
-        store.set(url, {
-          url,
-          title: null,
-          description: null,
-          siteUrl: null,
-          status: "active",
-          requestCount: 1,
-          lastRequestedAt: now,
-          lastCrawledAt: null,
-          errorCount: 0,
-          lastError: null,
-          createdAt: now
-        });
-      }
-      return ok(true);
-    },
-    async get(url) {
-      return ok(store.get(url) ?? null);
-    },
-    async popular(limit) {
-      const sorted = [...store.values()].sort(
-        (a, b) => b.requestCount - a.requestCount
-      );
-      return ok(sorted.slice(0, limit));
-    },
-    async updateMetadata(url, metadata) {
-      const existing = store.get(url);
-      if (existing) {
-        Object.assign(existing, metadata);
-      }
-      return ok(true);
-    },
-    async count() {
-      return ok(store.size);
-    }
-  };
-}
-var adapter = createMemoryCatalogAdapter();
-async function GET(req) {
-  return handleCatalogRequest(req, adapter);
-}
-export {
-  GET
-};

--- a/api/feed.ts
+++ b/api/feed.ts
@@ -1,236 +1,37 @@
-// @ts-nocheck
-// api/feed.ts
-function ok(value) {
-  return { ok: true, value };
-}
-function err(error) {
-  return { ok: false, error };
-}
-var BLOCKED_HOSTNAMES = /* @__PURE__ */ new Set([
-  "localhost",
-  "127.0.0.1",
-  "::1",
-  "0.0.0.0",
-  "169.254.169.254"
-]);
-var BLOCKED_PREFIXES = ["10.", "192.168."];
-function isPrivate172(hostname) {
-  const match = hostname.match(/^172\.(\d+)\./);
-  if (!match) return false;
-  const octet = parseInt(match[1], 10);
-  return octet >= 16 && octet <= 31;
-}
-function extractMappedIPv4(hostname) {
-  const dotted = hostname.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
-  if (dotted) return dotted[1];
-  const hex = hostname.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
-  if (hex) {
-    const high = parseInt(hex[1], 16);
-    const low = parseInt(hex[2], 16);
-    return `${high >> 8 & 255}.${high & 255}.${low >> 8 & 255}.${low & 255}`;
-  }
-  return null;
-}
-function isPrivateIPv4(ip) {
-  return BLOCKED_HOSTNAMES.has(ip) || BLOCKED_PREFIXES.some((prefix) => ip.startsWith(prefix)) || isPrivate172(ip);
-}
-function validateProxyUrl(url) {
-  if (!url) {
-    return err("Missing url parameter");
-  }
-  let parsed;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return err("Invalid URL");
-  }
-  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-    return err("Only http and https URLs are allowed");
-  }
-  const rawHostname = parsed.hostname.replace(/^\[|\]$/g, "");
-  const ipToCheck = extractMappedIPv4(rawHostname) ?? rawHostname;
-  if (isPrivateIPv4(ipToCheck)) {
-    return err("Access to internal addresses is blocked");
-  }
-  return ok(parsed);
-}
-var TRACKER_DOMAINS = [
-  "pixel.quantserve.com",
-  "sb.scorecardresearch.com",
-  "analytics.twitter.com",
-  "www.google-analytics.com",
-  "www.facebook.com/tr",
-  "feeds.feedburner.com",
-  "feeds.feedblitz.com",
-  "stats.wordpress.com",
-  "pixel.wp.com",
-  "tr.snapchat.com",
-  "bat.bing.com",
-  "ct.pinterest.com",
-  "tags.tiqcdn.com"
-];
-var IMG_REGEX = /<img\b[^>]*>/gi;
-var SRC_REGEX = /\bsrc=["']([^"']*)["']/i;
-var WIDTH_REGEX = /\bwidth=["']?(\d+)["']?/i;
-var HEIGHT_REGEX = /\bheight=["']?(\d+)["']?/i;
-function isTrackerDomain(src) {
-  return TRACKER_DOMAINS.some((domain) => src.includes(domain));
-}
-function isTrackingPixel(imgTag) {
-  const srcMatch = imgTag.match(SRC_REGEX);
-  if (!srcMatch) return false;
-  const src = srcMatch[1];
-  if (isTrackerDomain(src)) return true;
-  const widthMatch = imgTag.match(WIDTH_REGEX);
-  const heightMatch = imgTag.match(HEIGHT_REGEX);
-  if (widthMatch && heightMatch) {
-    const w = parseInt(widthMatch[1], 10);
-    const h = parseInt(heightMatch[1], 10);
-    if (w <= 1 && h <= 1) return true;
-  }
-  return false;
-}
-function stripTrackers(html) {
-  return html.replace(
-    IMG_REGEX,
-    (imgTag) => isTrackingPixel(imgTag) ? "" : imgTag
-  );
-}
-var TRACKING_PARAMS = /* @__PURE__ */ new Set([
-  "utm_source",
-  "utm_medium",
-  "utm_campaign",
-  "utm_term",
-  "utm_content",
-  "utm_id",
-  "fbclid",
-  "gclid",
-  "gclsrc",
-  "dclid",
-  "msclkid",
-  "twclid",
-  "igshid",
-  "mc_cid",
-  "mc_eid",
-  "_ga",
-  "_gl",
-  "oly_anon_id",
-  "oly_enc_id",
-  "vero_id",
-  "s_cid",
-  "icid",
-  "ef_id"
-]);
-var URL_IN_ATTR_REGEX = /\b(href|src)="([^"]*)"/gi;
-function cleanUrl(raw) {
-  const qIndex = raw.indexOf("?");
-  if (qIndex === -1) return raw;
-  const base = raw.slice(0, qIndex);
-  const query = raw.slice(qIndex + 1);
-  const params = query.split("&").filter((p) => {
-    const key = p.split("=")[0].toLowerCase();
-    return !TRACKING_PARAMS.has(key);
-  });
-  return params.length > 0 ? `${base}?${params.join("&")}` : base;
-}
-function cleanLinks(html) {
-  return html.replace(URL_IN_ATTR_REGEX, (_, attr, url) => {
-    return `${attr}="${cleanUrl(url)}"`;
+import { handleProxyRequest } from "../src/core/proxy/proxy-handler";
+import {
+  resolveCatalogStorage,
+  describeCatalogStorageMode,
+} from "../src/core/catalog/resolve-catalog-storage";
+
+// Module-load logging — surfaces which catalog backend resolved. Before
+// the persistent-catalog fix, this lambda ran an in-memory adapter that
+// silently dropped all upserts on every cold start, which is why the
+// stats page showed zero feeds tracked. The log line catches a future
+// regression to memory mode on the first deploy.
+console.log(`[feed-proxy] catalog=${describeCatalogStorageMode()}`);
+
+const catalogPromise = resolveCatalogStorage();
+
+async function dispatch(
+  req: Request,
+  contentType: string,
+): Promise<Response> {
+  const catalogAdapter = await catalogPromise;
+  // `cleanContent: true` mirrors server.ts (the Hono entry point used for
+  // self-hosting). `catalogAdapter` is fire-and-forget: the proxy returns
+  // the feed response immediately and the catalog upsert runs in the
+  // background. Failures are swallowed.
+  return handleProxyRequest(req, contentType, {
+    catalogAdapter,
+    cleanContent: true,
   });
 }
-function cleanFeedContent(raw) {
-  let result = raw;
-  result = result.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, (_, content) => {
-    return `<![CDATA[${cleanLinks(stripTrackers(content))}]]>`;
-  });
-  result = result.replace(/&lt;([\s\S]*?)&gt;/g, (match) => {
-    const decoded = match.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&").replace(/&quot;/g, '"');
-    const cleaned = cleanLinks(stripTrackers(decoded));
-    return cleaned.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-  });
-  return result;
+
+export async function GET(req: Request): Promise<Response> {
+  return dispatch(req, "text/xml");
 }
-async function handleProxyRequest(req, defaultContentType, options) {
-  const target = await extractTargetUrl(req);
-  const validation = validateProxyUrl(target);
-  if (!validation.ok) {
-    const status = validation.error === "Access to internal addresses is blocked" ? 403 : 400;
-    return new Response(validation.error, { status });
-  }
-  const url = validation.value.href;
-  const cache = options?.cache;
-  if (cache) {
-    const cached = cache.get(url);
-    if (cached) {
-      return new Response(cached.body, {
-        status: cached.status,
-        headers: { "Content-Type": cached.contentType }
-      });
-    }
-  }
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15e3);
-    const response = await fetch(url, {
-      headers: { "User-Agent": "FeedZero/1.0 (RSS Reader)" },
-      signal: controller.signal
-    });
-    clearTimeout(timeout);
-    const contentType = response.headers.get("content-type") || defaultContentType;
-    const body = await response.arrayBuffer();
-    if (cache && response.status >= 200 && response.status < 400) {
-      cache.set(url, body, contentType, response.status);
-    }
-    if (options?.catalogAdapter && response.status >= 200 && response.status < 400) {
-      options.catalogAdapter.upsert(url).catch(() => {
-      });
-    }
-    const isTextContent = /xml|html|text/i.test(contentType);
-    if (options?.cleanContent && isTextContent && response.status >= 200 && response.status < 400) {
-      const text = new TextDecoder().decode(body);
-      const cleaned = cleanFeedContent(text);
-      return new Response(cleaned, {
-        status: response.status,
-        headers: { "Content-Type": contentType }
-      });
-    }
-    return new Response(body, {
-      status: response.status,
-      headers: { "Content-Type": contentType }
-    });
-  } catch (e) {
-    const message = e instanceof Error ? e.message : "Unknown error";
-    console.error(
-      JSON.stringify({
-        level: "error",
-        context: "proxy",
-        target: url,
-        error: message,
-        timestamp: (/* @__PURE__ */ new Date()).toISOString()
-      })
-    );
-    return new Response(`Proxy error: ${message}`, { status: 502 });
-  }
+
+export async function POST(req: Request): Promise<Response> {
+  return dispatch(req, "text/xml");
 }
-async function extractTargetUrl(req) {
-  if (req.method === "POST") {
-    try {
-      const body = await req.json();
-      return body.url ?? null;
-    } catch {
-      return null;
-    }
-  }
-  const url = new URL(req.url, "http://localhost");
-  return url.searchParams.get("url");
-}
-async function GET(req) {
-  return handleProxyRequest(req, "text/xml");
-}
-async function POST(req) {
-  return handleProxyRequest(req, "text/xml");
-}
-export {
-  GET,
-  POST
-};

--- a/api/stats-sync.ts
+++ b/api/stats-sync.ts
@@ -1,105 +1,19 @@
-// @ts-nocheck
-// api/stats-sync.ts
-var API_HEADERS = {
-  "Content-Type": "application/json",
-  "Access-Control-Allow-Origin": "*",
-  "X-Content-Type-Options": "nosniff"
-};
-async function handleSyncStatsRequest(request, adapter2) {
-  if (request.method !== "GET") {
-    return new Response(
-      JSON.stringify({ ok: false, error: "Method not allowed" }),
-      { status: 405, headers: API_HEADERS }
-    );
-  }
-  const result = await adapter2.count();
-  if (!result.ok) {
-    return new Response(
-      JSON.stringify({ ok: false, error: result.error }),
-      { status: 500, headers: API_HEADERS }
-    );
-  }
-  return new Response(
-    JSON.stringify({ ok: true, vaults: result.value }),
-    { status: 200, headers: API_HEADERS }
-  );
-}
-function ok(value) {
-  return { ok: true, value };
-}
-function err(error) {
-  return { ok: false, error };
-}
-function createVercelBlobAdapter() {
-  return {
-    async get(vaultId) {
-      try {
-        const { head } = await import("@vercel/blob");
-        const pathname = `vaults/${vaultId}.json`;
-        let metadata;
-        try {
-          metadata = await head(pathname);
-        } catch {
-          return ok(null);
-        }
-        const response = await fetch(metadata.url);
-        if (!response.ok) return ok(null);
-        const data = await response.text();
-        return ok(data);
-      } catch (e) {
-        return err(`Vercel Blob get failed: ${e.message}`);
-      }
-    },
-    async put(vaultId, data) {
-      try {
-        const { put } = await import("@vercel/blob");
-        const pathname = `vaults/${vaultId}.json`;
-        await put(pathname, data, {
-          access: "public",
-          addRandomSuffix: false,
-          allowOverwrite: true,
-          contentType: "application/json"
-        });
-        return ok(true);
-      } catch (e) {
-        return err(`Vercel Blob put failed: ${e.message}`);
-      }
-    },
-    async delete(vaultId) {
-      try {
-        const { del } = await import("@vercel/blob");
-        const pathname = `vaults/${vaultId}.json`;
-        await del(pathname);
-        return ok(true);
-      } catch (e) {
-        return err(`Vercel Blob delete failed: ${e.message}`);
-      }
-    },
-    async count() {
-      try {
-        const { list } = await import("@vercel/blob");
-        let total = 0;
-        let cursor;
-        do {
-          const result = await list({
-            prefix: "vaults/",
-            limit: 1e3,
-            ...cursor ? { cursor } : {}
-          });
-          total += result.blobs.length;
-          cursor = result.hasMore ? result.cursor : void 0;
-        } while (cursor);
-        return ok(total);
-      } catch (e) {
-        return err(`Vercel Blob count failed: ${e.message}`);
-      }
-    }
-  };
-}
-var adapter = createVercelBlobAdapter();
-async function GET(req) {
+import { handleSyncStatsRequest } from "../src/core/sync/sync-stats-handler";
+import {
+  resolveAdapter,
+  describeAdapterMode,
+} from "../src/core/sync/adapters/resolve-adapter";
+
+// Module-load logging — surfaces the resolved sync adapter, same diagnostic
+// that caught the 2026-05-12 sync regression (see PR #43 observability).
+console.log(`[stats-sync] adapter=${describeAdapterMode()}`);
+
+// resolveAdapter() picks Upstash when its credentials are present (post-#45),
+// Vercel Blob if its token is present, filesystem otherwise. The previous
+// version of this file hardcoded createVercelBlobAdapter(), which is why
+// the Vaults stat read zero after the Upstash migration.
+const adapter = resolveAdapter();
+
+export async function GET(req: Request): Promise<Response> {
   return handleSyncStatsRequest(req, adapter);
 }
-export {
-  GET
-};

--- a/src/core/catalog/adapters/upstash-adapter.ts
+++ b/src/core/catalog/adapters/upstash-adapter.ts
@@ -1,0 +1,230 @@
+/**
+ * Upstash-backed CatalogStorageAdapter.
+ *
+ * Replaces the previous memory-only adapter that silently lost all catalog
+ * data on every Vercel Lambda cold start (~15min idle window). The new
+ * adapter persists to the same Upstash KV instance as license storage,
+ * Stripe event-id dedup, and (post-PR-#45) vault sync.
+ *
+ * Key layout:
+ *   catalog:feed:<url>   — JSON CatalogFeed for one known feed URL
+ *   catalog:ranking      — Redis sorted set: members = feed URLs,
+ *                          scores = requestCount. Enables O(log N) inserts
+ *                          and O(top-K + lookup) reads for popular().
+ *
+ * Performance shape:
+ *   - upsert: 1 GET + 1 SET + 1 ZADD. Pipelined under one HTTP request when
+ *     possible, but Upstash's REST client doesn't expose pipelines for
+ *     ZADD+SET in a single call, so today this is 3 round trips. The
+ *     constant factor isn't load-bearing at FeedZero's scale.
+ *   - get: 1 GET.
+ *   - popular(N): 1 ZRANGE + 1 MGET (NOT N+1 individual GETs).
+ *   - count: 1 ZCARD (O(1) on the sorted set's size counter).
+ *
+ * Keyspace isolation: only writes keys under the `catalog:` prefix.
+ * No collision possible with `license:*` (license adapter), `vault:*`
+ * (sync adapter from PR #45), or `customer:*` (license customer index).
+ */
+
+import { type Result, ok, err } from "../../../utils/result";
+import type {
+  CatalogFeed,
+  CatalogStorageAdapter,
+} from "../catalog-types";
+
+/**
+ * Minimal subset of the Upstash Redis client the catalog adapter needs.
+ * Defined inline so the adapter can be unit-tested with a fake AND the
+ * production wrapper can pass the real `@upstash/redis` client unchanged.
+ */
+export interface UpstashCatalogClient {
+  get<T = unknown>(key: string): Promise<T | null>;
+  set(
+    key: string,
+    value: unknown,
+    opts?: { nx?: boolean; ex?: number },
+  ): Promise<unknown>;
+  /**
+   * Add or update a member's score in a sorted set. Returns the number
+   * of new elements added (Upstash returns `null` in some no-op edge
+   * cases — we don't read the return value, so widening to allow null
+   * keeps the interface compatible with the real `@upstash/redis` shape).
+   */
+  zadd(
+    key: string,
+    scoreMember: { score: number; member: string },
+  ): Promise<number | null>;
+  /** Cardinality (member count) of a sorted set — O(1). */
+  zcard(key: string): Promise<number>;
+  /**
+   * Range of members from a sorted set. `rev: true` walks from highest
+   * score downward (what popular() needs).
+   */
+  zrange(
+    key: string,
+    start: number,
+    stop: number,
+    opts?: { rev?: boolean },
+  ): Promise<string[]>;
+  /** Batch GET — N keys in one round trip. */
+  mget<T = unknown>(...keys: string[]): Promise<Array<T | null>>;
+}
+
+const FEED_KEY_PREFIX = "catalog:feed:";
+const RANKING_KEY = "catalog:ranking";
+
+function feedKey(url: string): string {
+  return FEED_KEY_PREFIX + url;
+}
+
+/**
+ * Wrap an async Upstash call so any thrown error becomes a Result.err
+ * with the original message. Same pattern as `tryUpstash` in the license
+ * and sync adapters.
+ */
+async function tryUpstash<T>(op: () => Promise<T>): Promise<Result<T>> {
+  try {
+    return ok(await op());
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return err(`upstash catalog error: ${message}`);
+  }
+}
+
+export class UpstashCatalogAdapter implements CatalogStorageAdapter {
+  constructor(private readonly client: UpstashCatalogClient) {}
+
+  async upsert(url: string): Promise<Result<true>> {
+    return tryUpstash(async () => {
+      const now = new Date().toISOString();
+      const existing = await this.client.get<CatalogFeed>(feedKey(url));
+      const updated: CatalogFeed = existing
+        ? {
+            ...existing,
+            requestCount: existing.requestCount + 1,
+            lastRequestedAt: now,
+          }
+        : {
+            url,
+            title: null,
+            description: null,
+            siteUrl: null,
+            status: "active",
+            requestCount: 1,
+            lastRequestedAt: now,
+            lastCrawledAt: null,
+            errorCount: 0,
+            lastError: null,
+            createdAt: now,
+          };
+
+      await this.client.set(feedKey(url), updated);
+      // Keep the sorted-set ranking in sync. ZADD with an existing member
+      // overwrites its score, so we don't need to ZREM first.
+      await this.client.zadd(RANKING_KEY, {
+        score: updated.requestCount,
+        member: url,
+      });
+      return true as const;
+    });
+  }
+
+  async get(url: string): Promise<Result<CatalogFeed | null>> {
+    return tryUpstash(async () => {
+      const value = await this.client.get<CatalogFeed>(feedKey(url));
+      return value ?? null;
+    });
+  }
+
+  async popular(limit: number): Promise<Result<CatalogFeed[]>> {
+    return tryUpstash(async () => {
+      // 1. ZRANGE the top N URLs by score (descending).
+      const urls = await this.client.zrange(RANKING_KEY, 0, limit - 1, {
+        rev: true,
+      });
+      if (urls.length === 0) return [];
+
+      // 2. MGET all entries in one round trip. Skip null entries — they
+      //    represent ranking-set members whose detail rows have been GC'd
+      //    or were never written (defensive; should be impossible under
+      //    normal operation).
+      const keys = urls.map(feedKey);
+      const entries = await this.client.mget<CatalogFeed>(...keys);
+      return entries.filter((e): e is CatalogFeed => e !== null);
+    });
+  }
+
+  async updateMetadata(
+    url: string,
+    metadata: Partial<
+      Pick<
+        CatalogFeed,
+        | "title"
+        | "description"
+        | "siteUrl"
+        | "status"
+        | "lastCrawledAt"
+        | "errorCount"
+        | "lastError"
+      >
+    >,
+  ): Promise<Result<true>> {
+    return tryUpstash(async () => {
+      const existing = await this.client.get<CatalogFeed>(feedKey(url));
+      // No-op on missing — avoids creating partial entries with only
+      // metadata fields and no requestCount (which would skew popular()).
+      if (!existing) return true as const;
+      const merged: CatalogFeed = { ...existing, ...metadata };
+      await this.client.set(feedKey(url), merged);
+      return true as const;
+    });
+  }
+
+  async count(): Promise<Result<number>> {
+    return tryUpstash(() => this.client.zcard(RANKING_KEY));
+  }
+}
+
+/**
+ * Resolve Upstash REST credentials from either naming convention. Mirrors
+ * `resolveUpstashCredentials` in license/storage-upstash.ts — operators
+ * configure once and all three adapters (license, sync, catalog) pick it up.
+ */
+function resolveUpstashCredentials(
+  env: Record<string, string | undefined>,
+): { url: string; token: string } | null {
+  const url = env.UPSTASH_REDIS_REST_URL ?? env.KV_REST_API_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN ?? env.KV_REST_API_TOKEN;
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+/** True iff the env carries a usable Upstash REST credential pair. */
+export function hasUpstashCatalogCredentials(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return resolveUpstashCredentials(env) !== null;
+}
+
+/**
+ * Build an `UpstashCatalogAdapter` backed by the real `@upstash/redis`
+ * client. Throws if Upstash credentials are not configured — fail-fast
+ * at startup is preferable to a silent no-op store (which is precisely
+ * the failure mode the previous memory-only adapter exhibited).
+ */
+export async function createUpstashCatalogAdapter(
+  env: Record<string, string | undefined> = process.env,
+): Promise<UpstashCatalogAdapter> {
+  const creds = resolveUpstashCredentials(env);
+  if (!creds) {
+    throw new Error(
+      "Upstash REST credentials not found. Set UPSTASH_REDIS_REST_URL + " +
+        "UPSTASH_REDIS_REST_TOKEN, or use the Vercel Marketplace Upstash " +
+        "integration which auto-injects KV_REST_API_URL + KV_REST_API_TOKEN.",
+    );
+  }
+  const { Redis } = await import("@upstash/redis");
+  return new UpstashCatalogAdapter(
+    new Redis({ url: creds.url, token: creds.token }),
+  );
+}

--- a/src/core/catalog/resolve-catalog-storage.ts
+++ b/src/core/catalog/resolve-catalog-storage.ts
@@ -1,0 +1,40 @@
+/**
+ * Pick the right CatalogStorageAdapter based on the environment.
+ *
+ * Mirrors `src/core/license/resolve-storage.ts` and
+ * `src/core/sync/adapters/resolve-adapter.ts` — same env-var precedence
+ * (canonical `UPSTASH_REDIS_REST_*` first, Vercel-Marketplace-injected
+ * `KV_REST_API_*` second), same fallback to in-memory for dev/test.
+ *
+ * Memory mode is correct for tests and self-hosters who haven't set up an
+ * Upstash REST integration. It is NOT correct for production multi-instance
+ * Vercel deployments — every cold-started lambda gets a fresh empty map,
+ * which is exactly the bug this module exists to fix. The module-load log
+ * line in api/catalog.ts surfaces the resolved mode so an operator can
+ * catch a regression to memory mode on first deploy.
+ */
+
+import {
+  createMemoryCatalogAdapter,
+} from "./adapters/memory-adapter";
+import {
+  createUpstashCatalogAdapter,
+  hasUpstashCatalogCredentials,
+} from "./adapters/upstash-adapter";
+import type { CatalogStorageAdapter } from "./catalog-types";
+
+export async function resolveCatalogStorage(
+  env: Record<string, string | undefined> = process.env,
+): Promise<CatalogStorageAdapter> {
+  if (hasUpstashCatalogCredentials(env)) {
+    return createUpstashCatalogAdapter(env);
+  }
+  return createMemoryCatalogAdapter();
+}
+
+/** Label form of `resolveCatalogStorage` for module-load logging. */
+export function describeCatalogStorageMode(
+  env: Record<string, string | undefined> = process.env,
+): "upstash" | "memory" {
+  return hasUpstashCatalogCredentials(env) ? "upstash" : "memory";
+}

--- a/tests/core/catalog/resolve-catalog-storage.test.ts
+++ b/tests/core/catalog/resolve-catalog-storage.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveCatalogStorage,
+  describeCatalogStorageMode,
+} from "@/core/catalog/resolve-catalog-storage";
+import { UpstashCatalogAdapter } from "@/core/catalog/adapters/upstash-adapter";
+
+describe("resolveCatalogStorage", () => {
+  // Mirrors the shape of resolveLicenseStorage / resolveSeenEventStore so an
+  // operator who knows one knows the other.
+
+  it("returns a memory adapter when Upstash env is absent", async () => {
+    const adapter = await resolveCatalogStorage({});
+    // Memory adapter satisfies the interface but is NOT UpstashCatalogAdapter.
+    expect(adapter).not.toBeInstanceOf(UpstashCatalogAdapter);
+    // Verify the interface shape is intact (smoke test, not exhaustive).
+    expect(typeof adapter.upsert).toBe("function");
+    expect(typeof adapter.popular).toBe("function");
+    expect(typeof adapter.count).toBe("function");
+  });
+
+  it("returns UpstashCatalogAdapter when canonical UPSTASH_* env is set", async () => {
+    const adapter = await resolveCatalogStorage({
+      UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+      UPSTASH_REDIS_REST_TOKEN: "tok",
+    });
+    expect(adapter).toBeInstanceOf(UpstashCatalogAdapter);
+  });
+
+  it("returns UpstashCatalogAdapter when Vercel-Marketplace KV_REST_API_* names are set", async () => {
+    // The Vercel Marketplace Upstash integration injects KV_REST_API_*
+    // (legacy Vercel KV names). All three Upstash-backed adapters honor
+    // both name pairs.
+    const adapter = await resolveCatalogStorage({
+      KV_REST_API_URL: "https://example.upstash.io",
+      KV_REST_API_TOKEN: "tok",
+    });
+    expect(adapter).toBeInstanceOf(UpstashCatalogAdapter);
+  });
+
+  it("prefers UPSTASH_* over KV_REST_API_* when both are set", async () => {
+    // Explicit override beats auto-injected. Same rule as license/sync.
+    const adapter = await resolveCatalogStorage({
+      UPSTASH_REDIS_REST_URL: "https://canonical.upstash.io",
+      UPSTASH_REDIS_REST_TOKEN: "canonical-tok",
+      KV_REST_API_URL: "https://legacy.upstash.io",
+      KV_REST_API_TOKEN: "legacy-tok",
+    });
+    expect(adapter).toBeInstanceOf(UpstashCatalogAdapter);
+  });
+});
+
+describe("describeCatalogStorageMode (module-load logging label)", () => {
+  it("returns 'memory' when Upstash env is missing", () => {
+    expect(describeCatalogStorageMode({})).toBe("memory");
+  });
+
+  it("returns 'upstash' when canonical UPSTASH_REDIS_REST_* are set", () => {
+    expect(
+      describeCatalogStorageMode({
+        UPSTASH_REDIS_REST_URL: "https://x",
+        UPSTASH_REDIS_REST_TOKEN: "tok",
+      }),
+    ).toBe("upstash");
+  });
+
+  it("returns 'upstash' when only Vercel-Marketplace KV_REST_API_* is set", () => {
+    expect(
+      describeCatalogStorageMode({
+        KV_REST_API_URL: "https://x",
+        KV_REST_API_TOKEN: "tok",
+      }),
+    ).toBe("upstash");
+  });
+});

--- a/tests/core/catalog/upstash-adapter.test.ts
+++ b/tests/core/catalog/upstash-adapter.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Upstash-backed catalog storage adapter (PR following #45 — eliminates the
+ * "stats always show zero" bug rooted in the memory-only catalog adapter
+ * being reset on every Vercel Lambda cold start).
+ *
+ * Key layout:
+ *   catalog:feed:<url>   — JSON CatalogFeed (one per known feed URL)
+ *   catalog:ranking      — Redis sorted set keyed on requestCount, members
+ *                          are feed URLs. Enables O(log N) inserts and
+ *                          O(top-K) reads for popular().
+ *
+ * The adapter accepts an injected `UpstashCatalogClient` so tests stay
+ * trivially mockable. Production wrapper constructs a real `@upstash/redis`
+ * Redis client and passes it in. Mirrors `storage-upstash.ts` exactly.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  UpstashCatalogAdapter,
+  type UpstashCatalogClient,
+} from "@/core/catalog/adapters/upstash-adapter";
+
+/** In-memory fake of the small Upstash subset the adapter needs. */
+function fakeClient(): UpstashCatalogClient & {
+  store: Map<string, unknown>;
+  zset: Map<string, number>;
+} {
+  const store = new Map<string, unknown>();
+  const zset = new Map<string, number>(); // member -> score
+  return {
+    store,
+    zset,
+    async get<T = unknown>(key: string): Promise<T | null> {
+      return store.has(key) ? (store.get(key) as T) : null;
+    },
+    async set(key, value) {
+      store.set(key, value);
+      return "OK";
+    },
+    async zadd(_key, scoreMember) {
+      // Upstash zadd accepts { score, member }. Our fake supports only the
+      // single-pair variant the adapter uses.
+      zset.set(scoreMember.member, scoreMember.score);
+      return 1;
+    },
+    async zcard(_key) {
+      return zset.size;
+    },
+    async zrange(_key, start, stop, opts) {
+      // Sorted desc when opts.rev = true; the adapter always passes rev: true
+      // for popular(). Return member URLs in score order.
+      const entries = [...zset.entries()].sort((a, b) =>
+        opts?.rev ? b[1] - a[1] : a[1] - b[1],
+      );
+      return entries.slice(start, stop + 1).map(([m]) => m);
+    },
+    async mget<T = unknown>(...keys: string[]): Promise<Array<T | null>> {
+      return keys.map((k) => (store.has(k) ? (store.get(k) as T) : null));
+    },
+  };
+}
+
+const URL1 = "https://example.com/feed.xml";
+const URL2 = "https://other.com/rss";
+const URL3 = "https://third.com/atom";
+
+describe("UpstashCatalogAdapter", () => {
+  describe("upsert", () => {
+    it("creates a new feed entry with requestCount=1 and status=active", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      const result = await adapter.upsert(URL1);
+      expect(result.ok).toBe(true);
+
+      const got = await adapter.get(URL1);
+      expect(got.ok).toBe(true);
+      if (!got.ok) return;
+      expect(got.value).not.toBeNull();
+      expect(got.value!.url).toBe(URL1);
+      expect(got.value!.requestCount).toBe(1);
+      expect(got.value!.status).toBe("active");
+      expect(got.value!.title).toBeNull();
+    });
+
+    it("increments requestCount on subsequent upserts of the same URL", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      await adapter.upsert(URL1);
+      await adapter.upsert(URL1);
+      await adapter.upsert(URL1);
+
+      const got = await adapter.get(URL1);
+      if (!got.ok) return;
+      expect(got.value!.requestCount).toBe(3);
+    });
+
+    it("keeps the sorted-set ranking in sync with requestCount", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      await adapter.upsert(URL1); // count 1
+      await adapter.upsert(URL2); // count 1
+      await adapter.upsert(URL1); // count 2
+      await adapter.upsert(URL1); // count 3
+      await adapter.upsert(URL2); // count 2
+
+      // The ranking sorted set must reflect the current counts so popular()
+      // returns the right order without scanning all entries.
+      expect(client.zset.get(URL1)).toBe(3);
+      expect(client.zset.get(URL2)).toBe(2);
+    });
+
+    it("returns Result.err when the underlying client throws", async () => {
+      const broken: UpstashCatalogClient = {
+        async get() { return null; },
+        async set() { throw new Error("redis error"); },
+        async zadd() { return 0; },
+        async zcard() { return 0; },
+        async zrange() { return []; },
+        async mget() { return []; },
+      };
+      const result = await new UpstashCatalogAdapter(broken).upsert(URL1);
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("get", () => {
+    it("returns ok(null) for an unknown URL", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      const result = await adapter.get(URL1);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toBeNull();
+    });
+  });
+
+  describe("popular", () => {
+    it("returns the top N feeds by requestCount descending", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      // URL2: 5 requests, URL1: 3 requests, URL3: 1 request
+      for (let i = 0; i < 5; i++) await adapter.upsert(URL2);
+      for (let i = 0; i < 3; i++) await adapter.upsert(URL1);
+      await adapter.upsert(URL3);
+
+      const result = await adapter.popular(2);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toHaveLength(2);
+      expect(result.value[0].url).toBe(URL2);
+      expect(result.value[0].requestCount).toBe(5);
+      expect(result.value[1].url).toBe(URL1);
+      expect(result.value[1].requestCount).toBe(3);
+    });
+
+    it("returns empty array when no feeds are known", async () => {
+      const adapter = new UpstashCatalogAdapter(fakeClient());
+      const result = await adapter.popular(10);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toEqual([]);
+    });
+
+    it("uses MGET to batch the per-URL detail fetches (no N+1 round trips)", async () => {
+      // Production-perf invariant: popular() looks up N URLs via the sorted
+      // set then fetches their entries. If we do N separate GETs, that's
+      // N round trips. Using MGET collapses to 1 round trip.
+      const client = fakeClient();
+      let mgetCalls = 0;
+      const original = client.mget.bind(client);
+      client.mget = async <T = unknown>(...keys: string[]) => {
+        mgetCalls++;
+        return original<T>(...keys);
+      };
+      const adapter = new UpstashCatalogAdapter(client);
+      await adapter.upsert(URL1);
+      await adapter.upsert(URL2);
+      await adapter.upsert(URL3);
+
+      mgetCalls = 0; // reset after the upserts
+      await adapter.popular(10);
+      expect(mgetCalls).toBe(1);
+    });
+  });
+
+  describe("count", () => {
+    it("returns ZCARD of the ranking set (O(1), not a full scan)", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      await adapter.upsert(URL1);
+      await adapter.upsert(URL2);
+      await adapter.upsert(URL3);
+
+      const result = await adapter.count();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toBe(3);
+    });
+
+    it("returns 0 when no feeds are known", async () => {
+      const adapter = new UpstashCatalogAdapter(fakeClient());
+      const result = await adapter.count();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toBe(0);
+    });
+  });
+
+  describe("updateMetadata", () => {
+    it("merges fields into an existing entry", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      await adapter.upsert(URL1);
+      const result = await adapter.updateMetadata(URL1, {
+        title: "Example Feed",
+        description: "Test description",
+        siteUrl: "https://example.com",
+      });
+      expect(result.ok).toBe(true);
+
+      const got = await adapter.get(URL1);
+      if (!got.ok) return;
+      expect(got.value!.title).toBe("Example Feed");
+      expect(got.value!.description).toBe("Test description");
+      expect(got.value!.siteUrl).toBe("https://example.com");
+      // requestCount must be preserved.
+      expect(got.value!.requestCount).toBe(1);
+    });
+
+    it("is a no-op when the feed doesn't exist (avoids creating partial entries)", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      const result = await adapter.updateMetadata(URL1, { title: "Test" });
+      expect(result.ok).toBe(true);
+      // No entry created.
+      const got = await adapter.get(URL1);
+      if (!got.ok) return;
+      expect(got.value).toBeNull();
+    });
+  });
+
+  describe("keyspace isolation", () => {
+    it("only writes keys under the catalog: prefix (no collision with license/sync namespaces)", async () => {
+      const client = fakeClient();
+      const adapter = new UpstashCatalogAdapter(client);
+      await adapter.upsert(URL1);
+      const keys = [...client.store.keys()];
+      expect(keys.every((k) => k.startsWith("catalog:"))).toBe(true);
+      // The ranking sorted set also uses the catalog: prefix.
+      expect(keys.some((k) => k.startsWith("license:") || k.startsWith("vault:"))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The "Feeds tracked" stat and the top-feeds leaderboard on the public stats page have always shown zero — not because of a privacy floor, but because the underlying catalog had no persistence layer. This PR fixes it.

## Why the data was zero

Two unrelated architecture bugs:

1. **`api/catalog.ts`** used `createMemoryCatalogAdapter()` — an in-memory `Map` that resets on every Vercel Lambda cold start. Worse, `api/feed.ts` (proxy) and `api/catalog.ts` (stats reader) are separate lambdas with separate memory. The proxy's upserts could never reach the stats endpoint's reads.
2. **`api/stats-sync.ts`** hardcoded `createVercelBlobAdapter()`. After PR #45 migrated sync to Upstash, the stats endpoint kept querying an empty Blob bucket.

There were no rules to relax — the data simply wasn't being persisted across lambda invocations.

## What changes

- **`src/core/catalog/adapters/upstash-adapter.ts`** (new) — persistent catalog on Upstash KV. Keys: `catalog:feed:<url>` for entries, `catalog:ranking` as a Redis sorted set keyed on `requestCount`. `popular()` is ZRANGE+MGET (2 round trips, no N+1). `count()` is ZCARD (O(1)).
- **`src/core/catalog/resolve-catalog-storage.ts`** (new) — env-driven cascade, same shape as `resolveLicenseStorage` / `resolveSeenEventStore`.
- **`api/catalog.ts`**, **`api/feed.ts`**, **`api/stats-sync.ts`** rewritten as source-form thin wrappers. `api/feed.ts` now passes `catalogAdapter` to `handleProxyRequest` so proxy writes actually persist. `api/stats-sync.ts` uses `resolveAdapter()` so it queries the live sync backend (Upstash post-#45).
- Each `api/*.ts` ships a `console.log("[catalog] storage=upstash")` / `[stats-sync] adapter=upstash` module-load line — same diagnostic pattern as PR #43. A regression to memory mode is visible in the first Vercel deploy log.

## Test plan

- [x] 1894 unit/integration tests pass (20 new: 13 for `UpstashCatalogAdapter`, 7 for resolver)
- [x] `npx tsc --noEmit` clean
- [x] Keyspace-isolation test: catalog adapter only writes `catalog:*`; no collision with `license:*`, `vault:*`, or `customer:*` namespaces.
- [x] MGET batching test: `popular(N)` uses one MGET round trip, not N individual GETs (production-perf invariant).
- [ ] **Post-merge runtime verification:** confirm `[catalog] storage=upstash` and `[stats-sync] adapter=upstash` in cold-start Vercel logs. Refresh some feeds via the deployed app, then load `/stats` — expect non-zero "Feeds tracked" count.

## Migration / rollback

- **No data migration needed.** Existing per-feed counts have always been ephemeral (zeroed every cold start). The post-fix catalog starts from zero but actually accumulates this time.
- **Rollback path:** remove the Upstash credentials temporarily to force memory mode. The change is additive — memory adapter stays as the fallback.

## Write-volume note

Every proxy fetch now writes to Upstash (1 GET + 1 SET + 1 ZADD = 3 commands). For high-traffic operation this could approach Upstash quota limits — worth monitoring after deploy. If volume becomes a concern, the cheapest mitigation is a per-URL dedup window (e.g., skip the upsert if the same URL was upserted in the last 60s) — implementable as an in-memory `Map<url, lastUpsertMs>` inside the adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)