### PR TITLE
feat(sync): "Restore from cloud" button for stale local state recovery

### DIFF
--- a/docs/features/008-zero-knowledge-sync.md
+++ b/docs/features/008-zero-knowledge-sync.md
@@ -101,6 +101,15 @@ Feature: Zero-knowledge cloud sync
     Given any sync operation
     Then the server only stores/retrieves opaque encrypted blobs
     And vault IDs are derived from the passphrase (not the data)
+
+  Scenario: Restore from cloud after stale local state
+    Given a sync-enabled user whose local state has drifted from the cloud
+    When they click "Restore from cloud" in the Data & Storage dialog
+    And confirm the replace
+    Then the cloud vault is pulled and imported into local storage
+    And the feed and article stores refresh in place
+    And a toast reports "Restored N feeds from cloud."
+    And the dialog closes
 ```
 
 ## Architecture
@@ -167,7 +176,7 @@ All API handlers use the Web standard `Request -> Response` pattern. Three entry
 | `src/core/sync/adapters/filesystem-adapter.ts` | Filesystem storage adapter |
 | `src/core/sync/adapters/vercel-blob-adapter.ts` | Vercel Blob storage adapter |
 | `src/core/sync/adapters/resolve-adapter.ts` | Reads `SYNC_STORAGE` env var, returns adapter |
-| `src/stores/sync-store.ts` | Zustand store: `enableSync`, `push`, `pull`, `scheduleSyncPush` (5s debounce + 0-30s jitter), `logout`, `switchToExistingCloud`. Stores `credentials: SyncCredentials | null` (not raw passphrase). |
+| `src/stores/sync-store.ts` | Zustand store: `enableSync`, `push`, `pull`, `forceResync` (user-initiated "replace local with cloud"), `scheduleSyncPush` (5s debounce + 0-30s jitter), `logout`, `switchToExistingCloud`. Stores `credentials: SyncCredentials | null` (not raw passphrase). |
 | `server.ts` | Hono standalone server |
 | `api/sync.ts` | Vercel serverless wrapper (pre-bundled during build, ADR 007) |
 

--- a/src/components/sync/sync-setup-dialog.tsx
+++ b/src/components/sync/sync-setup-dialog.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   LogOut,
   KeyRound,
+  DownloadCloud,
 } from "lucide-react";
 import {
   Dialog,
@@ -31,7 +32,8 @@ type DialogView =
   | "existing"
   | "confirm-delete"
   | "confirm-disable"
-  | "confirm-logout";
+  | "confirm-logout"
+  | "confirm-restore";
 
 interface ConfirmationViewProps {
   open: boolean;
@@ -111,6 +113,7 @@ export function SyncSetupDialog() {
   const enableSync = useSyncStore((s) => s.enableSync);
   const disableSync = useSyncStore((s) => s.disableSync);
   const logout = useSyncStore((s) => s.logout);
+  const forceResync = useSyncStore((s) => s.forceResync);
   const switchToExistingCloud = useSyncStore((s) => s.switchToExistingCloud);
   const resetApp = useAppStore((s) => s.resetApp);
   const localFeedCount = useFeedStore((s) => s.feeds.length);
@@ -122,6 +125,7 @@ export function SyncSetupDialog() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDisabling, setIsDisabling] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
 
   useEffect(() => {
     if (!open) {
@@ -130,6 +134,7 @@ export function SyncSetupDialog() {
       setIsDeleting(false);
       setIsDisabling(false);
       setIsLoggingOut(false);
+      setIsRestoring(false);
     }
   }, [open]);
 
@@ -161,6 +166,19 @@ export function SyncSetupDialog() {
     setIsLoggingOut(true);
     await logout();
     handleOpenChange(false);
+  }
+
+  async function handleRestore() {
+    setIsRestoring(true);
+    const result = await forceResync();
+    setIsRestoring(false);
+    if (result.ok) {
+      toast(`Restored ${result.value.feedCount} feeds from cloud.`);
+      handleOpenChange(false);
+    } else {
+      toast.error(`Restore failed: ${result.error}`);
+      setView("status");
+    }
   }
 
   const getStatusDescription = () => {
@@ -245,6 +263,28 @@ export function SyncSetupDialog() {
     );
   }
 
+  if (view === "confirm-restore") {
+    return (
+      <ConfirmationView
+        open={open}
+        onOpenChange={handleOpenChange}
+        icon={
+          <div className="flex size-12 items-center justify-center rounded-full bg-blue-100">
+            <DownloadCloud className="size-6 text-blue-600" />
+          </div>
+        }
+        title="Restore from cloud?"
+        description="This will replace your local feeds and articles with what's stored in the cloud. Use this if a device shows the wrong feed list after sync."
+        confirmLabel="Restore"
+        loadingLabel="Restoring..."
+        confirmIcon={<DownloadCloud className="mr-2 size-4" />}
+        isLoading={isRestoring}
+        onConfirm={handleRestore}
+        onCancel={() => setView("status")}
+      />
+    );
+  }
+
   if (view === "confirm-logout") {
     return (
       <ConfirmationView
@@ -308,6 +348,15 @@ export function SyncSetupDialog() {
             >
               <CloudOff className="mr-2 size-4" />
               Switch to local only
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => setView("confirm-restore")}
+              disabled={status === "syncing"}
+            >
+              <DownloadCloud className="mr-2 size-4" />
+              Restore from cloud
             </Button>
             <Button
               variant="outline"

--- a/src/stores/sync-store.ts
+++ b/src/stores/sync-store.ts
@@ -38,6 +38,13 @@ interface SyncStore {
   logout: () => Promise<void>;
   push: () => Promise<void>;
   pull: () => Promise<void>;
+  /**
+   * Explicit "replace local with cloud" — bypasses pull's in-flight dedup
+   * and the debounced push timer, then refreshes the in-memory feed and
+   * article stores so the UI reflects the imported vault immediately.
+   * Used by the Settings → Restore from cloud button.
+   */
+  forceResync: () => Promise<Result<{ feedCount: number }>>;
   scheduleSyncPush: () => void;
   setDialogOpen: (open: boolean) => void;
   switchToExistingCloud: (
@@ -195,6 +202,42 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
     });
 
     return inFlightPull;
+  },
+
+  forceResync: async () => {
+    const { credentials } = get();
+    if (!credentials) {
+      return err("Not signed in to cloud; cannot restore");
+    }
+
+    // Cancel any pending push so it can't fire after our import and
+    // overwrite cloud with stale local state.
+    clearPendingTimers();
+
+    set({ status: "syncing", error: null });
+
+    const pullResult = await pullVault(credentials);
+    if (!pullResult.ok) {
+      set({ status: "error", error: pullResult.error });
+      return err(pullResult.error);
+    }
+
+    const importResult = await importVault(pullResult.value);
+    if (!importResult.ok) {
+      set({ status: "error", error: importResult.error });
+      return err(importResult.error);
+    }
+
+    // Refresh in-memory stores so the UI shows the imported vault
+    // without waiting for the user to navigate. Lazy-imports avoid
+    // a circular dependency on app boot.
+    const { useFeedStore } = await import("./feed-store.ts");
+    await useFeedStore.getState().loadFeeds();
+    const { useArticleStore } = await import("./article-store.ts");
+    await useArticleStore.getState().preloadAll();
+
+    set({ status: "synced", lastSyncedAt: Date.now(), error: null });
+    return ok({ feedCount: pullResult.value.feeds.length });
   },
 
   scheduleSyncPush: () => {

--- a/tests/components/sync/sync-setup-dialog.test.tsx
+++ b/tests/components/sync/sync-setup-dialog.test.tsx
@@ -17,6 +17,12 @@ vi.mock("@/core/storage/db", () => ({
       hmacKeyJwk: { kty: "oct", k: "hmac-key" },
     },
   }),
+  // forceResync's UI-refresh path lazy-imports feed-store + article-store,
+  // which call into the db layer. Stubs below let those calls complete
+  // cleanly without booting fake-indexeddb.
+  getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getFolders: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getAllArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
 }));
 
 vi.mock("@/core/storage/crypto", () => ({
@@ -237,6 +243,91 @@ describe("SyncSetupDialog", () => {
         name: /switch to local only/i,
       });
       expect(button).toBeDisabled();
+    });
+  });
+
+  describe("restore from cloud", () => {
+    beforeEach(() => {
+      useSyncStore.setState({
+        status: "synced",
+        credentials: mockCredentials,
+        lastSyncedAt: Date.now(),
+        dialogOpen: true,
+      });
+    });
+
+    it("shows Restore from cloud button for synced users", () => {
+      render(<SyncSetupDialog />);
+      expect(
+        screen.getByRole("button", { name: /restore from cloud/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("clicking Restore from cloud shows a confirmation explaining the replace", async () => {
+      const user = userEvent.setup();
+      render(<SyncSetupDialog />);
+
+      await user.click(
+        screen.getByRole("button", { name: /restore from cloud/i }),
+      );
+
+      expect(
+        screen.getByText(/replace your local feeds and articles/i),
+      ).toBeInTheDocument();
+    });
+
+    it("disables Restore from cloud while syncing", () => {
+      useSyncStore.setState({
+        status: "syncing",
+        credentials: mockCredentials,
+        dialogOpen: true,
+      });
+
+      render(<SyncSetupDialog />);
+
+      const button = screen.getByRole("button", {
+        name: /restore from cloud/i,
+      });
+      expect(button).toBeDisabled();
+    });
+
+    it("confirming restore pulls the vault and closes the dialog on success", async () => {
+      const { pullVault } = await import("@/core/sync/sync-service");
+      vi.mocked(pullVault).mockResolvedValue({
+        ok: true,
+        value: {
+          version: 1,
+          exportedAt: Date.now(),
+          feeds: [
+            {
+              id: "f1",
+              url: "https://example.com",
+              title: "Example",
+              description: "",
+              siteUrl: "",
+              createdAt: 0,
+              updatedAt: 0,
+            },
+          ],
+          articles: [],
+        },
+      });
+
+      const user = userEvent.setup();
+      render(<SyncSetupDialog />);
+
+      await user.click(
+        screen.getByRole("button", { name: /restore from cloud/i }),
+      );
+      // Confirm button inside the confirmation view
+      await user.click(
+        screen.getByRole("button", { name: /^restore$/i }),
+      );
+
+      // Dialog should close on success
+      expect(useSyncStore.getState().dialogOpen).toBe(false);
+      // Status should be back to synced after the import completes
+      expect(useSyncStore.getState().status).toBe("synced");
     });
   });
 });

--- a/tests/stores/sync-store.test.ts
+++ b/tests/stores/sync-store.test.ts
@@ -212,6 +212,99 @@ describe("sync-store", () => {
     });
   });
 
+  describe("forceResync", () => {
+    it("returns err when no credentials are set", async () => {
+      useSyncStore.setState({ credentials: null });
+      const result = await useSyncStore.getState().forceResync();
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/cloud/i);
+      }
+    });
+
+    it("pulls, imports, and reports feed count on success", async () => {
+      mockPullVault.mockResolvedValue({
+        ok: true,
+        value: {
+          version: 1,
+          exportedAt: Date.now(),
+          feeds: [
+            {
+              id: "f1",
+              url: "https://example.com",
+              title: "Example",
+              description: "",
+              siteUrl: "",
+              createdAt: 0,
+              updatedAt: 0,
+            },
+            {
+              id: "f2",
+              url: "https://example2.com",
+              title: "Example 2",
+              description: "",
+              siteUrl: "",
+              createdAt: 0,
+              updatedAt: 0,
+            },
+          ],
+          articles: [],
+        },
+      });
+      mockImportVault.mockResolvedValue({ ok: true, value: true });
+      useSyncStore.setState({
+        credentials: mockCredentials,
+        status: "synced",
+      });
+
+      const result = await useSyncStore.getState().forceResync();
+
+      expect(mockPullVault).toHaveBeenCalledWith(mockCredentials);
+      expect(mockImportVault).toHaveBeenCalled();
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.feedCount).toBe(2);
+      expect(useSyncStore.getState().status).toBe("synced");
+    });
+
+    it("surfaces pull failure to status and result", async () => {
+      mockPullVault.mockResolvedValue({
+        ok: false,
+        error: "Vault not found",
+      });
+      useSyncStore.setState({
+        credentials: mockCredentials,
+        status: "synced",
+      });
+
+      const result = await useSyncStore.getState().forceResync();
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe("Vault not found");
+      expect(useSyncStore.getState().status).toBe("error");
+      expect(useSyncStore.getState().error).toBe("Vault not found");
+    });
+
+    it("surfaces import failure to status and result", async () => {
+      mockPullVault.mockResolvedValue({
+        ok: true,
+        value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+      });
+      mockImportVault.mockResolvedValue({
+        ok: false,
+        error: "Failed to import data: db not open",
+      });
+      useSyncStore.setState({
+        credentials: mockCredentials,
+        status: "synced",
+      });
+
+      const result = await useSyncStore.getState().forceResync();
+
+      expect(result.ok).toBe(false);
+      expect(useSyncStore.getState().status).toBe("error");
+    });
+  });
+
   describe("logout", () => {
     it("destroys local state and resets stores", async () => {
       const { destroyLocal } = await import(


### PR DESCRIPTION
## Summary

- Adds a Settings → Cloud sync → "Restore from cloud" button so a sync user can replace local state with the cloud vault without the disable + re-enable round-trip (which deletes/recreates the cloud vault).
- New store action `forceResync()` bypasses pull's in-flight dedup and clears pending debounced pushes (so a queued push can't fire between pull and import and briefly re-publish stale local state). After import succeeds, refreshes the feed and article stores in place so the UI reflects the restored vault immediately.
- Toast on success: "Restored N feeds from cloud." On failure: error toast and return to the status view so the user can retry.

This is Piece 2 of the sync-robustness queue — pairs with PR #56's `test.fixme()` pin: the same drift class (status="synced" but local feeds missing) now has a user-runnable recovery path.

## Test plan

- [x] `npx vitest run tests/stores/sync-store.test.ts` — 4 new `forceResync` unit tests (no-creds, success+feedCount, pull failure, import failure) green; 15/15 total
- [x] `npx vitest run tests/components/sync/sync-setup-dialog.test.tsx` — 4 new component tests (button visible, confirm view, syncing-state disable, success closes dialog) green; 14/14 total
- [x] `npm test` — full suite, 1987 passed / 25 skipped, 0 regressions
- [x] `npx tsc --noEmit` — clean

## Notes

- No E2E added: `tests/e2e/sync.spec.ts` doesn't cover any synced-state action button (Switch to local only, Log out). Component + store coverage is at parity with the existing actions in that view.
- `docs/features/008-zero-knowledge-sync.md` updated with a new Gherkin scenario and the store action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)