### PR TITLE
chore(scripts): mint smoke license token for CI bearer-auth

### DIFF
--- a/scripts/mint-smoke-license.ts
+++ b/scripts/mint-smoke-license.ts
@@ -1,0 +1,83 @@
+/**
+ * One-off CLI: mint a long-lived license token for use as the
+ * SMOKE_LICENSE_TOKEN GitHub Actions secret, which gates the data-
+ * roundtrip assertions in tests/smoke/sync-cross-device.test.ts.
+ *
+ * The token is signed with the same LICENSE_SIGNING_KEY used by
+ * production. It uses a sentinel customerId/keyId so it's identifiable
+ * in logs but never matches a real Stripe customer. The keyId is not
+ * added to the revocation deny-list, so production verify accepts it
+ * until expiry (5 years by default).
+ *
+ * Usage:
+ *
+ *   # Pull the signing key from Vercel
+ *   vercel env pull .env.production --environment=production
+ *
+ *   # Mint the token (5 years valid, "pro" tier)
+ *   set -a; source .env.production; set +a
+ *   npx tsx scripts/mint-smoke-license.ts
+ *
+ *   # Copy the printed token. Add it as a GitHub Actions repo secret
+ *   # named SMOKE_LICENSE_TOKEN at:
+ *   #   https://github.com/forcingfx/feedzero/settings/secrets/actions
+ *
+ *   # Delete the local env file (contains the signing key in cleartext)
+ *   rm .env.production
+ *
+ * To rotate the smoke token: re-run this script and update the secret.
+ * To revoke a leaked smoke token: add its keyId to the revocation list
+ * via your existing license storage tooling; the smoke can no longer
+ * authenticate. Generate a fresh one with this script.
+ */
+
+import { signLicense } from "../src/core/license/sign";
+
+const SIGNING_KEY = process.env.LICENSE_SIGNING_KEY;
+if (!SIGNING_KEY) {
+  console.error(
+    "[mint-smoke-license] LICENSE_SIGNING_KEY env var is required.\n" +
+      "  Run: vercel env pull .env.production --environment=production\n" +
+      "  Then: set -a; source .env.production; set +a\n",
+  );
+  process.exit(1);
+}
+
+const FIVE_YEARS_SEC = 5 * 365 * 24 * 3600;
+
+function randomHex(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+const nowSec = Math.floor(Date.now() / 1000);
+
+const token = await signLicense(
+  {
+    tier: "pro",
+    // Sentinel customerId — distinct from any real "cus_*" Stripe id so
+    // it's grep-able in logs and obviously not a real customer.
+    customerId: "smoke-license",
+    keyId: randomHex(16),
+    issuedAtSec: nowSec,
+    expirySec: nowSec + FIVE_YEARS_SEC,
+  },
+  { secret: SIGNING_KEY },
+);
+
+const expiryDate = new Date((nowSec + FIVE_YEARS_SEC) * 1000)
+  .toISOString()
+  .slice(0, 10);
+
+console.log("");
+console.log("=== Smoke license token (copy this to GitHub Actions secret) ===");
+console.log("");
+console.log(token);
+console.log("");
+console.log(`Expires: ${expiryDate}`);
+console.log(
+  "Add as: https://github.com/forcingfx/feedzero/settings/secrets/actions",
+);
+console.log("Secret name: SMOKE_LICENSE_TOKEN");
+console.log("");


### PR DESCRIPTION
## Summary

Adds `scripts/mint-smoke-license.ts` — a one-off CLI that produces a long-lived (5-year) license token signed with the production `LICENSE_SIGNING_KEY`. The token becomes the `SMOKE_LICENSE_TOKEN` GitHub Actions repo secret so `tests/smoke/sync-cross-device.test.ts` can run its data-roundtrip assertions against gated `/api/sync` deploys (`LAUNCH_PAID_TIER=1`).

## Why

Right now the cross-device smoke test only runs its auth-gate regression guard (asserts unauthenticated PUT returns 401). With this secret in place, the full byte-fidelity round-trip across two HTTP clients is exercised on every preview deploy — closes the missing coverage class.

## Usage

```sh
# Pull the signing key from Vercel
vercel env pull .env.production --environment=production

# Source the key into the shell
set -a; source .env.production; set +a

# Mint the token
npx tsx scripts/mint-smoke-license.ts

# Copy the printed token; add as SMOKE_LICENSE_TOKEN repo secret at:
#   https://github.com/forcingfx/feedzero/settings/secrets/actions

# Clean up
rm .env.production
```

## Design notes

- **Sentinel `customerId: "smoke-license"`** — distinct from any real Stripe `cus_*` id so it's grep-able in logs and obviously not a real customer.
- **Random 16-byte hex `keyId`** per run — successive mints don't conflict.
- **5-year expiry** — long enough that rotation is not a quarterly chore; mark a calendar reminder.
- **No unit test** — operator tooling. Same class as `cleanup-sentinel-vaults.ts` and `migrate-blob-to-upstash.ts`. `signLicense` itself is unit-tested in `tests/core/license/sign.test.ts`.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Run locally: produces a token starting with `fz_`
- [ ] Add to GitHub secrets, trigger a preview, smoke runs the full data assertions (200 / matching ciphertext / HEAD 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)