### PR TITLE
feat(test): production-grade sync stress tests at 100-feed scale (A: smoke, B: e2e pin-known-issue)

### DIFF
--- a/tests/e2e/sync-100-feeds.spec.ts
+++ b/tests/e2e/sync-100-feeds.spec.ts
@@ -1,0 +1,300 @@
+// @ts-nocheck — dynamic imports of /src/* are Vite-resolved at runtime,
+// not typecheckable by tsc. The test runs in browser via Playwright.
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Production-grade sync stress test: Device A creates a sync account
+ * with 100 feeds and pushes. Device B (separate browser context, SAME
+ * derived keys) pulls and verifies all 100 feeds arrived intact.
+ *
+ * STATUS: `test.fixme()` — this test currently fails against the local
+ * dev server. The failure exposes what looks like a real cross-device
+ * sync bug, NOT a flaky test. See the "Investigation findings" block
+ * inside the test body for details. Run with:
+ *
+ *     npx playwright test tests/e2e/sync-100-feeds.spec.ts --project=desktop
+ *
+ * The fixme() marker keeps CI green while preserving the test as the
+ * authoritative spec for what "sync at scale" must do. When the
+ * underlying issue is fixed, switch `test.fixme()` back to `test()`.
+ *
+ * Strategy (all of this works correctly):
+ *  - Derive keys ONCE up front via the project's own key-material
+ *    module in a throwaway browser context. No Node-side
+ *    reimplementation that could drift from the real derivation.
+ *  - Inject the resulting StoredKeyMaterial into BOTH device contexts'
+ *    localStorage via addInitScript, plus `onboarding-complete` and
+ *    `storage-mode=sync`. Each device boots straight into the app as
+ *    a returning sync user with the SAME vaultId — no onboarding-UI
+ *    dependency.
+ *  - Mock all `/api/feed` responses via page.route() so feed parsing
+ *    runs on synthetic data, predictably, with no real network.
+ *  - /api/sync is NOT mocked: goes to the Vite dev server's in-memory
+ *    adapter, shared across both contexts via the dev-server process.
+ *
+ * What this test does NOT cover (out of scope, separate tests):
+ *  - Real Upstash latency at scale → tests/smoke/sync-large-vault.test.ts
+ *  - Vault encryption correctness → tests/core/sync/vault-crypto.test.ts
+ *  - Onboarding UI flow → tests/e2e/sync.spec.ts (existing)
+ *  - Conflict resolution between simultaneous pushes (separate test)
+ *  - Recovery from partial push failure (separate test)
+ */
+
+// Four non-EFF-wordlist tokens. Real passphrases use the EFF wordlist;
+// this can't collide with a real user passphrase even if this test
+// somehow ran against production.
+const TEST_PASSPHRASE =
+  "stresstest__alpha stresstest__beta stresstest__gamma stresstest__delta";
+const FEED_COUNT = 100;
+
+function mockFeedXml(i: number): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Stress Test Feed ${i}</title>
+    <link>https://stress-test-${i}.example.com</link>
+    <description>Synthetic feed ${i} for the 100-feed sync stress test</description>
+    <item>
+      <title>Article from feed ${i}</title>
+      <link>https://stress-test-${i}.example.com/0</link>
+      <description>Synthetic article.</description>
+      <guid>stress-${i}-0</guid>
+    </item>
+  </channel>
+</rss>`;
+}
+
+/** Intercept every `/api/feed` POST and return the right mock based on
+ *  the URL the client passed in the body. */
+async function mockAllFeedRequests(page: Page): Promise<void> {
+  await page.route("**/api/feed*", async (route) => {
+    const request = route.request();
+    const body = request.postData();
+    let targetUrl: string | null = null;
+    if (body) {
+      try {
+        targetUrl = (JSON.parse(body) as { url?: string }).url ?? null;
+      } catch {
+        /* ignore */
+      }
+    }
+    if (!targetUrl) {
+      return route.fulfill({ status: 400, body: "Missing url" });
+    }
+    const match = /stress-test-(\d{3})/.exec(targetUrl);
+    if (!match) {
+      return route.fulfill({ status: 404, body: "Unknown stress URL" });
+    }
+    const i = Number.parseInt(match[1]!, 10);
+    return route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "application/rss+xml" },
+      body: mockFeedXml(i),
+    });
+  });
+}
+
+/** Pre-set the localStorage keys that make the app boot as a returning
+ *  sync user with our test identity. */
+async function preSetSyncIdentity(
+  page: Page,
+  storedKeys: unknown,
+): Promise<void> {
+  await page.addInitScript(
+    ({ keys }) => {
+      localStorage.setItem("feedzero:onboarding-complete", "true");
+      localStorage.setItem("feedzero:storage-mode", "sync");
+      localStorage.setItem("feedzero:derived-keys", JSON.stringify(keys));
+    },
+    { keys: storedKeys },
+  );
+}
+
+test.describe("Sync at scale — 100 feeds across two devices", () => {
+  /**
+   * KNOWN-FAILING — see investigation findings inside.
+   *
+   * To run anyway: change `test.fixme` to `test` and execute. The
+   * failure is at the "Device B sees 100 feeds" assertion.
+   */
+  test.fixme(
+    "Device A pushes 100 feeds; Device B pulls them all",
+    async ({ browser }) => {
+      test.setTimeout(180_000);
+
+      /* ==========================================================
+       * INVESTIGATION FINDINGS (2026-05-14, this session)
+       * ==========================================================
+       *
+       * What we verified works:
+       *  - Two-context derived-key injection: vaultId is identical
+       *    across both contexts (the spec for "same user, two devices").
+       *  - Device A's full flow: init → restoreSync sets credentials →
+       *    100x addFeed() succeeds → push() returns status="synced",
+       *    error=null. The dev server's in-memory adapter reports
+       *    >= 1 vault stored, and GET /api/sync?vaultId=<id> returns
+       *    ~79KB of ciphertext (consistent with 100 encrypted feeds).
+       *  - Device B's init: credentials reconstructed identically,
+       *    isDbReady flips to true, sync-store status flips to
+       *    "synced" (meaning pull() believed it succeeded).
+       *
+       * What fails:
+       *  - After Device B's status flips to "synced", BOTH the
+       *    in-memory feed-store AND IndexedDB show 0 feeds. A page
+       *    reload + explicit loadFeeds() doesn't recover them either.
+       *
+       * Hypothesis (needs investigation in src/core/sync/sync-service.ts):
+       *  pull() retrieves the vault, decryptVault() likely succeeds
+       *  (otherwise status would be "error"), but the importAll() step
+       *  that applies the decrypted VaultData to IndexedDB either:
+       *    (a) silently no-ops on the dev-server / memory-adapter path,
+       *    (b) writes to a different DB instance than the one
+       *        feed-store reads from, or
+       *    (c) throws an error that's caught and swallowed without
+       *        updating status.
+       *
+       * Reproducer:
+       *   Switch `test.fixme(...)` to `test(...)` and re-run. Watch
+       *   the diagnostic that the original investigation added — vault
+       *   ciphertext is large, but Device B's IndexedDB count via
+       *   getFeeds() is 0.
+       *
+       * Investigation next steps:
+       *  1. Add a console.log inside pullVault's importAll path to
+       *     confirm it actually runs and writes.
+       *  2. Verify the encrypted feed table name and key derivation
+       *     match between Device A's write and Device B's read.
+       *  3. If importAll runs but doesn't persist, check Dexie's
+       *     transaction completion — possibly a fire-and-forget that
+       *     status flips before the write commits.
+       * ==========================================================
+       */
+
+      // === STEP 1: Derive sync keys via the project's own module ===
+      const setupCtx = await browser.newContext();
+      const setupPage = await setupCtx.newPage();
+      await setupPage.goto("/");
+      const storedKeys = await setupPage.evaluate(async (passphrase) => {
+        const mod = await import("/src/core/storage/key-material.ts");
+        const result = await mod.deriveAndStoreKeys(passphrase, undefined, {
+          includeVaultKeys: true,
+        });
+        if (!result.ok) throw new Error(`derive failed: ${result.error}`);
+        return JSON.parse(localStorage.getItem("feedzero:derived-keys")!);
+      }, TEST_PASSPHRASE);
+      await setupCtx.close();
+      expect(storedKeys.vaultId).toMatch(/^[0-9a-f]{64}$/);
+
+      // === STEP 2: Device A — add 100 feeds + force push ===
+      const ctxA = await browser.newContext();
+      const pageA = await ctxA.newPage();
+      await preSetSyncIdentity(pageA, storedKeys);
+      await mockAllFeedRequests(pageA);
+
+      await pageA.goto("/feeds");
+
+      await pageA.waitForFunction(
+        async () => {
+          const [appMod, syncMod] = await Promise.all([
+            import("/src/stores/app-store.ts"),
+            import("/src/stores/sync-store.ts"),
+          ]);
+          return (
+            appMod.useAppStore.getState().isDbReady &&
+            syncMod.useSyncStore.getState().credentials !== null
+          );
+        },
+        undefined,
+        { timeout: 30_000 },
+      );
+
+      const addResults = await pageA.evaluate(async (count) => {
+        const mod = await import("/src/stores/feed-store.ts");
+        const successes: string[] = [];
+        const failures: Array<{ url: string; error: string }> = [];
+        for (let i = 0; i < count; i++) {
+          const url = `https://stress-test-${i.toString().padStart(3, "0")}.example.com/feed.xml`;
+          try {
+            await mod.useFeedStore.getState().addFeed(url);
+            successes.push(url);
+          } catch (e) {
+            failures.push({
+              url,
+              error: e instanceof Error ? e.message : String(e),
+            });
+          }
+        }
+        return { successes: successes.length, failures };
+      }, FEED_COUNT);
+      expect(addResults.failures).toEqual([]);
+      expect(addResults.successes).toBe(FEED_COUNT);
+
+      const feedCountA = await pageA.evaluate(async () => {
+        const mod = await import("/src/stores/feed-store.ts");
+        return mod.useFeedStore.getState().feeds.length;
+      });
+      expect(feedCountA).toBe(FEED_COUNT);
+
+      const pushOutcome = await pageA.evaluate(async () => {
+        const mod = await import("/src/stores/sync-store.ts");
+        await mod.useSyncStore.getState().push();
+        return {
+          status: mod.useSyncStore.getState().status,
+          error: mod.useSyncStore.getState().error,
+        };
+      });
+      expect(pushOutcome.error).toBeNull();
+      expect(pushOutcome.status).toBe("synced");
+
+      // === STEP 3: Device B — pull, verify all 100 feeds arrived ===
+      const ctxB = await browser.newContext();
+      const pageB = await ctxB.newPage();
+      await preSetSyncIdentity(pageB, storedKeys);
+      await mockAllFeedRequests(pageB);
+
+      await pageB.goto("/feeds");
+
+      // Wait for sync init + pull to settle.
+      await pageB.waitForFunction(
+        async () => {
+          const [appMod, syncMod] = await Promise.all([
+            import("/src/stores/app-store.ts"),
+            import("/src/stores/sync-store.ts"),
+          ]);
+          return (
+            appMod.useAppStore.getState().isDbReady &&
+            syncMod.useSyncStore.getState().status === "synced"
+          );
+        },
+        undefined,
+        { timeout: 60_000 },
+      );
+
+      // Force in-memory feed-store reload from IndexedDB.
+      await pageB.evaluate(async () => {
+        const mod = await import("/src/stores/feed-store.ts");
+        await mod.useFeedStore.getState().loadFeeds();
+      });
+
+      const feedCountB = await pageB.evaluate(async () => {
+        const mod = await import("/src/stores/feed-store.ts");
+        return mod.useFeedStore.getState().feeds.length;
+      });
+      expect(feedCountB).toBe(FEED_COUNT);
+
+      // Spot-check identity.
+      const sampledUrlsPresent = await pageB.evaluate(async () => {
+        const mod = await import("/src/stores/feed-store.ts");
+        const feeds = mod.useFeedStore.getState().feeds;
+        const samples = ["000", "049", "099"].map(
+          (i) => `https://stress-test-${i}.example.com/feed.xml`,
+        );
+        return samples.map((url) => feeds.some((f) => f.url === url));
+      });
+      expect(sampledUrlsPresent).toEqual([true, true, true]);
+
+      await ctxA.close();
+      await ctxB.close();
+    },
+  );
+});

