### PR TITLE
fix(scripts): mint-smoke-license auto-loads .env.production

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -72,4 +72,10 @@ jobs:
           # exercise them; without it the data tests skip and only the
           # auth-gate regression guard runs.
           SMOKE_LICENSE_TOKEN: ${{ secrets.SMOKE_LICENSE_TOKEN }}
+          # Vercel Preview Deployment Protection 401s every request at
+          # the edge before app code runs. The Protection Bypass for
+          # Automation token (configured in Vercel project settings)
+          # exempts CI requests carrying the x-vercel-protection-bypass
+          # header. Required for any smoke run against a preview URL.
+          VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
         run: npx vitest run tests/smoke/sync-cross-device.test.ts

--- a/scripts/mint-smoke-license.ts
+++ b/scripts/mint-smoke-license.ts
@@ -14,8 +14,7 @@
  *   # Pull the signing key from Vercel
  *   vercel env pull .env.production --environment=production
  *
- *   # Mint the token (5 years valid, "pro" tier)
- *   set -a; source .env.production; set +a
+ *   # Mint the token (script auto-loads .env.production if present)
  *   npx tsx scripts/mint-smoke-license.ts
  *
  *   # Copy the printed token. Add it as a GitHub Actions repo secret
@@ -31,14 +30,52 @@
  * authenticate. Generate a fresh one with this script.
  */
 
+import { readFileSync, existsSync } from "node:fs";
 import { signLicense } from "../src/core/license/sign";
