### PR TITLE
fix(observability): inject APP_VERSION at build so /api/health reports the real version

### DIFF
--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -22,6 +22,15 @@ import path from "path";
 
 const apiDir = path.resolve("api");
 
+// Read the current package.json version so we can inline it into every
+// serverless bundle as `process.env.APP_VERSION`. Without this, the
+// /api/health endpoint reports "unknown" (the fallback in
+// src/core/health/health-handler.ts) and operators lose the canonical
+// "is the right code on prod" signal.
+const pkgVersion = JSON.parse(
+  readFileSync(path.resolve("package.json"), "utf-8"),
+).version;
+
 /**
  * Recursively collect every `.ts` file under api/. Vercel maps subdirectories
  * to URL path segments (`api/stripe/webhook.ts` → `/api/stripe/webhook`), so
@@ -60,6 +69,13 @@ try {
     // wrapper size (Stripe SDK is ~700KB inlined) and pulls in Node-specific
     // code paths esbuild handles poorly (causing Vercel deploy errors).
     external: ["@vercel/blob", "stripe", "@upstash/redis"],
+    // Inline `process.env.APP_VERSION` as a string literal so the health
+    // handler reports the build's version without depending on a Vercel
+    // env var being set. Tied to package.json — the release-bump commit
+    // is the single source of truth for what gets reported.
+    define: {
+      "process.env.APP_VERSION": JSON.stringify(pkgVersion),
+    },
   });
 
   // Map each source api/.../X.ts to its corresponding tempOut/.../X.js bundle.

--- a/tests/smoke/health-version.test.ts
+++ b/tests/smoke/health-version.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+/**
+ * Production smoke test: the deployed /api/health endpoint must report the
+ * version from package.json, not the "unknown" fallback. Catches the failure
+ * mode where APP_VERSION isn't injected by the build (which previously hid a
+ * post-deploy "is the right code on prod" check behind a useless string).
+ *
+ * RED today, GREEN after scripts/build-api.js inlines `process.env.APP_VERSION`
+ * at esbuild time from package.json. The handler reads either VITE_APP_VERSION
+ * (SPA context) or process.env.APP_VERSION (serverless context); only the
+ * serverless side is reachable from a smoke test because /api/health runs as
+ * a Vercel function.
+ *
+ * Skipped by default. Runs with SMOKE_TESTS=1.
+ */
+const SKIP = !process.env.SMOKE_TESTS;
+const BASE_URL = process.env.SMOKE_BASE_URL ?? "https://my.feedzero.app";
+
+// Vercel Preview Deployment Protection 401s every request before app code
+// runs. The bypass header (same one used by sync-cross-device smoke) exempts
+// CI from the gate. Production URLs (my.feedzero.app) don't need it.
+const PROTECTION_BYPASS = process.env.VERCEL_PROTECTION_BYPASS;
+const BYPASS_HEADER: Record<string, string> = PROTECTION_BYPASS
+  ? { "x-vercel-protection-bypass": PROTECTION_BYPASS }
+  : {};
+
+function readPackageVersion(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const pkgPath = path.resolve(here, "../../package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
+  return pkg.version;
+}
+
+describe.skipIf(SKIP)("production /api/health (live)", () => {
+  it("reports the version from package.json, not the 'unknown' fallback", async () => {
+    const res = await fetch(`${BASE_URL}/api/health`, {
+      headers: BYPASS_HEADER,
+      cache: "no-store",
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { ok: boolean; version: string };
+    expect(body.ok).toBe(true);
+    // The whole point: the build must inject the version.
+    expect(body.version).not.toBe("unknown");
+    // And it should be the version the smoke runner was checked out against.
+    // SMOKE_BASE_URL points at a specific deploy whose source commit is the
+    // current checkout — for prod runs this means main; for preview runs the
+    // checkout-action runs against the deploy SHA. Either way, the deployed
+    // version should match the in-repo package.json.
+    expect(body.version).toBe(readPackageVersion());
+  }, 10_000);
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,15 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import { readFileSync } from "fs";
 import { toWebRequest, sendWebResponse } from "./vite-dev-proxy.js";
+
+// Inject the current package.json version as a build-time constant so
+// the SPA and dev server can identify which build is running. The
+// serverless side is fed by scripts/build-api.js's esbuild define.
+const pkgVersion = JSON.parse(
+  readFileSync(path.resolve("package.json"), "utf-8"),
+).version;
 
 /**
  * Dev server API proxy plugin.
@@ -246,6 +254,9 @@ function apiProxyPlugin() {
 export default defineConfig({
   server: {
     port: 3000,
+  },
+  define: {
+    "import.meta.env.VITE_APP_VERSION": JSON.stringify(pkgVersion),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- `/api/health` returns \`{"version":"unknown"}\` in production today because no build step ever injected the version. Surfaced when verifying the 0.8.2 release deploy — the canonical "is the right code on prod" curl was useless.
- Reads \`package.json#version\` at config load and inlines it via esbuild \`define\` in \`scripts/build-api.js\` (serverless) and via Vite \`define\` in \`vite.config.js\` (SPA / dev server).
- Tying the value to package.json means the next release-bump commit is the single source of truth for what \`/api/health\` reports — no Vercel env-var step to forget.

## Test plan

- [x] **RED** — new \`tests/smoke/health-version.test.ts\` failed against current prod (\`expected 'unknown' not to be 'unknown'\`).
- [x] **GREEN local build proof** — ran \`node scripts/build-api.js\` and grepped \`api/health.ts\` for \`"0.8.2"\` (the package.json version): present in the bundled output.
- [x] **Full suite** — \`npm test\` → 1987 passed / 26 skipped / 0 regressions.
- [x] **Type check** — \`npx tsc --noEmit\` clean.
- [ ] **Post-deploy SMOKE** — after merge + Vercel deploy:
  ```
  curl https://my.feedzero.app/api/health | jq -r .version    # expect 0.8.2
  SMOKE_TESTS=1 npx vitest run tests/smoke/health-version.test.ts
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)