--- a/tests/smoke/sync-large-vault.test.ts
+++ b/tests/smoke/sync-large-vault.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { randomBytes } from "node:crypto";
+
+/**
+ * Production-grade smoke test: PUT then GET a realistically-shaped
+ * encrypted vault of ~100 feeds + ~2000 articles' worth of data
+ * against the live /api/sync endpoint. Assert byte-equality.
+ *
+ * Why this exists: PR #45 (Upstash migration) silently broke vault
+ * reads for 24h because the SDK's auto-deserialization turned our
+ * stored JSON string back into an object on GET. The unit suite passed
+ * because the fake client returned strings as-is; the production SDK
+ * did not. A 1.5MB realistic-shape roundtrip is exactly the kind of
+ * test that would have failed loudly on the first PR #45 deploy.
+ *
+ * What this test does NOT do:
+ *  - Encrypt anything. /api/sync stores opaque strings; the smoke
+ *    test cares about transport + storage byte-fidelity, not crypto
+ *    correctness. Crypto is unit-tested in vault-crypto.test.ts.
+ *  - Use a real user's vaultId. We pick a sentinel-shaped vaultId
+ *    (64 'c' chars) so the existing sentinel-cleanup script catches
+ *    it if a test run is interrupted and the DELETE doesn't fire.
+ *
+ * Skipped by default. Runs with SMOKE_TESTS=1.
+ *
+ * Side effects (all cleaned up in try/finally):
+ *  - One sentinel vault under vault:cccc… is briefly stored in
+ *    production Upstash, then deleted.
+ *  - Real /api/sync PUT, GET, DELETE round-trips occur.
+ */
+
+const SKIP = !process.env.SMOKE_TESTS;
+const BASE_URL = process.env.SMOKE_BASE_URL ?? "https://my.feedzero.app";
+
+/**
+ * Sentinel vaultId: 64 same-char hex. Matches isSentinelVaultId() in
+ * src/core/sync/migration/sentinel-cleanup.ts. If this test exits
+ * abnormally (process killed, network blip during cleanup, etc.) the
+ * sentinel-cleanup script will remove it on the next operator run.
+ */
+const SENTINEL_VAULT_ID = "c".repeat(64);
+
+/**
+ * Target payload size: ~1.5 MB. Calibrated to mirror a realistic
+ * production vault for a power user — 100 feed metadata records (~400B
+ * each = 40KB plaintext) + 2000 article entries (~500B each = 1MB
+ * plaintext), with the ~1.33x base64 expansion after AES-GCM-256
+ * encryption applied to the bytes. Well under the 5MB MAX_VAULT_SIZE
+ * limit but big enough to surface payload-size class bugs (HTTP body
+ * limits, Upstash REST payload limits, base64 size blowup, etc.).
+ */
+const TARGET_PAYLOAD_BYTES = 1_500_000;
+
+function buildSyntheticVaultPayload(): {
+  version: number;
+  iv: number[];
+  ciphertext: string;
+} {
+  // 12-byte IV — matches the real AES-GCM-256 IV size used by
+  // vault-crypto.ts.
+  const iv = Array.from(randomBytes(12).values());
+  // Random bytes base64-encoded as the synthetic ciphertext. Real
+  // ciphertext would have an HMAC tag appended; this is opaque to the
+  // server which only stores the string.
+  const ciphertext = randomBytes(TARGET_PAYLOAD_BYTES).toString("base64");
+  return { version: 1, iv, ciphertext };
+}
+
+describe.skipIf(SKIP)(
+  "production /api/sync (live) — large vault roundtrip",
+  () => {
+    it(`PUT → GET roundtrip on a ${(TARGET_PAYLOAD_BYTES / 1_000_000).toFixed(1)}MB vault preserves byte-fidelity`, async () => {
+      const vaultPayload = buildSyntheticVaultPayload();
+
+      const putBody = JSON.stringify({
+        vaultId: SENTINEL_VAULT_ID,
+        vault: vaultPayload,
+      });
+      const putBodySize = putBody.length;
+
+      try {
+        // 1. PUT — store the vault.
+        const putStart = Date.now();
+        const putRes = await fetch(`${BASE_URL}/api/sync`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: putBody,
+        });
+        const putElapsedMs = Date.now() - putStart;
+        expect(putRes.status).toBe(200);
+        const putResBody = await putRes.json();
+        expect(putResBody.ok).toBe(true);
+        expect(typeof putResBody.updatedAt).toBe("number");
+        // Surface timing so an operator running this test sees the
+        // latency cost of a large vault. Useful for capacity planning.
+        console.log(
+          `[smoke-large-vault] PUT  ${putBodySize.toLocaleString()}B in ${putElapsedMs}ms (${Math.round(putBodySize / putElapsedMs)}KB/s)`,
+        );
+
+        // 2. GET — retrieve it back. This is the exact step that PR #45
+        //    broke (returned "[object Object]" instead of the payload).
+        const getStart = Date.now();
+        const getRes = await fetch(
+          `${BASE_URL}/api/sync?vaultId=${SENTINEL_VAULT_ID}`,
+        );
+        const getElapsedMs = Date.now() - getStart;
+        expect(getRes.status).toBe(200);
+        const getResBody = await getRes.json();
+        expect(getResBody.ok).toBe(true);
+        console.log(
+          `[smoke-large-vault] GET  returned ${(JSON.stringify(getResBody).length).toLocaleString()}B in ${getElapsedMs}ms`,
+        );
+
+        // 3. Byte-equal assertion on the vault structure. This is the
+        //    invariant: what was PUT is what comes back, regardless of
+        //    any SDK auto-parse / auto-stringify shenanigans between
+        //    the client → handler → adapter → Upstash chain.
+        expect(getResBody.vault.version).toBe(vaultPayload.version);
+        expect(getResBody.vault.iv).toEqual(vaultPayload.iv);
+        expect(getResBody.vault.ciphertext).toBe(vaultPayload.ciphertext);
+        // Catch the specific bug PR #45 introduced: ciphertext must
+        // be a STRING (not a parsed object), exactly the bytes we put.
+        expect(typeof getResBody.vault.ciphertext).toBe("string");
+        expect(getResBody.vault.ciphertext.length).toBe(
+          vaultPayload.ciphertext.length,
+        );
+      } finally {
+        // Cleanup: delete the sentinel vault regardless of assertion
+        // outcome. If this DELETE itself fails (network blip, etc.),
+        // the standalone sentinel-cleanup script catches the leftover
+        // on the next operator run because the vaultId is sentinel-shaped.
+        await fetch(`${BASE_URL}/api/sync?vaultId=${SENTINEL_VAULT_ID}`, {
+          method: "DELETE",
+        }).catch(() => {});
+      }
+    }, 60_000); // 60s for a 1.5MB roundtrip with network + Upstash latency
+
+    it("4xx error path on the same large-vault scale still returns valid JSON + traceId", async () => {
+      // Verify error responses don't regress at this payload scale —
+      // i.e. the body-size handling doesn't silently break the
+      // observability contract from PR #43.
+      const res = await fetch(`${BASE_URL}/api/sync`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        // Missing vaultId — 400 path.
+        body: JSON.stringify({
+          vault: { version: 1, iv: [1], ciphertext: "x" },
+        }),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+    }, 10_000);
+  },
+);


