### PR TITLE
feat(proxy): Upstash-backed rate limiter + bake SMOKE into RGR workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,9 @@ No ESLint or Prettier configuration exists in the project. TypeScript strict mod
 
 ## Development Workflow
 
-This project follows **Red-Green-Refactor (RGR)** — the TDD cycle where you write a failing test (red), make it pass with minimal code (green), then clean up (refactor). Every feature follows this exact sequence. **No step may be skipped or reordered.**
+This project follows **Red-Green-Refactor-Smoke (RGR+S)** — the TDD cycle where you write a failing test (red), make it pass with minimal code (green), clean up (refactor), and verify the change works against the real deployed system after merge (smoke). Every feature follows this exact sequence. **No step may be skipped or reordered.**
+
+Why we added SMOKE on top of standard RGR: two production bugs (2026-05-12 sync regression, 2026-05-14 stats-always-zero) shared a class — code was internally correct (unit tests green) but the *system* was wrong (stale env var, in-memory adapter resetting on every cold start). Unit tests cannot see this category: they run in a single process, against in-memory fakes, in <10s. Only a test that hits the *deployed* system against *real* infrastructure can. See [Smoke tests](#smoke-tests) below.
 
 1. **PLAN** — Gherkin-style stories, minimal scope. Confirm with user before proceeding.
 
@@ -288,6 +290,29 @@ This project follows **Red-Green-Refactor (RGR)** — the TDD cycle where you wr
    - ⛔ **STOP: Re-run `npm test` after refactoring. All tests must still pass.**
 
 6. **DOCUMENT** — Review the `docs/` folder. Update `docs/architecture.md`, `docs/data-schema.md`, and relevant feature docs in `docs/features/` to reflect what changed. Create a new feature doc from `docs/features/TEMPLATE.md` for any new feature. Update ADRs in `docs/decisions/` if architectural decisions were made.
+
+7. **SMOKE** — For any change that affects production behavior (endpoint handlers, data layer, adapter resolution, deployment artifacts), add a smoke test under `tests/smoke/` that exercises the **live deployed system** after merge. The smoke test asserts the feature works against real production infrastructure — not mocked adapters, not a dev server. Catches the class of bug where the code is correct but the deployed environment is wrong (config drift, missing env vars, wrong adapter resolved, serverless state not shared across lambdas).
+   - Smoke tests are skipped by default. Run with `SMOKE_TESTS=1 npx vitest run tests/smoke/<name>` after Vercel reports the deploy is Ready.
+   - The smoke test for a feature is part of the feature's definition of done. A PR that introduces or modifies a production code path without a corresponding smoke test is incomplete.
+   - ⛔ **STOP: If the smoke test fails after deploy, revert or roll forward with a fix immediately.** A merged PR isn't done until its smoke test passes against prod. "It passed CI" does not mean "it works in production."
+   - See [Smoke tests](#smoke-tests) for what to assert, what NOT to assert, and the anonymity floor.
+
+## Smoke tests
+
+Smoke tests live in `tests/smoke/` and run only when the `SMOKE_TESTS=1` env var is set. They are **not** part of `npm test`. They:
+
+- Hit real production URLs (`https://my.feedzero.app/api/*`) via `fetch`.
+- Assert system-level invariants the unit suite cannot check: "adapter X actually resolves to Upstash in prod", "rate limit 429s appear after N requests", "vault PUT then GET returns the same bytes against the real backend".
+- Are tolerant of test-induced side effects: a smoke test that exhausts a rate-limit bucket must wait for the window to reset before asserting "normal traffic works".
+- Run with `SMOKE_BASE_URL` overridable for staging / preview environments.
+
+What NOT to assert in smoke tests:
+- Unit-level behavior (function returns X for Y) — that's the RED step's job.
+- UI rendering (use Playwright E2E).
+- Per-user state (smoke tests are stateless and parallelizable).
+- Anything that would log raw IPs, user emails, license token values, or vault ciphertext. Smoke tests honor the same anonymity floor as production logs.
+
+Reference pattern: `tests/smoke/release-feed.test.ts` (fetches the live release feed), `tests/smoke/rate-limiter.test.ts` (verifies the proxy rate limiter engages against prod).
 
 ## Commit Messages
 

--- a/api/feed.ts
+++ b/api/feed.ts
@@ -3,28 +3,32 @@ import {
   resolveCatalogStorage,
   describeCatalogStorageMode,
 } from "../src/core/catalog/resolve-catalog-storage";
+import {
+  resolveProxyRateLimiter,
+  describeRateLimiterMode,
+} from "../src/core/proxy/resolve-rate-limiter";
 
-// Module-load logging — surfaces which catalog backend resolved. Before
-// the persistent-catalog fix, this lambda ran an in-memory adapter that
-// silently dropped all upserts on every cold start, which is why the
-// stats page showed zero feeds tracked. The log line catches a future
-// regression to memory mode on the first deploy.
-console.log(`[feed-proxy] catalog=${describeCatalogStorageMode()}`);
+// Module-load logging — surfaces which catalog backend resolved and
+// whether the rate limiter is active. Mirrors PR #43's pattern.
+console.log(
+  `[feed-proxy] catalog=${describeCatalogStorageMode()} ratelimit=${describeRateLimiterMode()}`,
+);
 
 const catalogPromise = resolveCatalogStorage();
+const rateLimitPromise = resolveProxyRateLimiter();
 
 async function dispatch(
   req: Request,
   contentType: string,
 ): Promise<Response> {
-  const catalogAdapter = await catalogPromise;
-  // `cleanContent: true` mirrors server.ts (the Hono entry point used for
-  // self-hosting). `catalogAdapter` is fire-and-forget: the proxy returns
-  // the feed response immediately and the catalog upsert runs in the
-  // background. Failures are swallowed.
+  const [catalogAdapter, rateLimit] = await Promise.all([
+    catalogPromise,
+    rateLimitPromise,
+  ]);
   return handleProxyRequest(req, contentType, {
     catalogAdapter,
     cleanContent: true,
+    ...(rateLimit ? { rateLimit } : {}),
   });
 }
 

--- a/api/page.ts
+++ b/api/page.ts
@@ -1,236 +1,29 @@
-// @ts-nocheck
-// api/page.ts
-function ok(value) {
-  return { ok: true, value };
-}
-function err(error) {
-  return { ok: false, error };
-}
-var BLOCKED_HOSTNAMES = /* @__PURE__ */ new Set([
-  "localhost",
-  "127.0.0.1",
-  "::1",
-  "0.0.0.0",
-  "169.254.169.254"
-]);
-var BLOCKED_PREFIXES = ["10.", "192.168."];
-function isPrivate172(hostname) {
-  const match = hostname.match(/^172\.(\d+)\./);
-  if (!match) return false;
-  const octet = parseInt(match[1], 10);
-  return octet >= 16 && octet <= 31;
-}
-function extractMappedIPv4(hostname) {
-  const dotted = hostname.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
-  if (dotted) return dotted[1];
-  const hex = hostname.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
-  if (hex) {
-    const high = parseInt(hex[1], 16);
-    const low = parseInt(hex[2], 16);
-    return `${high >> 8 & 255}.${high & 255}.${low >> 8 & 255}.${low & 255}`;
-  }
-  return null;
-}
-function isPrivateIPv4(ip) {
-  return BLOCKED_HOSTNAMES.has(ip) || BLOCKED_PREFIXES.some((prefix) => ip.startsWith(prefix)) || isPrivate172(ip);
-}
-function validateProxyUrl(url) {
-  if (!url) {
-    return err("Missing url parameter");
-  }
-  let parsed;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return err("Invalid URL");
-  }
-  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-    return err("Only http and https URLs are allowed");
-  }
-  const rawHostname = parsed.hostname.replace(/^\[|\]$/g, "");
-  const ipToCheck = extractMappedIPv4(rawHostname) ?? rawHostname;
-  if (isPrivateIPv4(ipToCheck)) {
-    return err("Access to internal addresses is blocked");
-  }
-  return ok(parsed);
-}
-var TRACKER_DOMAINS = [
-  "pixel.quantserve.com",
-  "sb.scorecardresearch.com",
-  "analytics.twitter.com",
-  "www.google-analytics.com",
-  "www.facebook.com/tr",
-  "feeds.feedburner.com",
-  "feeds.feedblitz.com",
-  "stats.wordpress.com",
-  "pixel.wp.com",
-  "tr.snapchat.com",
-  "bat.bing.com",
-  "ct.pinterest.com",
-  "tags.tiqcdn.com"
-];
-var IMG_REGEX = /<img\b[^>]*>/gi;
-var SRC_REGEX = /\bsrc=["']([^"']*)["']/i;
-var WIDTH_REGEX = /\bwidth=["']?(\d+)["']?/i;
-var HEIGHT_REGEX = /\bheight=["']?(\d+)["']?/i;
-function isTrackerDomain(src) {
-  return TRACKER_DOMAINS.some((domain) => src.includes(domain));
-}
-function isTrackingPixel(imgTag) {
-  const srcMatch = imgTag.match(SRC_REGEX);
-  if (!srcMatch) return false;
-  const src = srcMatch[1];
-  if (isTrackerDomain(src)) return true;
-  const widthMatch = imgTag.match(WIDTH_REGEX);
-  const heightMatch = imgTag.match(HEIGHT_REGEX);
-  if (widthMatch && heightMatch) {
-    const w = parseInt(widthMatch[1], 10);
-    const h = parseInt(heightMatch[1], 10);
-    if (w <= 1 && h <= 1) return true;
-  }
-  return false;
-}
-function stripTrackers(html) {
-  return html.replace(
-    IMG_REGEX,
-    (imgTag) => isTrackingPixel(imgTag) ? "" : imgTag
-  );
-}
-var TRACKING_PARAMS = /* @__PURE__ */ new Set([
-  "utm_source",
-  "utm_medium",
-  "utm_campaign",
-  "utm_term",
-  "utm_content",
-  "utm_id",
-  "fbclid",
-  "gclid",
-  "gclsrc",
-  "dclid",
-  "msclkid",
-  "twclid",
-  "igshid",
-  "mc_cid",
-  "mc_eid",
-  "_ga",
-  "_gl",
-  "oly_anon_id",
-  "oly_enc_id",
-  "vero_id",
-  "s_cid",
-  "icid",
-  "ef_id"
-]);
-var URL_IN_ATTR_REGEX = /\b(href|src)="([^"]*)"/gi;
-function cleanUrl(raw) {
-  const qIndex = raw.indexOf("?");
-  if (qIndex === -1) return raw;
-  const base = raw.slice(0, qIndex);
-  const query = raw.slice(qIndex + 1);
-  const params = query.split("&").filter((p) => {
-    const key = p.split("=")[0].toLowerCase();
-    return !TRACKING_PARAMS.has(key);
-  });
-  return params.length > 0 ? `${base}?${params.join("&")}` : base;
-}
-function cleanLinks(html) {
-  return html.replace(URL_IN_ATTR_REGEX, (_, attr, url) => {
-    return `${attr}="${cleanUrl(url)}"`;
+import { handleProxyRequest } from "../src/core/proxy/proxy-handler";
+import {
+  resolveProxyRateLimiter,
+  describeRateLimiterMode,
+} from "../src/core/proxy/resolve-rate-limiter";
+
+// Module-load logging — surfaces whether the rate limiter is active on
+// the article-extractor proxy. Same threat surface as /api/feed.
+console.log(`[page-proxy] ratelimit=${describeRateLimiterMode()}`);
+
+const rateLimitPromise = resolveProxyRateLimiter();
+
+async function dispatch(
+  req: Request,
+  contentType: string,
+): Promise<Response> {
+  const rateLimit = await rateLimitPromise;
+  return handleProxyRequest(req, contentType, {
+    ...(rateLimit ? { rateLimit } : {}),
   });
 }
-function cleanFeedContent(raw) {
-  let result = raw;
-  result = result.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, (_, content) => {
-    return `<![CDATA[${cleanLinks(stripTrackers(content))}]]>`;
-  });
-  result = result.replace(/&lt;([\s\S]*?)&gt;/g, (match) => {
-    const decoded = match.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&").replace(/&quot;/g, '"');
-    const cleaned = cleanLinks(stripTrackers(decoded));
-    return cleaned.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-  });
-  return result;
+
+export async function GET(req: Request): Promise<Response> {
+  return dispatch(req, "text/html");
 }
-async function handleProxyRequest(req, defaultContentType, options) {
-  const target = await extractTargetUrl(req);
-  const validation = validateProxyUrl(target);
-  if (!validation.ok) {
-    const status = validation.error === "Access to internal addresses is blocked" ? 403 : 400;
-    return new Response(validation.error, { status });
-  }
-  const url = validation.value.href;
-  const cache = options?.cache;
-  if (cache) {
-    const cached = cache.get(url);
-    if (cached) {
-      return new Response(cached.body, {
-        status: cached.status,
-        headers: { "Content-Type": cached.contentType }
-      });
-    }
-  }
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15e3);
-    const response = await fetch(url, {
-      headers: { "User-Agent": "FeedZero/1.0 (RSS Reader)" },
-      signal: controller.signal
-    });
-    clearTimeout(timeout);
-    const contentType = response.headers.get("content-type") || defaultContentType;
-    const body = await response.arrayBuffer();
-    if (cache && response.status >= 200 && response.status < 400) {
-      cache.set(url, body, contentType, response.status);
-    }
-    if (options?.catalogAdapter && response.status >= 200 && response.status < 400) {
-      options.catalogAdapter.upsert(url).catch(() => {
-      });
-    }
-    const isTextContent = /xml|html|text/i.test(contentType);
-    if (options?.cleanContent && isTextContent && response.status >= 200 && response.status < 400) {
-      const text = new TextDecoder().decode(body);
-      const cleaned = cleanFeedContent(text);
-      return new Response(cleaned, {
-        status: response.status,
-        headers: { "Content-Type": contentType }
-      });
-    }
-    return new Response(body, {
-      status: response.status,
-      headers: { "Content-Type": contentType }
-    });
-  } catch (e) {
-    const message = e instanceof Error ? e.message : "Unknown error";
-    console.error(
-      JSON.stringify({
-        level: "error",
-        context: "proxy",
-        target: url,
-        error: message,
-        timestamp: (/* @__PURE__ */ new Date()).toISOString()
-      })
-    );
-    return new Response(`Proxy error: ${message}`, { status: 502 });
-  }
+
+export async function POST(req: Request): Promise<Response> {
+  return dispatch(req, "text/html");
 }
-async function extractTargetUrl(req) {
-  if (req.method === "POST") {
-    try {
-      const body = await req.json();
-      return body.url ?? null;
-    } catch {
-      return null;
-    }
-  }
-  const url = new URL(req.url, "http://localhost");
-  return url.searchParams.get("url");
-}
-async function GET(req) {
-  return handleProxyRequest(req, "text/html");
-}
-async function POST(req) {
-  return handleProxyRequest(req, "text/html");
-}
-export {
-  GET,
-  POST
-};

--- a/src/core/proxy/proxy-handler.ts
+++ b/src/core/proxy/proxy-handler.ts
@@ -10,6 +10,26 @@ import { cleanFeedContent } from "../cleaner/cleaner.ts";
  */
 export const SUPPORTED_METHODS: readonly string[] = ["GET", "POST"];
 
+/**
+ * Per-client rate-limit hook. Caller injects a `limiter` and a
+ * `clientIdFor` function that derives the bucket key from the Request.
+ * The handler calls these BEFORE URL validation so invalid-URL probing
+ * still consumes the bucket. Returns 429 with `Retry-After` on deny.
+ * Both fields are required when `rateLimit` is set.
+ *
+ * Why an interface, not a concrete limiter type: keeps proxy-handler
+ * decoupled from the production Upstash limiter (and from `@upstash/redis`)
+ * so unit tests inject a fake.
+ */
+export interface ProxyRateLimit {
+  limiter: {
+    check(
+      clientId: string,
+    ): Promise<{ allowed: boolean; retryAfterSec?: number }>;
+  };
+  clientIdFor(req: Request): Promise<string>;
+}
+
 export interface ProxyOptions {
   /** Optional feed cache for deduplication across users. */
   cache?: FeedCache;
@@ -17,6 +37,14 @@ export interface ProxyOptions {
   catalogAdapter?: CatalogStorageAdapter;
   /** Strip trackers and tracking params from feed content before returning. */
   cleanContent?: boolean;
+  /**
+   * Optional per-client rate limiter. When set, the handler checks the
+   * limiter at request entry (before URL validation) and short-circuits
+   * with 429 if the client is over budget. Opt-in: omitting this leaves
+   * behavior unchanged (matches self-host / dev paths that don't run
+   * an Upstash-backed limiter).
+   */
+  rateLimit?: ProxyRateLimit;
 }
 
 /**
@@ -29,6 +57,27 @@ export async function handleProxyRequest(
   defaultContentType: string,
   options?: ProxyOptions,
 ): Promise<Response> {
+  // Rate-limit BEFORE URL validation so an attacker spraying invalid URLs
+  // still consumes their bucket. See rate-limiter test
+  // "checks the limiter BEFORE URL validation" for the regression guard.
+  if (options?.rateLimit) {
+    const clientId = await options.rateLimit.clientIdFor(req);
+    const result = await options.rateLimit.limiter.check(clientId);
+    if (!result.allowed) {
+      // RFC 6585 §4: 429 SHOULD include Retry-After. We always send it.
+      return new Response(
+        JSON.stringify({ ok: false, error: "rate limit exceeded" }),
+        {
+          status: 429,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": String(result.retryAfterSec ?? 60),
+          },
+        },
+      );
+    }
+  }
+
   const target = await extractTargetUrl(req);
 
   const validation = validateProxyUrl(target);

--- a/src/core/proxy/rate-limiter.ts
+++ b/src/core/proxy/rate-limiter.ts
@@ -1,0 +1,143 @@
+/**
+ * Per-client rate limiter for the production feed proxy.
+ *
+ * Architecture:
+ *  - Identify the client by hashing IP + User-Agent + project salt.
+ *    Raw IPs never leave the lambda's request context.
+ *  - Maintain a counter in Upstash KV keyed on the hash with a TTL window.
+ *    INCR returns the new count atomically; the first hit also EXPIRE-s
+ *    the key so the counter auto-resets at window boundary.
+ *  - Returns `{ allowed, retryAfterSec? }` per request — caller decides
+ *    whether to short-circuit with 429.
+ *
+ * Anonymity floor:
+ *  - The persisted key is `ratelimit:cli_<8-hex-chars>`. The hash uses
+ *    SHA-256 of `${ip}|${ua}|${salt}` — without the salt the hash is
+ *    still reversible via rainbow attack on common UAs, so the salt is
+ *    load-bearing for privacy. Rotating the salt invalidates all buckets
+ *    (useful for emergency reset).
+ *  - We DON'T log raw IPs anywhere. The `cli_xxxx` prefix matches the
+ *    `req_xxxx` shape from PR #43 so an operator can grep both.
+ *
+ * Why fail-open on Upstash errors: a rate limiter that takes the whole
+ * proxy down when storage hiccups is worse than no rate limiter. We log
+ * the failure and let the request through.
+ */
+
+/**
+ * Minimal subset of the Upstash Redis client the rate limiter needs.
+ * Defined inline so tests pass a fake without pulling in `@upstash/redis`.
+ */
+export interface UpstashRateLimitClient {
+  /** Atomic increment. Returns the new value. */
+  incr(key: string): Promise<number>;
+  /** Set TTL on a key in seconds. Returns 1 if set, 0 if key missing. */
+  expire(key: string, sec: number): Promise<number>;
+  /** Time-to-live in seconds. -1 = no TTL, -2 = key missing. */
+  ttl(key: string): Promise<number>;
+}
+
+export interface RateLimitConfig {
+  /** Max requests per client per window. Default: 300. */
+  limit: number;
+  /** Window length in seconds. Default: 60. */
+  windowSec: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  /** Seconds until the window resets. Only populated when allowed=false. */
+  retryAfterSec?: number;
+}
+
+const KEY_PREFIX = "ratelimit:";
+
+export class UpstashRateLimiter {
+  constructor(
+    private readonly client: UpstashRateLimitClient,
+    private readonly config: RateLimitConfig,
+  ) {}
+
+  async check(clientId: string): Promise<RateLimitResult> {
+    const key = KEY_PREFIX + clientId;
+    try {
+      const count = await this.client.incr(key);
+      // First hit in a new window — set the TTL so the counter auto-resets.
+      // Subsequent hits skip EXPIRE so the window doesn't slide forward
+      // (which would allow a steady-rate attacker to evade limits).
+      if (count === 1) {
+        await this.client.expire(key, this.config.windowSec);
+      }
+      if (count > this.config.limit) {
+        const ttl = await this.client.ttl(key);
+        // ttl can be -1 (no expiry — shouldn't happen) or -2 (missing — race
+        // condition between INCR and TTL). Treat both as "use the full
+        // window" to avoid returning 0 retry-after.
+        const retryAfterSec = ttl > 0 ? ttl : this.config.windowSec;
+        return { allowed: false, retryAfterSec };
+      }
+      return { allowed: true };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      // Fail OPEN — log and allow. See file header for rationale.
+      console.error(
+        JSON.stringify({
+          route: "rate-limiter",
+          errClass: "UpstashRateLimitError",
+          errMsg: message,
+          ts: new Date().toISOString(),
+        }),
+      );
+      return { allowed: true };
+    }
+  }
+}
+
+/**
+ * Derive a stable, opaque client identifier from a Request. Hashes
+ * IP + User-Agent + salt with SHA-256 and returns `cli_<8-hex-chars>`.
+ *
+ * The 8 hex chars give 4 billion possibilities — collisions across a year
+ * of traffic are negligible, and even a collision is harmless (worst case:
+ * two clients share a rate-limit bucket, slightly tighter than intended).
+ */
+export async function hashClientId(
+  request: Request,
+  salt: string,
+): Promise<string> {
+  const ip = extractClientIp(request);
+  const ua = request.headers.get("user-agent") ?? "";
+  const input = `${ip}|${ua}|${salt}`;
+
+  const encoder = new TextEncoder();
+  const buffer = await crypto.subtle.digest(
+    "SHA-256",
+    encoder.encode(input),
+  );
+  const bytes = new Uint8Array(buffer);
+  let hex = "";
+  for (let i = 0; i < 4; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return "cli_" + hex;
+}
+
+/**
+ * Extract the client IP from common forwarding headers. Returns "unknown"
+ * if no header is present (defensive — Vercel always sets x-forwarded-for
+ * in practice, but we don't want a crash).
+ *
+ * x-forwarded-for can be a comma-separated chain ("client, proxy1, proxy2").
+ * The FIRST entry is the original client; subsequent entries are
+ * infrastructure proxies and shouldn't change the client identity.
+ */
+function extractClientIp(request: Request): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const real = request.headers.get("x-real-ip");
+  if (real) return real.trim();
+  return "unknown";
+}

--- a/src/core/proxy/resolve-rate-limiter.ts
+++ b/src/core/proxy/resolve-rate-limiter.ts
@@ -1,0 +1,90 @@
+/**
+ * Resolve a production rate limiter from environment configuration.
+ *
+ * Returns `undefined` when the limiter shouldn't run (no Upstash creds,
+ * or no salt). The proxy handler's `rateLimit?` option is opt-in, so
+ * undefined cleanly disables rate limiting in dev / self-host / preview
+ * environments where Upstash isn't configured.
+ *
+ * Salt sourcing (load-bearing for anonymity):
+ *   1. `RATE_LIMIT_HASH_SALT` env var (explicit, operator-controlled).
+ *   2. `LICENSE_SIGNING_KEY` env var (already required in production,
+ *      high entropy, already secret-scoped in Vercel).
+ *   3. None → return undefined. Fail-CLOSED on salt because a limiter
+ *      without a salt persists hashes that are rainbow-attackable on
+ *      common IP+UA pairs; better to not rate-limit than to compromise
+ *      anonymity.
+ */
+
+import type { ProxyRateLimit } from "./proxy-handler";
+import {
+  UpstashRateLimiter,
+  hashClientId,
+} from "./rate-limiter";
+
+/**
+ * Defaults chosen to accommodate a "refresh all" of a 200-feed folder
+ * (which can fire 200 requests in 1 burst) without false-positive 429s,
+ * while still blocking sustained 5+ req/sec abuse. Tunable via the
+ * options arg if a route wants tighter limits.
+ */
+const DEFAULT_LIMIT = 300;
+const DEFAULT_WINDOW_SEC = 60;
+
+export interface RateLimiterConfig {
+  limit?: number;
+  windowSec?: number;
+}
+
+function hasUpstashCreds(
+  env: Record<string, string | undefined>,
+): { url: string; token: string } | null {
+  const url = env.UPSTASH_REDIS_REST_URL ?? env.KV_REST_API_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN ?? env.KV_REST_API_TOKEN;
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+function resolveSalt(
+  env: Record<string, string | undefined>,
+): string | null {
+  const explicit = env.RATE_LIMIT_HASH_SALT;
+  if (explicit && explicit.length > 0) return explicit;
+  const fallback = env.LICENSE_SIGNING_KEY;
+  if (fallback && fallback.length > 0) return fallback;
+  return null;
+}
+
+export async function resolveProxyRateLimiter(
+  env: Record<string, string | undefined> = process.env,
+  config: RateLimiterConfig = {},
+): Promise<ProxyRateLimit | undefined> {
+  const creds = hasUpstashCreds(env);
+  if (!creds) return undefined;
+  const salt = resolveSalt(env);
+  if (!salt) return undefined;
+
+  // Dynamic import keeps the SDK out of dev/test bundles when Upstash
+  // is not configured — matches the pattern in license/storage-upstash.ts.
+  const { Redis } = await import("@upstash/redis");
+  const client = new Redis({ url: creds.url, token: creds.token });
+
+  const limiter = new UpstashRateLimiter(client, {
+    limit: config.limit ?? DEFAULT_LIMIT,
+    windowSec: config.windowSec ?? DEFAULT_WINDOW_SEC,
+  });
+
+  return {
+    limiter,
+    clientIdFor: (req) => hashClientId(req, salt),
+  };
+}
+
+/** Label form for module-load logging in api/feed.ts and api/page.ts. */
+export function describeRateLimiterMode(
+  env: Record<string, string | undefined> = process.env,
+): "upstash" | "off" {
+  if (!hasUpstashCreds(env)) return "off";
+  if (!resolveSalt(env)) return "off";
+  return "upstash";
+}

--- a/tests/core/proxy/proxy-handler.test.ts
+++ b/tests/core/proxy/proxy-handler.test.ts
@@ -236,3 +236,104 @@ describe("proxyFetch ↔ handleProxyRequest contract", () => {
     expect(SUPPORTED_METHODS).toContain("POST");
   });
 });
+
+describe("handleProxyRequest — rate limiting", () => {
+  // Production-defense layer. Without this, a single client could hammer
+  // the proxy unbounded and the catalog counts would be indistinguishable
+  // from "popular feed" traffic. Opt-in via the `rateLimit` option so
+  // self-host / dev paths are unaffected.
+
+  function makeRequest(): Request {
+    return new Request("http://localhost/api/feed", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-forwarded-for": "203.0.113.42",
+      },
+      body: JSON.stringify({ url: "https://example.com/feed.xml" }),
+    });
+  }
+
+  it("short-circuits with 429 when the limiter denies the request", async () => {
+    const denyLimiter = {
+      async check() {
+        return { allowed: false as const, retryAfterSec: 42 };
+      },
+    };
+    const clientIdFor = async () => "cli_test1234";
+    const res = await handleProxyRequest(makeRequest(), "text/xml", {
+      rateLimit: { limiter: denyLimiter, clientIdFor },
+    });
+    expect(res.status).toBe(429);
+  });
+
+  it("includes a Retry-After header on 429", async () => {
+    // RFC 6585 §4: 429 responses SHOULD include Retry-After. Clients
+    // (and well-behaved bots) read this header to back off correctly.
+    const denyLimiter = {
+      async check() {
+        return { allowed: false as const, retryAfterSec: 42 };
+      },
+    };
+    const clientIdFor = async () => "cli_test1234";
+    const res = await handleProxyRequest(makeRequest(), "text/xml", {
+      rateLimit: { limiter: denyLimiter, clientIdFor },
+    });
+    expect(res.headers.get("Retry-After")).toBe("42");
+  });
+
+  it("passes through to the proxy when the limiter allows the request", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("<rss>ok</rss>", {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
+    );
+    const allowLimiter = {
+      async check() {
+        return { allowed: true as const };
+      },
+    };
+    const clientIdFor = async () => "cli_test1234";
+    const res = await handleProxyRequest(makeRequest(), "text/xml", {
+      rateLimit: { limiter: allowLimiter, clientIdFor },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("checks the limiter BEFORE URL validation (so invalid URLs still count)", async () => {
+    // Why: an attacker spraying invalid URLs should still consume their
+    // rate-limit budget. Otherwise they can probe the proxy unbounded.
+    let checkCount = 0;
+    const limiter = {
+      async check() {
+        checkCount++;
+        return { allowed: true as const };
+      },
+    };
+    const clientIdFor = async () => "cli_test1234";
+    const req = new Request("http://localhost/api/feed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "http://10.0.0.1/internal" }), // SSRF target
+    });
+    const res = await handleProxyRequest(req, "text/xml", {
+      rateLimit: { limiter, clientIdFor },
+    });
+    expect(res.status).toBe(403);
+    expect(checkCount).toBe(1);
+  });
+
+  it("does not rate-limit when no limiter is configured (current default)", async () => {
+    // Opt-in: existing test paths and self-hosters running without Upstash
+    // must not be affected by this PR.
+    fetchSpy.mockResolvedValue(
+      new Response("<rss>ok</rss>", {
+        status: 200,
+        headers: { "Content-Type": "text/xml" },
+      }),
+    );
+    const res = await handleProxyRequest(makeRequest(), "text/xml");
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/core/proxy/rate-limiter.test.ts
+++ b/tests/core/proxy/rate-limiter.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Stateless rate limiter for the production feed proxy. Counts requests per
+ * (hashed) client identifier in a 60-second sliding window via Upstash KV.
+ *
+ * Anonymity floor (matches the rest of FeedZero's logging surface):
+ *  - We HASH the client identifier (IP + User-Agent) with a project-scoped
+ *    salt before persisting. Raw IPs never leave the lambda's request
+ *    context. The hash is enough to count per-client rates but not enough
+ *    to reverse-look-up the user.
+ *  - The hash key is `cli_<8 hex chars>`-prefixed so it's grep-friendly in
+ *    Vercel logs, mirroring the `req_` traceId shape from PR #43.
+ *  - The counter key in Upstash is `ratelimit:cli_<hash>` and auto-expires
+ *    after the window. Nothing accumulates beyond the window.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  UpstashRateLimiter,
+  hashClientId,
+  type UpstashRateLimitClient,
+} from "@/core/proxy/rate-limiter";
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request("http://localhost/api/feed", {
+    method: "POST",
+    headers,
+  });
+}
+
+const SALT = "test-rate-limit-salt-v1";
+
+describe("hashClientId", () => {
+  it("returns a string starting with 'cli_'", async () => {
+    const id = await hashClientId(
+      makeRequest({ "x-forwarded-for": "203.0.113.1" }),
+      SALT,
+    );
+    expect(id.startsWith("cli_")).toBe(true);
+  });
+
+  it("has 8+ hex chars after the prefix (so collisions are rare)", async () => {
+    const id = await hashClientId(
+      makeRequest({ "x-forwarded-for": "203.0.113.1" }),
+      SALT,
+    );
+    const random = id.slice("cli_".length);
+    expect(random.length).toBeGreaterThanOrEqual(8);
+    expect(/^[0-9a-f]+$/.test(random)).toBe(true);
+  });
+
+  it("produces the same hash for the same IP + UA + salt (deterministic)", async () => {
+    const a = await hashClientId(
+      makeRequest({
+        "x-forwarded-for": "203.0.113.1",
+        "user-agent": "Mozilla/5.0",
+      }),
+      SALT,
+    );
+    const b = await hashClientId(
+      makeRequest({
+        "x-forwarded-for": "203.0.113.1",
+        "user-agent": "Mozilla/5.0",
+      }),
+      SALT,
+    );
+    expect(a).toBe(b);
+  });
+
+  it("produces different hashes for different IPs", async () => {
+    const a = await hashClientId(
+      makeRequest({ "x-forwarded-for": "203.0.113.1" }),
+      SALT,
+    );
+    const b = await hashClientId(
+      makeRequest({ "x-forwarded-for": "203.0.113.2" }),
+      SALT,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("produces different hashes for different User-Agents on the same IP", async () => {
+    // Pair IP+UA so multiple users behind one NAT (corporate office, mobile
+    // CGNAT) don't all share one rate-limit bucket.
+    const a = await hashClientId(
+      makeRequest({
+        "x-forwarded-for": "203.0.113.1",
+        "user-agent": "Firefox/120",
+      }),
+      SALT,
+    );
+    const b = await hashClientId(
+      makeRequest({
+        "x-forwarded-for": "203.0.113.1",
+        "user-agent": "Chrome/120",
+      }),
+      SALT,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it("produces different hashes for the same input under different salts (salt is honored)", async () => {
+    // Rotating the salt invalidates all cached hashes — useful for emergency
+    // reset of accumulated rate-limit state.
+    const req = makeRequest({ "x-forwarded-for": "203.0.113.1" });
+    const a = await hashClientId(req, "salt-v1");
+    const b = await hashClientId(req, "salt-v2");
+    expect(a).not.toBe(b);
+  });
+
+  it("falls back to 'unknown' when no IP header is present", async () => {
+    // Defensive: if Vercel doesn't set x-forwarded-for (impossible in
+    // practice, but we don't want a crash), still produce a stable hash.
+    const id = await hashClientId(makeRequest({}), SALT);
+    expect(id.startsWith("cli_")).toBe(true);
+  });
+
+  it("uses only the FIRST value of a comma-separated x-forwarded-for chain", async () => {
+    // x-forwarded-for can be a chain: "client, proxy1, proxy2". The first
+    // value is the original client. Proxies after that are infrastructure
+    // and shouldn't change the client identity.
+    const a = await hashClientId(
+      makeRequest({ "x-forwarded-for": "203.0.113.1, 10.0.0.1" }),
+      SALT,
+    );
+    const b = await hashClientId(
+      makeRequest({ "x-forwarded-for": "203.0.113.1, 10.0.0.2" }),
+      SALT,
+    );
+    expect(a).toBe(b);
+  });
+
+  it("does NOT include the raw IP or UA in the output (anonymity floor)", async () => {
+    const id = await hashClientId(
+      makeRequest({
+        "x-forwarded-for": "203.0.113.42",
+        "user-agent": "Mozilla/5.0 (X11; Linux)",
+      }),
+      SALT,
+    );
+    expect(id).not.toContain("203.0.113.42");
+    expect(id).not.toContain("Mozilla");
+    expect(id).not.toContain("Linux");
+  });
+});
+
+describe("UpstashRateLimiter", () => {
+  function fakeClient(): UpstashRateLimitClient & {
+    incrCalls: string[];
+    expireCalls: Array<[string, number]>;
+    state: Map<string, number>;
+  } {
+    const state = new Map<string, number>();
+    const incrCalls: string[] = [];
+    const expireCalls: Array<[string, number]> = [];
+    return {
+      state,
+      incrCalls,
+      expireCalls,
+      async incr(key) {
+        incrCalls.push(key);
+        const next = (state.get(key) ?? 0) + 1;
+        state.set(key, next);
+        return next;
+      },
+      async expire(key, sec) {
+        expireCalls.push([key, sec]);
+        return 1;
+      },
+      async ttl(key) {
+        // Stub — return a positive value so retry-after has something to report.
+        return state.has(key) ? 42 : -2;
+      },
+    };
+  }
+
+  it("allows the first request in a new window", async () => {
+    const client = fakeClient();
+    const limiter = new UpstashRateLimiter(client, { limit: 10, windowSec: 60 });
+    const result = await limiter.check("cli_abc12345");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows requests up to (and including) the limit", async () => {
+    const client = fakeClient();
+    const limiter = new UpstashRateLimiter(client, { limit: 5, windowSec: 60 });
+    for (let i = 0; i < 5; i++) {
+      const r = await limiter.check("cli_abc");
+      expect(r.allowed).toBe(true);
+    }
+  });
+
+  it("denies the (limit+1)th request and returns retryAfterSec", async () => {
+    const client = fakeClient();
+    const limiter = new UpstashRateLimiter(client, { limit: 3, windowSec: 60 });
+    for (let i = 0; i < 3; i++) await limiter.check("cli_abc");
+    const result = await limiter.check("cli_abc");
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("sets the window TTL on the first hit (so the counter auto-expires)", async () => {
+    const client = fakeClient();
+    const limiter = new UpstashRateLimiter(client, { limit: 10, windowSec: 60 });
+    await limiter.check("cli_abc");
+    // First hit must EXPIRE the key with the window — otherwise the counter
+    // accumulates forever and we permanently ban the client.
+    expect(client.expireCalls).toHaveLength(1);
+    expect(client.expireCalls[0][0]).toBe("ratelimit:cli_abc");
+    expect(client.expireCalls[0][1]).toBe(60);
+  });
+
+  it("does NOT re-set TTL on subsequent hits (avoid resetting the window)", async () => {
+    // If EXPIRE fires on every hit, the window slides forward forever and
+    // a steady-rate attacker is never throttled. EXPIRE only on first hit.
+    const client = fakeClient();
+    const limiter = new UpstashRateLimiter(client, { limit: 10, windowSec: 60 });
+    await limiter.check("cli_abc"); // 1st hit
+    await limiter.check("cli_abc"); // 2nd hit
+    await limiter.check("cli_abc"); // 3rd hit
+    expect(client.expireCalls).toHaveLength(1);
+  });
+
+  it("uses separate buckets for separate client ids", async () => {
+    const client = fakeClient();
+    const limiter = new UpstashRateLimiter(client, { limit: 2, windowSec: 60 });
+    await limiter.check("cli_aaa");
+    await limiter.check("cli_aaa");
+    // cli_aaa is now at the limit. cli_bbb should still be allowed.
+    const result = await limiter.check("cli_bbb");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("fails open if Upstash throws (don't block legitimate traffic on infra failure)", async () => {
+    // Critical safety: a rate limiter that fails CLOSED on storage errors
+    // takes the whole proxy down when Upstash hiccups. Fail OPEN — log the
+    // error, allow the request, accept the operational risk.
+    const broken: UpstashRateLimitClient = {
+      async incr() { throw new Error("upstash down"); },
+      async expire() { return 0; },
+      async ttl() { return -2; },
+    };
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const limiter = new UpstashRateLimiter(broken, { limit: 1, windowSec: 60 });
+      const result = await limiter.check("cli_abc");
+      expect(result.allowed).toBe(true);
+      // We must log so an operator can see Upstash is misbehaving.
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/tests/core/proxy/resolve-rate-limiter.test.ts
+++ b/tests/core/proxy/resolve-rate-limiter.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveProxyRateLimiter,
+  describeRateLimiterMode,
+} from "@/core/proxy/resolve-rate-limiter";
+
+const UPSTASH_ENV = {
+  UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+  UPSTASH_REDIS_REST_TOKEN: "tok",
+};
+
+describe("resolveProxyRateLimiter", () => {
+  it("returns undefined when no Upstash credentials are present (opt-out)", async () => {
+    // Self-host / dev / preview without Upstash configured should not have
+    // rate limiting at all — the resolver returns undefined and the proxy
+    // skips the check entirely (matches the `rateLimit?` opt-in shape).
+    const result = await resolveProxyRateLimiter({});
+    expect(result).toBeUndefined();
+  });
+
+  it("returns a RateLimit when Upstash creds + salt are present", async () => {
+    const result = await resolveProxyRateLimiter({
+      ...UPSTASH_ENV,
+      RATE_LIMIT_HASH_SALT: "explicit-salt-v1",
+    });
+    expect(result).toBeDefined();
+    expect(typeof result?.clientIdFor).toBe("function");
+    expect(typeof result?.limiter.check).toBe("function");
+  });
+
+  it("falls back to LICENSE_SIGNING_KEY when RATE_LIMIT_HASH_SALT is unset", async () => {
+    // The salt is load-bearing for anonymity (without it the hash is
+    // rainbow-attackable on IP+UA pairs). LICENSE_SIGNING_KEY is required
+    // in production anyway and has high entropy; it's a safe fallback.
+    const result = await resolveProxyRateLimiter({
+      ...UPSTASH_ENV,
+      LICENSE_SIGNING_KEY: "this-is-a-license-signing-key-32b",
+    });
+    expect(result).toBeDefined();
+  });
+
+  it("returns undefined when neither RATE_LIMIT_HASH_SALT nor LICENSE_SIGNING_KEY is set", async () => {
+    // Fail-CLOSED on salt: a limiter without a salt persists raw-IP-style
+    // hashes that can be reverse-attacked. Better to not rate-limit than
+    // to do it in a way that compromises anonymity.
+    const result = await resolveProxyRateLimiter({ ...UPSTASH_ENV });
+    expect(result).toBeUndefined();
+  });
+
+  it("produces a clientIdFor that returns the cli_<hex> shape", async () => {
+    const result = await resolveProxyRateLimiter({
+      ...UPSTASH_ENV,
+      RATE_LIMIT_HASH_SALT: "salt",
+    });
+    expect(result).toBeDefined();
+    const req = new Request("http://localhost/api/feed", {
+      method: "POST",
+      headers: { "x-forwarded-for": "203.0.113.1" },
+    });
+    const id = await result!.clientIdFor(req);
+    expect(id).toMatch(/^cli_[0-9a-f]+$/);
+  });
+});
+
+describe("describeRateLimiterMode (module-load logging label)", () => {
+  it("returns 'off' when no Upstash creds are present", () => {
+    expect(describeRateLimiterMode({})).toBe("off");
+  });
+
+  it("returns 'off' when Upstash creds but no salt", () => {
+    expect(describeRateLimiterMode({ ...UPSTASH_ENV })).toBe("off");
+  });
+
+  it("returns 'upstash' when Upstash creds AND salt are present", () => {
+    expect(
+      describeRateLimiterMode({
+        ...UPSTASH_ENV,
+        RATE_LIMIT_HASH_SALT: "salt",
+      }),
+    ).toBe("upstash");
+  });
+
+  it("returns 'upstash' when Upstash creds + LICENSE_SIGNING_KEY (fallback salt)", () => {
+    expect(
+      describeRateLimiterMode({
+        ...UPSTASH_ENV,
+        LICENSE_SIGNING_KEY: "key",
+      }),
+    ).toBe("upstash");
+  });
+});

--- a/tests/smoke/rate-limiter.test.ts
+++ b/tests/smoke/rate-limiter.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Smoke test: verifies the production proxy rate limiter is wired and
+ * enforces its threshold against the live deployed system.
+ *
+ * Catches the class of bug where unit tests pass (the limiter logic is
+ * correct in isolation) but the deployed env has the wrong adapter, a
+ * missing salt env var, or skipped wiring in api/feed.ts → silent
+ * disablement. Mocked tests can't see any of that.
+ *
+ * Skipped by default — runs only when `SMOKE_TESTS=1` is set:
+ *
+ *   SMOKE_TESTS=1 npx vitest run tests/smoke/
+ *
+ * Suitable for post-deploy verification (manually or via CI). Not part
+ * of `npm test` because it hits real infrastructure and consumes a real
+ * rate-limit bucket.
+ *
+ * Side effect: this test will exhaust the rate-limit bucket for the IP
+ * it runs from. Do not run from a shared IP during active hours; wait
+ * for the 60s window to elapse before re-running.
+ */
+
+const SKIP = !process.env.SMOKE_TESTS;
+
+const BASE_URL = process.env.SMOKE_BASE_URL ?? "https://my.feedzero.app";
+const PROXY_URL = `${BASE_URL}/api/feed`;
+// Use a known-good feed URL the proxy will accept. We don't care about
+// the response payload — just the status code (200 vs 429).
+const TARGET_FEED = "https://feedzero.app/releases.xml";
+// Slightly over the production default of 300 req/min, so we expect a
+// transition from 200s to 429s somewhere in the middle.
+const BURST_COUNT = 320;
+const RETRY_AFTER_FLOOR_SEC = 1;
+const RETRY_AFTER_CEIL_SEC = 60;
+
+async function callProxy(): Promise<{ status: number; retryAfter: string | null }> {
+  const res = await fetch(PROXY_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url: TARGET_FEED }),
+  });
+  // Drain body so the connection can be reused.
+  await res.arrayBuffer();
+  return { status: res.status, retryAfter: res.headers.get("Retry-After") };
+}
+
+describe.skipIf(SKIP)("production proxy rate limiter (live)", () => {
+  it(`hammering ${PROXY_URL} produces 429s with Retry-After`, async () => {
+    // Sequential, not parallel — parallel would saturate the lambda's
+    // concurrent-fetch budget and produce noise unrelated to the limiter.
+    const statuses: number[] = [];
+    let firstRetryAfter: string | null = null;
+
+    for (let i = 0; i < BURST_COUNT; i++) {
+      const { status, retryAfter } = await callProxy();
+      statuses.push(status);
+      if (status === 429 && firstRetryAfter === null) {
+        firstRetryAfter = retryAfter;
+      }
+    }
+
+    const ok = statuses.filter((s) => s === 200).length;
+    const limited = statuses.filter((s) => s === 429).length;
+
+    // We MUST see some 200s (the proxy was reachable) AND some 429s
+    // (the limiter actually engaged). Either side being zero is a
+    // failure.
+    expect(ok).toBeGreaterThan(0);
+    expect(limited).toBeGreaterThan(0);
+
+    // RFC 6585: 429 SHOULD include Retry-After. Production must comply.
+    expect(firstRetryAfter).toBeTruthy();
+    if (firstRetryAfter) {
+      const retryAfterSec = Number.parseInt(firstRetryAfter, 10);
+      expect(retryAfterSec).toBeGreaterThanOrEqual(RETRY_AFTER_FLOOR_SEC);
+      expect(retryAfterSec).toBeLessThanOrEqual(RETRY_AFTER_CEIL_SEC);
+    }
+  }, 120_000); // generous: 320 sequential requests at ~200ms each = ~64s
+
+  it("the proxy serves 200s for normal traffic (sanity check)", async () => {
+    // Defensive: if the previous test ran in the same window, the bucket
+    // is exhausted and this would 429 spuriously. We wait until the
+    // window resets before asserting "normal traffic is allowed".
+    await new Promise((r) => setTimeout(r, 65_000));
+    const { status } = await callProxy();
+    expect(status).toBe(200);
+  }, 90_000);
+});


### PR DESCRIPTION
## Summary

Two changes ship together:

1. **Per-client rate limiter on `/api/feed` and `/api/page`** (the two external-fetch proxies). Upstash-backed sliding-window counter keyed by hash(IP + User-Agent + salt). 300 req/min default. 429 with `Retry-After` on deny. Fail-open on Upstash errors, fail-closed on missing salt (anonymity floor).

2. **CLAUDE.md update: SMOKE is now step 7 of the RGR workflow.** Any change that affects production behavior must ship with a smoke test under `tests/smoke/` that exercises the live deployed system. The new `tests/smoke/rate-limiter.test.ts` is the first canonical example.

## Why both in one PR

The architectural reflection on the recent sync + stats bugs identified that the test suite can prove the *code* is correct but cannot prove the *system* is correct (config drift, wrong adapter resolved, serverless state model violations). Adding smoke tests to the RGR cycle is the structural fix. Shipping the pattern alongside its first canonical example (the rate limiter) gives future PRs something concrete to copy.

## Anonymity floor

- Raw IPs and User-Agents never persisted. Only `cli_<8-hex>` hashes, auto-expiring after the 60s window.
- Hash includes a project-scoped salt (`RATE_LIMIT_HASH_SALT` or `LICENSE_SIGNING_KEY` fallback). Fail-closed on missing salt — a limiter without a salt persists rainbow-attackable hashes.
- 429 body carries only `{ok: false, error: "rate limit exceeded"}` and `Retry-After`. No client identifier echoed back.

## Test plan

- [x] 1924 unit/integration tests pass (30 new: 16 for limiter+hash, 9 for resolver, 5 for proxy-handler 429 path)
- [x] `npx tsc --noEmit` clean
- [x] Smoke test added under `tests/smoke/rate-limiter.test.ts` (skipped by default; runs with `SMOKE_TESTS=1`)
- [ ] **Post-merge:** run `SMOKE_TESTS=1 npx vitest run tests/smoke/rate-limiter.test.ts` and confirm 429s appear after ~300 requests, with `Retry-After` in [1, 60]s, and that traffic resumes after the window resets.

## What this PR does NOT include

- **Backfilling smoke tests for sync, catalog, stats.** The SMOKE step in CLAUDE.md now requires them for any future change to those endpoints; backfilling is a separate ergonomics PR.
- **Moving memory adapters to `src/test-utils/`.** The deeper architectural fix (test doubles should not be reachable as production defaults) is a follow-up.

## Rollback

Remove `RATE_LIMIT_HASH_SALT` and `LICENSE_SIGNING_KEY` from Vercel env (or just the salt). The resolver fails open to `undefined`, the proxy handler skips the check. No code revert needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)