### PR TITLE
fix(reader): hide prev/next/back nav pills on desktop

### DIFF
--- a/src/components/reader/reader-panel.tsx
+++ b/src/components/reader/reader-panel.tsx
@@ -82,53 +82,53 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
     </div>
   );
 
-  // navPills depends only on props — safe to compute before early returns so
-  // the back button is always visible (even while the article is loading).
-  const navPills = onNavigate && (prevArticle || nextArticle || onBack) ? (
-    <div
-      data-testid="nav-pills-bar"
-      className="flex items-center gap-2 px-4 pb-4 pt-2 shrink-0"
-    >
-      {onBack && (
-        <Button
-          data-testid="back-pill"
-          variant="outline"
-          size="sm"
-          className="shrink-0 rounded-full h-8 px-3 gap-1 bg-background/95 backdrop-blur-sm shadow-md"
-          onClick={onBack}
-        >
-          <ChevronLeft className="size-3.5 shrink-0" />
-          {isDesktop && "Back"}
-        </Button>
-      )}
-      {prevArticle && (
-        <Button
-          data-testid="prev-pill"
-          variant="outline"
-          size="sm"
-          className="flex-1 min-w-0 flex items-center gap-1 justify-start rounded-full shadow-md bg-background/95 backdrop-blur-sm"
-          onClick={() => onNavigate(prevArticle)}
-        >
-          <ChevronLeft className="size-3.5 shrink-0" />
-          {isDesktop && <Kbd className="shrink-0">k</Kbd>}
-          <span className="truncate">{decodeEntities(prevArticle.title)}</span>
-        </Button>
-      )}
-      {nextArticle && (
-        <Button
-          data-testid="next-pill"
-          variant="outline"
-          size="sm"
-          className="flex-1 min-w-0 flex items-center gap-1 justify-end rounded-full shadow-md bg-background/95 backdrop-blur-sm"
-          onClick={() => onNavigate(nextArticle)}
-        >
-          <span className="truncate">{decodeEntities(nextArticle.title)}</span>
-          {isDesktop && <Kbd className="shrink-0">j</Kbd>}
-          <ChevronRight className="size-3.5 shrink-0" />
-        </Button>
-      )}
-    </div>
-  ) : null;
+  // Navigation pills (back / prev / next) are mobile-only. Desktop keeps
+  // the article list panel always visible plus j/k keyboard shortcuts —
+  // the pills would just clutter the reader. On mobile the reader takes
+  // the full screen, so the pills are the primary nav affordance.
+  const navPills =
+    !isDesktop && onNavigate && (prevArticle || nextArticle || onBack) ? (
+      <div
+        data-testid="nav-pills-bar"
+        className="flex items-center gap-2 px-4 pb-4 pt-2 shrink-0"
+      >
+        {onBack && (
+          <Button
+            data-testid="back-pill"
+            variant="outline"
+            size="sm"
+            className="shrink-0 rounded-full h-8 px-3 gap-1 bg-background/95 backdrop-blur-sm shadow-md"
+            onClick={onBack}
+          >
+            <ChevronLeft className="size-3.5 shrink-0" />
+          </Button>
+        )}
+        {prevArticle && (
+          <Button
+            data-testid="prev-pill"
+            variant="outline"
+            size="sm"
+            className="flex-1 min-w-0 flex items-center gap-1 justify-start rounded-full shadow-md bg-background/95 backdrop-blur-sm"
+            onClick={() => onNavigate(prevArticle)}
+          >
+            <ChevronLeft className="size-3.5 shrink-0" />
+            <span className="truncate">{decodeEntities(prevArticle.title)}</span>
+          </Button>
+        )}
+        {nextArticle && (
+          <Button
+            data-testid="next-pill"
+            variant="outline"
+            size="sm"
+            className="flex-1 min-w-0 flex items-center gap-1 justify-end rounded-full shadow-md bg-background/95 backdrop-blur-sm"
+            onClick={() => onNavigate(nextArticle)}
+          >
+            <span className="truncate">{decodeEntities(nextArticle.title)}</span>
+            <ChevronRight className="size-3.5 shrink-0" />
+          </Button>
+        )}
+      </div>
+    ) : null;
 
   // Wraps empty/loading states in the flex column so layout is stable and the
   // nav bar (including back button) is always visible when onNavigate is provided.

--- a/tests/components/reader/reader-panel.test.tsx
+++ b/tests/components/reader/reader-panel.test.tsx
@@ -240,7 +240,8 @@ describe("ReaderPanel", () => {
     expect(contentWrapper!.className).toContain("overflow-x-hidden");
   });
 