### PR DESCRIPTION
## Summary

Two new tests for the user-requested \"production level test that adds 100 valid feeds and syncs it and pulls it successfully on another device.\"

### A. \`tests/smoke/sync-large-vault.test.ts\` ✅ working

Production smoke test: PUT then GET a 1.5MB encrypted-shape vault against \`my.feedzero.app/api/sync\`. Asserts byte-equality. Confirms 100 feeds + 2000 articles worth of ciphertext round-trips intact through Upstash REST + the auto-deserialize posture from ADR 008.

\`\`\`
SMOKE_TESTS=1 npx vitest run tests/smoke/sync-large-vault.test.ts
\`\`\`

Verified against live production: PUT 2.0MB in 1928ms (1037KB/s), GET in 945ms, byte-equal. ~4s total.

### B. \`tests/e2e/sync-100-feeds.spec.ts\` ⚠️ \`test.fixme()\` — pins a known issue

Cross-device E2E: two browser contexts share the same derived keys (pre-computed via the project's own \`key-material.ts\` in a throwaway context — no Node-side reimplementation that could drift). Device A adds 100 mocked feeds and force-pushes. Device B should pull all 100.

**Currently fails against the dev server. The failure is a real bug, not a flaky test:** Device B's pull marks status as \"synced\" and the server vault has ~79KB of ciphertext (consistent with 100 encrypted feeds), but Device B's IndexedDB AND in-memory feed-store both show 0 feeds after the pull. Page reload + explicit \`loadFeeds()\` doesn't recover them.

Hypothesis (in the test body): \`pullVault\` retrieves and decrypts correctly, but \`importAll\` either silently no-ops, writes to a different DB instance than feed-store reads from, or fires-and-forgets without awaiting the Dexie transaction.

The test body has a full \"Investigation findings\" block with concrete next-step diagnostics. \`test.fixme()\` keeps CI green while preserving the spec; flip back to \`test()\` when the underlying issue is fixed.

## Why B is shipped as a known-issue pin

A failing test that surfaces a real bug is more valuable for \"super robust\" sync than a passing test that hides one. Sync at 100-feed scale is currently broken on the client end-to-end path; B is the proof. Shipping it now gives a future session full context to pick up the investigation.

## Test plan

- [x] 1948 unit/integration tests pass; \`tsc --noEmit\` clean
- [x] A passes against production (4s, 2MB roundtrip, byte-equal)
- [x] B reports \`skipped\` (fixme), doesn't break CI
- [ ] Follow-up PR: investigate Device B's pull → importAll path; flip B from fixme to test once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)