+
+/**
+ * Parse a `.env`-style file into key/value pairs. Handles double-quoted
+ * values (the format Vercel CLI writes) so values containing shell
+ * metacharacters survive without being mangled by `source` / `sed`.
+ * Strips a single layer of surrounding `"..."` if present; leaves
+ * unquoted values as-is.
+ */
+function loadEnvFile(path: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of readFileSync(path, "utf8").split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      value.length >= 2 &&
+      value.startsWith('"') &&
+      value.endsWith('"')
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+// Auto-load .env.production if it exists. Avoids brittle shell sourcing.
+const ENV_FILE = ".env.production";
+if (existsSync(ENV_FILE) && !process.env.LICENSE_SIGNING_KEY) {
+  for (const [k, v] of Object.entries(loadEnvFile(ENV_FILE))) {
+    if (!(k in process.env)) process.env[k] = v;
+  }
+}
 
 const SIGNING_KEY = process.env.LICENSE_SIGNING_KEY;
 if (!SIGNING_KEY) {
   console.error(
     "[mint-smoke-license] LICENSE_SIGNING_KEY env var is required.\n" +
       "  Run: vercel env pull .env.production --environment=production\n" +
-      "  Then: set -a; source .env.production; set +a\n",
+      `  Then: npx tsx scripts/mint-smoke-license.ts\n` +
+      "  (The script auto-loads .env.production if present in cwd.)\n",
   );
   process.exit(1);
 }

--- a/tests/smoke/sync-cross-device.test.ts
+++ b/tests/smoke/sync-cross-device.test.ts
@@ -42,6 +42,23 @@ const AUTH_HEADER: Record<string, string> = LICENSE_TOKEN
   ? { Authorization: `Bearer ${LICENSE_TOKEN}` }
   : {};
 
+// Vercel Preview Deployment Protection 401s every request at the edge
+// before our app code runs. The Protection Bypass for Automation
+// feature exempts requests carrying this header from the gate. The
+// secret is configured in Vercel project settings and mirrored as a
+// GHA secret. Header name is the literal value Vercel documents.
+// Empty / absent → no header sent (production base URLs don't need it).
+const PROTECTION_BYPASS = process.env.VERCEL_PROTECTION_BYPASS;
+const BYPASS_HEADER: Record<string, string> = PROTECTION_BYPASS
+  ? {
+      "x-vercel-protection-bypass": PROTECTION_BYPASS,
+      // Tells Vercel to also set a bypass cookie on this response so
+      // follow-up requests within the same fetch session don't need
+      // the header repeatedly. Harmless if Vercel ignores it.
+      "x-vercel-set-bypass-cookie": "true",
+    }
+  : {};
+
 // Sentinel vaultId (64-char single-character hex). Distinct from the
 // large-vault test's 'c' sentinel so parallel smoke runs do not race.
 // Matches isSentinelVaultId() in sentinel-cleanup.ts.
@@ -75,7 +92,11 @@ describe.skipIf(SKIP_AUTH)(
           fetch(input, { ...init, cache: "no-store" });
         const putRes = await deviceA(`${BASE_URL}/api/sync`, {
           method: "PUT",
-          headers: { "Content-Type": "application/json", ...AUTH_HEADER },
+          headers: {
+            "Content-Type": "application/json",
+            ...BYPASS_HEADER,
+            ...AUTH_HEADER,
+          },
           body: putBody,
         });
         expect(putRes.status).toBe(200);
@@ -87,7 +108,7 @@ describe.skipIf(SKIP_AUTH)(
           fetch(input, { ...init, cache: "no-store" });
         const getRes = await deviceB(
           `${BASE_URL}/api/sync?vaultId=${SENTINEL_VAULT_ID}`,
-          { headers: AUTH_HEADER },
+          { headers: { ...BYPASS_HEADER, ...AUTH_HEADER } },
         );
         expect(getRes.status).toBe(200);
         const body = (await getRes.json()) as {
@@ -105,7 +126,7 @@ describe.skipIf(SKIP_AUTH)(
       } finally {
         await fetch(`${BASE_URL}/api/sync?vaultId=${SENTINEL_VAULT_ID}`, {
           method: "DELETE",
-          headers: AUTH_HEADER,
+          headers: { ...BYPASS_HEADER, ...AUTH_HEADER },
         }).catch(() => {});
       }
     }, 30_000);
@@ -118,7 +139,7 @@ describe.skipIf(SKIP_AUTH)(
       const bogusId = "e".repeat(64);
       const res = await fetch(`${BASE_URL}/api/sync?vaultId=${bogusId}`, {
         method: "HEAD",
-        headers: AUTH_HEADER,
+        headers: { ...BYPASS_HEADER, ...AUTH_HEADER },
       });
       expect(res.status).toBe(404);
     }, 15_000);
@@ -139,7 +160,11 @@ describe.skipIf(SKIP || LICENSE_TOKEN !== undefined)(
       const vaultPayload = buildSyntheticVaultPayload();
       const res = await fetch(`${BASE_URL}/api/sync`, {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        // Bypass header is still required to get past Vercel Preview
+        // Protection (which 401s at the edge). The auth-gate assertion
+        // is specifically about the app's bearer check, not Vercel's
+        // platform-level protection.
+        headers: { "Content-Type": "application/json", ...BYPASS_HEADER },
         body: JSON.stringify({
           vaultId: SENTINEL_VAULT_ID,
           vault: vaultPayload,

--- a/tests/smoke/sync-cross-device.test.ts
+++ b/tests/smoke/sync-cross-device.test.ts
@@ -48,15 +48,23 @@ const AUTH_HEADER: Record<string, string> = LICENSE_TOKEN
 // secret is configured in Vercel project settings and mirrored as a
 // GHA secret. Header name is the literal value Vercel documents.
 // Empty / absent → no header sent (production base URLs don't need it).
+//
+// NOT sending `x-vercel-set-bypass-cookie: true` because it causes
+// Vercel to do a redirect-then-set-cookie dance that Node fetch
+// follows in a loop ("redirect count exceeded"). The per-request
+// header-only mode works without a cookie session — each request
+// carries its own bypass.
 const PROTECTION_BYPASS = process.env.VERCEL_PROTECTION_BYPASS;
+if (process.env.SMOKE_TESTS && PROTECTION_BYPASS) {
+  // Diagnostic — confirms the secret reached the test env without
+  // leaking the value itself. Vercel bypass tokens are 32 chars.
+  // eslint-disable-next-line no-console
+  console.log(
+    `[smoke] VERCEL_PROTECTION_BYPASS length=${PROTECTION_BYPASS.length}`,
+  );
+}
 const BYPASS_HEADER: Record<string, string> = PROTECTION_BYPASS
-  ? {
-      "x-vercel-protection-bypass": PROTECTION_BYPASS,
-      // Tells Vercel to also set a bypass cookie on this response so
-      // follow-up requests within the same fetch session don't need
-      // the header repeatedly. Harmless if Vercel ignores it.
-      "x-vercel-set-bypass-cookie": "true",
-    }
+  ? { "x-vercel-protection-bypass": PROTECTION_BYPASS }
   : {};
 
 // Sentinel vaultId (64-char single-character hex). Distinct from the


### PR DESCRIPTION
## Summary

The previous workflow required `set -a; source .env.production; set +a` before invoking the script. In practice that path is brittle:

1. zsh `set -a` + `source` doesn't reliably auto-export double-quoted values containing shell metacharacters (`$`, `` ` ``, `\`). The signing key (long random base64) routinely contains them.
2. Shell extraction via `grep | sed` produces empty captures when values contain `"` mid-string or unusual escaping.

Fix: the script now reads `.env.production` directly using a small inline parser if the file exists in cwd and `LICENSE_SIGNING_KEY` isn't already set. No shell prep needed — just `npx tsx scripts/mint-smoke-license.ts`.

Existing env vars take precedence, so CI invocations (where the key is injected via secret, not a file) keep working unchanged.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Smoke: no env file, no env var → clean error message
- [ ] Smoke: with `.env.production` present, token printed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)