-  it("sticky nav bar is not inside the overflow-x-hidden content area", () => {
+  it("sticky nav bar (mobile) is not inside the overflow-x-hidden content area", () => {
+    mockIsDesktop = false;
     useArticleStore.setState({
       selectedArticle: mockArticle(),
       articles: [],
@@ -256,7 +257,8 @@ describe("ReaderPanel", () => {
     expect(contentArea!.contains(navBar)).toBe(false);
   });
 
-  it("nav pills are rounded-full for floating appearance", () => {
+  it("nav pills are rounded-full for floating appearance (mobile)", () => {
+    mockIsDesktop = false;
     useArticleStore.setState({
       selectedArticle: mockArticle(),
       articles: [],
@@ -268,7 +270,8 @@ describe("ReaderPanel", () => {
     expect(pill.className).toContain("rounded-full");
   });
 
-  it("nav pills bar has no border-t (floating, not a separator bar)", () => {
+  it("nav pills bar has no border-t (mobile floating, not a separator bar)", () => {
+    mockIsDesktop = false;
     useArticleStore.setState({
       selectedArticle: mockArticle(),
       articles: [],
@@ -335,17 +338,34 @@ describe("ReaderPanel", () => {
     });
   });
 
-  describe("desktop navigation pills", () => {
+  describe("mobile navigation pills", () => {
     const nextArt = { ...mockArticle(), id: "a2", title: "Next Article" };
     const prevArt = { ...mockArticle(), id: "a0", title: "Prev Article" };
 
     beforeEach(() => {
-      mockIsDesktop = true;
+      // Pills are mobile-only. On desktop the user has the article list
+      // panel always visible plus j/k shortcuts — the pills are redundant
+      // and clutter the reader. Mobile keeps them as the primary nav
+      // affordance since the article list isn't on screen.
+      mockIsDesktop = false;
       useArticleStore.setState({
         selectedArticle: mockArticle(),
         articles: [],
         isLoading: false,
       });
+    });
+
+    it("does NOT render prev/next pills on desktop", () => {
+      mockIsDesktop = true;
+      render(
+        <ReaderPanel
+          nextArticle={nextArt}
+          prevArticle={prevArt}
+          onNavigate={vi.fn()}
+        />,
+      );
+      expect(screen.queryByTestId("next-pill")).toBeNull();
+      expect(screen.queryByTestId("prev-pill")).toBeNull();
     });
 
     it("shows next pill when nextArticle prop provided", () => {
@@ -368,20 +388,6 @@ describe("ReaderPanel", () => {
       render(<ReaderPanel />);
       expect(screen.queryByTestId("next-pill")).toBeNull();
       expect(screen.queryByTestId("prev-pill")).toBeNull();
-    });
-
-    it("next pill shows j kbd hint", () => {
-      render(<ReaderPanel nextArticle={nextArt} onNavigate={vi.fn()} />);
-      const pill = screen.getByTestId("next-pill");
-      expect(pill.querySelector("kbd")).toBeTruthy();
-      expect(pill.querySelector("kbd")!.textContent).toBe("j");
-    });
-
-    it("prev pill shows k kbd hint", () => {
-      render(<ReaderPanel prevArticle={prevArt} onNavigate={vi.fn()} />);
-      const pill = screen.getByTestId("prev-pill");
-      expect(pill.querySelector("kbd")).toBeTruthy();
-      expect(pill.querySelector("kbd")!.textContent).toBe("k");
     });
 
     it("clicking next pill calls onNavigate with nextArticle", async () => {


### PR DESCRIPTION
## Summary

Desktop has the article list panel always visible plus j/k keyboard shortcuts — the floating prev/next/back pills add clutter without adding affordance. On mobile the reader takes the full screen and the pills stay as the primary nav.

## Changes

- `src/components/reader/reader-panel.tsx`: gate the entire `navPills` block on `!isDesktop`. Removed always-false dead branches (`{isDesktop && <Kbd/>}`) inside the pills.
- `tests/components/reader/reader-panel.test.tsx`:
  - Renamed "desktop navigation pills" describe to "mobile navigation pills" with `mockIsDesktop = false`.
  - Added one test asserting the bar does NOT render on desktop.
  - Three structural assertions (overflow ancestor, rounded-full, no border-t) now explicitly set `mockIsDesktop = false`.
  - Removed two "kbd hint" tests — kbd shortcuts don't apply on mobile (the only context where pills now render).

## Test plan

- [x] `tsc --noEmit` clean
- [x] Full suite green (1947 tests passing)
- [x] Reader-panel tests: 42/42

🤖 Generated with [Claude Code](https://claude.com/claude-code)