### PR TITLE
fix(ui): anchor dialog vertical center to dvh (keyboard pushes buttons off-screen on iOS)

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -59,8 +59,17 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          // Layout + animation (unchanged from shadcn baseline).
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          // Layout + animation. Vertical anchor uses `top-[50dvh]`, NOT the
+          // shadcn baseline's `top-[50%]`. `dvh` is the dynamic viewport
+          // height — it shrinks when iOS Safari's soft keyboard rises, so
+          // the dialog's center stays in the *visible* area. With the
+          // baseline `top-[50%]` the dialog was anchored to the layout
+          // viewport (which doesn't shrink on iOS), and although PR #44
+          // sized the dialog correctly via max-h:100dvh, the bottom buttons
+          // (Back / Enable sync etc.) still slid behind the keyboard.
+          // `translate-y-[-50%]` shifts the dialog up by half its own
+          // height so its center sits on the 50dvh anchor.
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50dvh] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           // Mobile keyboard handling. `100dvh` is the dynamic viewport
           // height — it shrinks when the iOS Safari soft keyboard opens
           // (iOS 15.4+, Chrome 108+, Firefox 101+). Combined with the

--- a/tests/components/ui/dialog-mobile-keyboard.test.tsx
+++ b/tests/components/ui/dialog-mobile-keyboard.test.tsx
@@ -56,4 +56,25 @@ describe("DialogContent — mobile keyboard cover prevention", () => {
     const className = content?.getAttribute("class") ?? "";
     expect(className).toContain("overflow-y-auto");
   });
+
+  it("anchors top to 50dvh (dynamic viewport), NOT 50% of the layout viewport", () => {
+    // Follow-up to PR #44 (2026-05-14 user report): the original fix made
+    // the dialog SIZE keyboard-aware via max-h: 100dvh, but POSITION stayed
+    // at top: 50% of the layout viewport. On iOS Safari the layout viewport
+    // extends behind the keyboard, so the dialog's center sat mid-layout-
+    // viewport (visually too low when keyboard is up). Result: input was
+    // visible but the buttons below it (Back / Enable sync) were hidden
+    // behind the keyboard.
+    //
+    // Fix: top-[50dvh] tracks the dynamic viewport — when keyboard opens
+    // and dvh shrinks, the dialog's center moves up to stay in the visible
+    // area. Combined with translate-y: -50%, the dialog ends up centered
+    // in the visible area above the keyboard.
+    const { baseElement } = mountOpenDialog();
+    const content = baseElement.querySelector('[role="dialog"]');
+    const className = content?.getAttribute("class") ?? "";
+    expect(className).toMatch(/top-\[50dvh\]/);
+    // The bug was specifically `top-[50%]` — assert it's gone.
+    expect(className).not.toMatch(/top-\[50%\]/);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #44. The user reported (with screenshot) that the sync passphrase-confirm dialog still hid its 'Back' and 'Enable sync' buttons behind iOS Safari's soft keyboard. PR #44 fixed dialog SIZING (the input became visible) but POSITIONING stayed at `top: 50%` of the layout viewport — which on iOS extends behind the keyboard. The dialog's bottom 40% sat in the hidden region.

## Fix

`top-[50%]` → `top-[50dvh]` on `DialogContent`. `dvh` tracks the dynamic viewport, so when the keyboard rises and dvh shrinks, the dialog's center moves up and stays in the visible area.

## Test plan

- [x] 1926 unit/integration tests pass (1 new structural assertion pins both `top-[50dvh]` presence AND absence of `top-[50%]`)
- [x] `npx tsc --noEmit` clean
- [ ] **Real-device verification (the acceptance gate):** reopen the sync passphrase dialog on iOS Safari with the keyboard up. The 'Back' and 'Enable sync' buttons should be tappable without scrolling the page.

## Notes

- Same browser support as the rest of the dvh-based mobile fix: iOS Safari 15.4+, Chrome 108+, Firefox 101+.
- On desktop `dvh === vh`, so no change in behavior.
- This fix lands in every dialog in the app (sync, onboarding, settings, etc.) via the shared primitive — no per-dialog edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)