### PR TITLE
feat(migration): --skip-existing + sentinel-vault cleanup

### DIFF
--- a/scripts/cleanup-sentinel-vaults.ts
+++ b/scripts/cleanup-sentinel-vaults.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+/**
+ * CLI wrapper for the test-sentinel vault cleanup.
+ *
+ * Usage:
+ *
+ *   # Dry-run (default — list sentinel keys, delete nothing)
+ *   npx tsx scripts/cleanup-sentinel-vaults.ts
+ *
+ *   # Execute (delete sentinel keys from Upstash)
+ *   npx tsx scripts/cleanup-sentinel-vaults.ts --execute
+ *
+ * Required env vars (one pair):
+ *
+ *   UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN
+ *     OR KV_REST_API_URL + KV_REST_API_TOKEN  (Vercel-Marketplace aliases)
+ *
+ * A sentinel is any `vault:<64-hex>` where all 64 chars are the same
+ * (e.g. `vault:aaaa…`). Real PBKDF2-derived vaultIds are uniformly
+ * random hex — same-char chance is 16^-63 ≈ 0 — so any match is a
+ * test artifact, safe to delete.
+ *
+ * The cleanup module + tests are at
+ * src/core/sync/migration/sentinel-cleanup.ts and
+ * tests/core/sync/migration/sentinel-cleanup.test.ts.
+ */
+
+import {
+  cleanupSentinelVaults,
+  type SentinelScanClient,
+} from "../src/core/sync/migration/sentinel-cleanup.ts";
+
+function parseArgs(): { execute: boolean } {
+  return { execute: process.argv.slice(2).includes("--execute") };
+}
+
+function resolveUpstashCreds(): { url: string; token: string } {
+  const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.KV_REST_API_URL;
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.KV_REST_API_TOKEN;
+  if (!url || !token) {
+    throw new Error(
+      "Upstash credentials missing. Set UPSTASH_REDIS_REST_URL + " +
+        "UPSTASH_REDIS_REST_TOKEN (or KV_REST_API_URL + KV_REST_API_TOKEN).",
+    );
+  }
+  return { url, token };
+}
+
+async function main(): Promise<void> {
+  const { execute } = parseArgs();
+  const creds = resolveUpstashCreds();
+
+  const { Redis } = await import("@upstash/redis");
+  const upstash = new Redis({
+    url: creds.url,
+    token: creds.token,
+    // Matches the live UpstashSyncAdapter posture (ADR 008).
+    automaticDeserialization: false,
+  });
+
+  const client: SentinelScanClient = {
+    scan: (cursor, opts) => upstash.scan(cursor, opts),
+    del: (key) => upstash.del(key),
+  };
+
+  console.log(
+    execute
+      ? "[cleanup] EXECUTE — deletes any vault:<64-same-char> keys from Upstash."
+      : "[cleanup] DRY-RUN — lists sentinel keys, deletes nothing. Pass --execute to apply.",
+  );
+
+  const start = Date.now();
+  const result = await cleanupSentinelVaults(client, {
+    execute,
+    onProgress: (event) => {
+      console.log(
+        `[cleanup] ${event.action.toUpperCase().padEnd(8)} ${event.key.slice(0, 20)}…`,
+      );
+    },
+  });
+  const elapsedMs = Date.now() - start;
+
+  console.log("");
+  console.log("[cleanup] === Summary ===");
+  console.log(`[cleanup]   foundSentinels: ${result.foundSentinels.length}`);
+  console.log(`[cleanup]   deleted:        ${result.deleted}`);
+  console.log(`[cleanup]   elapsed:        ${elapsedMs}ms`);
+  if (!execute && result.foundSentinels.length > 0) {
+    console.log("");
+    console.log(
+      `[cleanup] Found ${result.foundSentinels.length} sentinel(s). Re-run with --execute to delete.`,
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error("[cleanup] FATAL:", e instanceof Error ? e.message : String(e));
+  process.exit(2);
+});

--- a/scripts/migrate-blob-to-upstash.ts
+++ b/scripts/migrate-blob-to-upstash.ts
@@ -39,11 +39,16 @@ import {
   type UpstashSetClient,
 } from "../src/core/sync/migration/blob-to-upstash.ts";
 
-function parseArgs(): { execute: boolean; deleteBlob: boolean } {
+function parseArgs(): {
+  execute: boolean;
+  deleteBlob: boolean;
+  skipExisting: boolean;
+} {
   const args = process.argv.slice(2);
   return {
     execute: args.includes("--execute"),
     deleteBlob: args.includes("--delete-blob"),
+    skipExisting: args.includes("--skip-existing"),
   };
 }
 
@@ -61,7 +66,7 @@ function resolveUpstashCreds(): { url: string; token: string } {
 }
 
 async function main(): Promise<void> {
-  const { execute, deleteBlob } = parseArgs();
+  const { execute, deleteBlob, skipExisting } = parseArgs();
 
   if (!process.env.BLOB_READ_WRITE_TOKEN) {
     throw new Error(
@@ -117,24 +122,30 @@ async function main(): Promise<void> {
     async set(key, value) {
       return upstash.set(key, value);
     },
+    async get(key) {
+      const value = await upstash.get<string>(key);
+      return value ?? null;
+    },
   };
 
   // Top-of-run banner so the operator knows what mode is active. Dry-run
   // mode is the cheap-to-trust default; execute is loud.
+  const skipNote = skipExisting ? " (--skip-existing: leaves fresh Upstash data intact)" : "";
   if (!execute) {
-    console.log("[migrate] DRY-RUN — no writes. Pass --execute to actually migrate.");
+    console.log(`[migrate] DRY-RUN — no writes. Pass --execute to actually migrate.${skipNote}`);
   } else if (deleteBlob) {
-    console.log("[migrate] EXECUTE + DELETE-BLOB — writes to Upstash, deletes Blob originals after each success.");
+    console.log(`[migrate] EXECUTE + DELETE-BLOB — writes to Upstash, deletes Blob originals after each success.${skipNote}`);
   } else {
-    console.log("[migrate] EXECUTE — writes to Upstash, leaves Blob originals in place.");
+    console.log(`[migrate] EXECUTE — writes to Upstash, leaves Blob originals in place.${skipNote}`);
   }
 
   const start = Date.now();
   const result = await migrateBlobVaultsToUpstash(blobClient, upstashClient, {
     execute,
     deleteBlob,
+    skipExisting,
     onProgress: (event) => {
-      const label = event.action.toUpperCase().padEnd(10);
+      const label = event.action.toUpperCase().padEnd(18);
       const msg = event.error ? ` — ${event.error}` : "";
       console.log(`[migrate] ${label} vault:${event.vaultId.slice(0, 12)}…${msg}`);
     },
@@ -143,11 +154,12 @@ async function main(): Promise<void> {
 
   console.log("");
   console.log("[migrate] === Summary ===");
-  console.log(`[migrate]   found:    ${result.found}`);
-  console.log(`[migrate]   skipped:  ${result.skipped} (non-vault files under vaults/)`);
-  console.log(`[migrate]   migrated: ${result.migrated}`);
-  console.log(`[migrate]   deleted:  ${result.deleted}`);
-  console.log(`[migrate]   failed:   ${result.failed.length}`);
+  console.log(`[migrate]   found:           ${result.found}`);
+  console.log(`[migrate]   skipped:         ${result.skipped} (non-vault files under vaults/)`);
+  console.log(`[migrate]   skippedExisting: ${result.skippedExisting} (already in Upstash; --skip-existing)`);
+  console.log(`[migrate]   migrated:        ${result.migrated}`);
+  console.log(`[migrate]   deleted:         ${result.deleted}`);
+  console.log(`[migrate]   failed:          ${result.failed.length}`);
   if (result.failed.length > 0) {
     for (const failure of result.failed) {
       console.log(`[migrate]     - vault:${failure.vaultId.slice(0, 12)}… — ${failure.error}`);

--- a/src/core/sync/migration/blob-to-upstash.ts
+++ b/src/core/sync/migration/blob-to-upstash.ts
@@ -71,6 +71,14 @@ export interface BlobListClient {
  */
 export interface UpstashSetClient {
   set(key: string, value: unknown): Promise<unknown>;
+  /**
+   * Required only when `skipExisting: true`. Returns the current value
+   * at the key, or `null` if absent. The migration uses this to detect
+   * post-#45 re-pushes that shouldn't be overwritten by the older Blob
+   * copy. Optional on the type so callers that never use skipExisting
+   * can pass a `set`-only client; runtime guards check before calling.
+   */
+  get?(key: string): Promise<string | null>;
 }
 
 export interface MigrateOptions {
@@ -79,10 +87,18 @@ export interface MigrateOptions {
   /** When true AND execute, deletes the Blob original after a successful
    *  Upstash write. Has no effect in dry-run. */
   deleteBlob?: boolean;
+  /**
+   * When true AND execute, skip any vault whose key already exists in
+   * Upstash. Default false (overwrite behavior matches the initial
+   * migration run). Use this on subsequent runs to avoid clobbering
+   * post-#45 client re-pushes with the older Blob copy. Requires the
+   * upstash client to expose `get`.
+   */
+  skipExisting?: boolean;
   /** Optional callback for per-vault progress logging. */
   onProgress?: (event: {
     vaultId: string;
-    action: "migrated" | "deleted" | "skipped" | "failed";
+    action: "migrated" | "deleted" | "skipped" | "skippedExisting" | "failed";
     error?: string;
   }) => void;
 }
@@ -94,6 +110,8 @@ export interface MigrateResult {
   skipped: number;
   /** Successfully written to Upstash. Always 0 in dry-run. */
   migrated: number;
+  /** Vaults skipped because they already exist in Upstash (skipExisting). */
+  skippedExisting: number;
   /** Successfully deleted from Blob after Upstash write. Requires
    *  execute=true AND deleteBlob=true. */
   deleted: number;
@@ -109,12 +127,14 @@ export async function migrateBlobVaultsToUpstash(
 ): Promise<MigrateResult> {
   const execute = options.execute ?? false;
   const deleteBlob = (options.deleteBlob ?? false) && execute;
+  const skipExisting = (options.skipExisting ?? false) && execute;
   const onProgress = options.onProgress ?? (() => {});
 
   const result: MigrateResult = {
     found: 0,
     skipped: 0,
     migrated: 0,
+    skippedExisting: 0,
     deleted: 0,
     failed: [],
   };
@@ -138,6 +158,17 @@ export async function migrateBlobVaultsToUpstash(
       if (!execute) {
         // Dry-run: we'd migrate this, but write nothing.
         continue;
+      }
+
+      // Skip-if-present check. Runs before the Blob read so we don't
+      // waste an HTTP round-trip on data we're not going to write.
+      if (skipExisting && upstash.get) {
+        const existing = await upstash.get(VAULT_KEY_PREFIX + vaultId);
+        if (existing !== null) {
+          result.skippedExisting += 1;
+          onProgress({ vaultId, action: "skippedExisting" });
+          continue;
+        }
       }
 
       // Read → write → (optional) delete. Any step's failure is

--- a/src/core/sync/migration/sentinel-cleanup.ts
+++ b/src/core/sync/migration/sentinel-cleanup.ts
@@ -1,0 +1,100 @@
+/**
+ * Delete test-sentinel vault entries from Upstash.
+ *
+ * A sentinel is a 64-hex-char vaultId where all 64 characters are the
+ * same (e.g. "aaaa…", "0000…"). A real PBKDF2-derived vaultId is
+ * uniformly random hex — the probability of all-same-char is 16^-63,
+ * effectively zero. So any vault key matching this pattern is a test
+ * artifact, safe to delete.
+ *
+ * Dry-run by default; execute is opt-in. Mirrors the safety posture of
+ * the Blob → Upstash migration.
+ *
+ * Tested in tests/core/sync/migration/sentinel-cleanup.test.ts with
+ * injected fake clients. CLI wrapper in
+ * scripts/cleanup-sentinel-vaults.ts.
+ */
+
+const VAULT_KEY_PREFIX = "vault:";
+
+/**
+ * True iff the input is a 64-hex-char string of all-the-same character.
+ * No real PBKDF2-derived vaultId satisfies this; only synthetic test
+ * IDs do.
+ */
+export function isSentinelVaultId(vaultId: string): boolean {
+  if (vaultId.length !== 64) return false;
+  // First char must be lower-case hex (matches the rest of the project's
+  // vaultId convention). Then assert every char is identical.
+  if (!/^[0-9a-f]$/.test(vaultId[0]!)) return false;
+  const first = vaultId[0];
+  for (let i = 1; i < 64; i++) {
+    if (vaultId[i] !== first) return false;
+  }
+  return true;
+}
+
+/**
+ * Minimal subset of the Upstash Redis client this cleanup needs. SCAN
+ * for enumeration, DEL for removal. Defined inline so tests inject a
+ * fake without the real `@upstash/redis` SDK.
+ */
+export interface SentinelScanClient {
+  scan(
+    cursor: number | string,
+    opts?: { match?: string; count?: number },
+  ): Promise<[number | string, string[]]>;
+  del(key: string): Promise<number>;
+}
+
+export interface SentinelCleanupOptions {
+  /** When false (default), no deletes fire — just counts. */
+  execute?: boolean;
+  onProgress?: (event: { key: string; action: "found" | "deleted" }) => void;
+}
+
+export interface SentinelCleanupResult {
+  /** Vault keys whose vaultId matches the sentinel pattern. */
+  foundSentinels: string[];
+  /** Successfully deleted. Always 0 in dry-run. */
+  deleted: number;
+}
+
+export async function cleanupSentinelVaults(
+  client: SentinelScanClient,
+  options: SentinelCleanupOptions = {},
+): Promise<SentinelCleanupResult> {
+  const execute = options.execute ?? false;
+  const onProgress = options.onProgress ?? (() => {});
+
+  const result: SentinelCleanupResult = { foundSentinels: [], deleted: 0 };
+
+  // Iterate all vault:* keys via SCAN cursor (pagination — see UpstashSyncAdapter).
+  let cursor: number | string = 0;
+  do {
+    const [next, keys] = await client.scan(cursor, {
+      match: `${VAULT_KEY_PREFIX}*`,
+      count: 100,
+    });
+    for (const key of keys) {
+      // Extract the vaultId suffix and check the sentinel pattern.
+      if (!key.startsWith(VAULT_KEY_PREFIX)) continue;
+      const vaultId = key.slice(VAULT_KEY_PREFIX.length);
+      if (!isSentinelVaultId(vaultId)) continue;
+
+      result.foundSentinels.push(key);
+      onProgress({ key, action: "found" });
+
+      if (execute) {
+        const removed = await client.del(key);
+        if (removed > 0) {
+          result.deleted += 1;
+          onProgress({ key, action: "deleted" });
+        }
+      }
+    }
+    cursor = next;
+  } while (cursor !== 0 && cursor !== "0");
+
+  return result;
+}

--- a/tests/core/sync/migration/blob-to-upstash.test.ts
+++ b/tests/core/sync/migration/blob-to-upstash.test.ts
@@ -272,6 +272,98 @@ describe("migrateBlobVaultsToUpstash", () => {
     });
   });
 
+  describe("skip-if-present (idempotent, post-hoc safety)", () => {
+    // After the first migration run we discovered that ~4 vaults existed
+    // in BOTH Blob and Upstash (users who had pre-#45 vaults AND re-pushed
+    // to Upstash after #45). The naive script overwrote the Upstash entry
+    // with the older Blob copy — a small data-staleness window until the
+    // client re-pushed. This option closes that window: skip if the
+    // Upstash key already exists.
+
+    function fakeUpstashWithGet(
+      existing: Record<string, string> = {},
+    ): UpstashSetClient & {
+      store: Map<string, string>;
+      get(key: string): Promise<string | null>;
+    } {
+      const store = new Map(Object.entries(existing));
+      return {
+        store,
+        async get(key: string) {
+          return store.has(key) ? (store.get(key) as string) : null;
+        },
+        async set(key, value) {
+          store.set(key, String(value));
+          return "OK";
+        },
+      };
+    }
+
+    it("skips vaults already present in Upstash when skipExisting:true", async () => {
+      const blob = fakeBlobClient(
+        [
+          { pathname: `vaults/${VAULT_ID_A}.json`, url: "https://blob/a", size: 100 },
+          { pathname: `vaults/${VAULT_ID_B}.json`, url: "https://blob/b", size: 100 },
+        ],
+        { "https://blob/a": SAMPLE_PAYLOAD_A, "https://blob/b": SAMPLE_PAYLOAD_B },
+      );
+      const upstash = fakeUpstashWithGet({
+        [`vault:${VAULT_ID_A}`]: "FRESH_FROM_UPSTASH_DO_NOT_OVERWRITE",
+      });
+
+      const result = await migrateBlobVaultsToUpstash(blob, upstash, {
+        execute: true,
+        skipExisting: true,
+      });
+
+      expect(result.found).toBe(2);
+      expect(result.migrated).toBe(1); // only VAULT_ID_B
+      expect(result.skippedExisting).toBe(1); // VAULT_ID_A
+      // The fresh Upstash value must be intact.
+      expect(upstash.store.get(`vault:${VAULT_ID_A}`)).toBe(
+        "FRESH_FROM_UPSTASH_DO_NOT_OVERWRITE",
+      );
+      expect(upstash.store.get(`vault:${VAULT_ID_B}`)).toBe(SAMPLE_PAYLOAD_B);
+    });
+
+    it("default (skipExisting:false) preserves the prior overwrite behavior", async () => {
+      // Old behavior: overwrite. Kept as default for backward compat with
+      // the (already-run) initial migration; new runs should opt in.
+      const blob = fakeBlobClient(
+        [{ pathname: `vaults/${VAULT_ID_A}.json`, url: "https://blob/a", size: 100 }],
+        { "https://blob/a": SAMPLE_PAYLOAD_A },
+      );
+      const upstash = fakeUpstashWithGet({
+        [`vault:${VAULT_ID_A}`]: "fresh",
+      });
+      await migrateBlobVaultsToUpstash(blob, upstash, { execute: true });
+      // Overwrote with Blob copy.
+      expect(upstash.store.get(`vault:${VAULT_ID_A}`)).toBe(SAMPLE_PAYLOAD_A);
+    });
+
+    it("skipExisting also prevents deleting the Blob original (we'd be deleting a backup)", async () => {
+      // If we skip the Upstash write because Upstash already has a fresher
+      // copy, the Blob copy is the OLDER one — and we shouldn't delete it
+      // (it's not authoritative, but it's still a backup). Delete only
+      // fires after a successful WRITE this run.
+      const blob = fakeBlobClient(
+        [{ pathname: `vaults/${VAULT_ID_A}.json`, url: "https://blob/a", size: 100 }],
+        { "https://blob/a": SAMPLE_PAYLOAD_A },
+      );
+      const upstash = fakeUpstashWithGet({
+        [`vault:${VAULT_ID_A}`]: "fresh",
+      });
+      const result = await migrateBlobVaultsToUpstash(blob, upstash, {
+        execute: true,
+        skipExisting: true,
+        deleteBlob: true,
+      });
+      expect(result.skippedExisting).toBe(1);
+      expect(result.deleted).toBe(0);
+      expect(blob.deleted).toEqual([]);
+    });
+  });
+
   describe("pagination", () => {
     it("iterates Blob's paginated list until hasMore is false", async () => {
       // Production Vercel Blob returns ~1000 per page. The migration must

--- a/tests/core/sync/migration/sentinel-cleanup.test.ts
+++ b/tests/core/sync/migration/sentinel-cleanup.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the test-sentinel vault cleanup.
+ *
+ * Background: during the May 13-14 sync incident + smoke-test work, a
+ * handful of synthetic-looking vaultIds (64 repetitions of the same hex
+ * char — e.g. "aaaa…" or "bbbb…") got stored in production. They're
+ * indistinguishable from real vaults to the server, but no real user
+ * would ever derive such a vaultId from a passphrase. They're test
+ * artifacts. This cleanup removes them.
+ *
+ * Same shape as the Blob→Upstash migration: dry-run-by-default,
+ * idempotent, opt-in execute. The CLI wrapper lives in
+ * scripts/cleanup-sentinel-vaults.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  isSentinelVaultId,
+  cleanupSentinelVaults,
+  type SentinelScanClient,
+} from "@/core/sync/migration/sentinel-cleanup";
+
+describe("isSentinelVaultId", () => {
+  it("matches 64 of the same hex char (lower-case)", () => {
+    expect(isSentinelVaultId("a".repeat(64))).toBe(true);
+    expect(isSentinelVaultId("0".repeat(64))).toBe(true);
+    expect(isSentinelVaultId("f".repeat(64))).toBe(true);
+  });
+
+  it("does NOT match real-looking 64-hex strings (mixed chars)", () => {
+    // A real PBKDF2-derived vaultId has high entropy — same-char chance
+    // is 16^-63 ≈ 0. Anything that's NOT all-same-char is treated as
+    // possibly-real and left alone.
+    expect(isSentinelVaultId("a".repeat(63) + "b")).toBe(false);
+    expect(isSentinelVaultId("0123456789abcdef".repeat(4))).toBe(false);
+    // Realistic example (random hex)
+    expect(isSentinelVaultId("3f2a1b4c5d6e7f8091a2b3c4d5e6f70819a2b3c4d5e6f70819a2b3c4d5e6f708")).toBe(false);
+  });
+
+  it("rejects strings that aren't 64 chars", () => {
+    expect(isSentinelVaultId("")).toBe(false);
+    expect(isSentinelVaultId("a")).toBe(false);
+    expect(isSentinelVaultId("a".repeat(63))).toBe(false);
+    expect(isSentinelVaultId("a".repeat(65))).toBe(false);
+  });
+
+  it("rejects non-hex characters even if 64-of-the-same", () => {
+    expect(isSentinelVaultId("g".repeat(64))).toBe(false);
+    expect(isSentinelVaultId("z".repeat(64))).toBe(false);
+    expect(isSentinelVaultId("A".repeat(64))).toBe(false); // uppercase not in our pattern
+  });
+});
+
+describe("cleanupSentinelVaults", () => {
+  function fakeClient(initial: string[]): SentinelScanClient & {
+    deleted: string[];
+  } {
+    const state = new Set(initial);
+    const deleted: string[] = [];
+    return {
+      deleted,
+      async scan(_cursor, opts) {
+        const match = opts?.match ?? "*";
+        const prefix = match.replace(/\*$/, "");
+        const keys = [...state].filter((k) => k.startsWith(prefix));
+        return [0, keys];
+      },
+      async del(key) {
+        if (state.has(key)) {
+          state.delete(key);
+          deleted.push(key);
+          return 1;
+        }
+        return 0;
+      },
+    };
+  }
+
+  const SENTINEL_A = `vault:${"a".repeat(64)}`;
+  const SENTINEL_B = `vault:${"b".repeat(64)}`;
+  const REAL_VAULT = `vault:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd`;
+
+  describe("dry-run (default)", () => {
+    it("reports which keys would be deleted, deletes nothing", async () => {
+      const client = fakeClient([SENTINEL_A, SENTINEL_B, REAL_VAULT]);
+      const result = await cleanupSentinelVaults(client);
+
+      expect(result.foundSentinels).toEqual(expect.arrayContaining([SENTINEL_A, SENTINEL_B]));
+      expect(result.foundSentinels.length).toBe(2);
+      expect(result.deleted).toBe(0);
+      expect(client.deleted).toEqual([]);
+    });
+
+    it("never matches real-looking vaultIds", async () => {
+      const client = fakeClient([REAL_VAULT]);
+      const result = await cleanupSentinelVaults(client);
+      expect(result.foundSentinels).toEqual([]);
+    });
+  });
+
+  describe("execute mode", () => {
+    it("deletes ONLY sentinel vaults, leaves real vaults intact", async () => {
+      const client = fakeClient([SENTINEL_A, SENTINEL_B, REAL_VAULT]);
+      const result = await cleanupSentinelVaults(client, { execute: true });
+
+      expect(result.deleted).toBe(2);
+      expect(client.deleted).toEqual(
+        expect.arrayContaining([SENTINEL_A, SENTINEL_B]),
+      );
+      expect(client.deleted).not.toContain(REAL_VAULT);
+    });
+
+    it("is idempotent — running twice deletes nothing on the second run", async () => {
+      const client = fakeClient([SENTINEL_A, REAL_VAULT]);
+      const first = await cleanupSentinelVaults(client, { execute: true });
+      const second = await cleanupSentinelVaults(client, { execute: true });
+
+      expect(first.deleted).toBe(1);
+      expect(second.deleted).toBe(0);
+      expect(client.deleted).toEqual([SENTINEL_A]);
+    });
+  });
+
+  describe("non-vault: keys", () => {
+    it("ignores keys outside the vault: prefix", async () => {
+      // Defensive: the cleanup scans `vault:*` only. Other namespaces
+      // (license:, catalog:, ratelimit:) shouldn't be touched even if
+      // somehow they happened to contain a 64-of-the-same-char tail.
+      const client = fakeClient([
+        SENTINEL_A,
+        "license:record:" + "a".repeat(64),
+        "catalog:feed:" + "a".repeat(64),
+      ]);
+      const result = await cleanupSentinelVaults(client, { execute: true });
+      expect(result.deleted).toBe(1);
+      expect(client.deleted).toEqual([SENTINEL_A]);
+    });
+  });
+});


### PR DESCRIPTION
Two follow-ups to PR #54.

## --skip-existing
Skips vaults already in Upstash so re-runs don't clobber fresh post-#45 client re-pushes with older Blob copies. Verified live: re-running the migration against the now-migrated keyspace reports 35 skippedExisting, 0 migrated, 0 failed.

## Sentinel cleanup
New `scripts/cleanup-sentinel-vaults.ts` removes `vault:<64-same-hex-char>` keys (test artifacts indistinguishable from real vaults to the server but obvious to a regex). 3 sentinels found and deleted in production (aaaa…, bbbb…, dddd…). `/api/stats-sync` now reports 48 vaults (was 51).

## Test plan

- [x] 1948 unit tests pass (+12 new: 3 skip-existing, 9 sentinel cleanup)
- [x] `npx tsc --noEmit` clean
- [x] Both scripts executed against production from local checkout; idempotency confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)