### PR TITLE
chore(release): bump version to 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feedzero",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feedzero",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedzero",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Privacy-first RSS reader",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Captures the architectural arc from PRs #43-#51:
- Upstash consolidation as the single production data layer (PR #45, #47)
- Observability: traceId + structured 5xx logger (PR #43)
- Proxy rate limiter (PR #48)
- Mobile dialog keyboard + bottom-sheet chrome fixes (PR #44, #46)
- Smoke-tests-in-RGR workflow change (PR #48 / CLAUDE.md)
- Smoke test backfill + the `[object Object]` sync GET fix it caught (PR #49)
- Comprehensive docs: 4 new ADRs + 2 incident postmortems (PR #50)

## User-facing release notes

Live in [forcingfx/feedzero-landing#2](https://github.com/forcingfx/feedzero-landing/pull/2). Once that lands, the deployed Atom feed at https://feedzero.app/releases.xml will surface the entry and the app's "What's new" feature auto-picks it up on next refresh.

## After merge

I'll tag `v0.8.1` on the merged commit and push the tag so the milestone is recognizable in git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)