### PR TITLE
fix(stripe-webhook): tolerate dahlia API drift + log silent 200-with-issue paths

### DIFF
--- a/src/core/stripe/test-fixtures.ts
+++ b/src/core/stripe/test-fixtures.ts
@@ -121,6 +121,41 @@ export function subscriptionUpdatedEvent(
   };
 }
 
+/**
+ * Dahlia-shaped subscription.updated event. The 2026-04-22 API version moved
+ * `current_period_end` from the top-level subscription onto each subscription
+ * item (`items.data[i].current_period_end`) to support items billing on
+ * different cadences. Real live events from dahlia-pinned endpoints arrive
+ * in this shape.
+ */
+export function subscriptionUpdatedEventDahlia(
+  args: SubscriptionUpdatedArgs,
+): StripeFixture {
+  const event = {
+    id: `evt_${args.subscriptionId}_updated_dahlia`,
+    type: "customer.subscription.updated",
+    data: {
+      object: {
+        id: args.subscriptionId,
+        customer: args.customerId,
+        status: args.status,
+        cancel_at_period_end: args.cancel_at_period_end,
+        // NOTE: no top-level current_period_end — that's the whole point of
+        // this fixture. It lives on the item instead.
+        items: {
+          data: [
+            { current_period_end: args.current_period_end },
+          ],
+        },
+      },
+    },
+  };
+  return {
+    event,
+    signature: (secret, ts) => buildSignature(event, secret, ts),
+  };
+}
+
 interface InvoicePaidArgs {
   customerId: string;
   subscriptionId: string;
@@ -135,6 +170,44 @@ export function invoicePaidEvent(args: InvoicePaidArgs): StripeFixture {
       object: {
         customer: args.customerId,
         subscription: args.subscriptionId,
+        lines: {
+          data: [
+            {
+              period: { end: args.current_period_end },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return {
+    event,
+    signature: (secret, ts) => buildSignature(event, secret, ts),
+  };
+}
+
+/**
+ * Dahlia-shaped invoice.paid event. The 2026-04-22 API version moved the
+ * top-level `subscription` field onto a discriminated `parent` object:
+ * `parent.subscription_details.subscription`. Real live events from
+ * dahlia-pinned endpoints arrive in this shape (this exact bug bit us
+ * on 2026-05-15 — operator paid $5, webhook returned 200 with
+ * `ignored: "invoice.paid without subscription"`).
+ */
+export function invoicePaidEventDahlia(args: InvoicePaidArgs): StripeFixture {
+  const event = {
+    id: `evt_${args.subscriptionId}_invoice_paid_dahlia`,
+    type: "invoice.paid",
+    data: {
+      object: {
+        customer: args.customerId,
+        // NOTE: no top-level `subscription` field in dahlia — moved to parent.
+        parent: {
+          type: "subscription_details",
+          subscription_details: {
+            subscription: args.subscriptionId,
+          },
+        },
         lines: {
           data: [
             {

--- a/src/core/stripe/webhook-handler.ts
+++ b/src/core/stripe/webhook-handler.ts
@@ -321,13 +321,38 @@ async function handleSubscriptionUpdated(
     );
   }
 
-  const expirySec = obj.current_period_end;
-  if (typeof expirySec !== "number") {
+  const expirySec = extractSubscriptionCurrentPeriodEnd(obj);
+  if (expirySec === null) {
     return acceptedWithIssue("Missing current_period_end");
   }
   return outcomeFromIssuerResult(
     await issuer.recordRenewal({ customerId, subscriptionId, expirySec }),
   );
+}
+
+/**
+ * Read `current_period_end` from a Subscription object, tolerant of API version drift.
+ *
+ * Legacy (pre-2026 dahlia): `subscription.current_period_end` at top level.
+ * Dahlia+ (2026-04-22 onward): moved to `subscription.items.data[0].current_period_end`
+ * — Stripe split billing periods per subscription item to support items that bill
+ * on different cadences.
+ *
+ * We try the dahlia path first (where dahlia-and-newer events arrive) and fall
+ * back to top-level for older API versions. Returning `null` triggers an
+ * acceptedWithIssue 200 in the caller; the wrapper logs the miss so the API
+ * version drift becomes visible in production logs.
+ */
+function extractSubscriptionCurrentPeriodEnd(
+  obj: Record<string, unknown>,
+): number | null {
+  const items = obj.items as
+    | { data?: Array<{ current_period_end?: unknown }> }
+    | undefined;
+  const itemEnd = items?.data?.[0]?.current_period_end;
+  if (typeof itemEnd === "number") return itemEnd;
+  const topLevel = obj.current_period_end;
+  return typeof topLevel === "number" ? topLevel : null;
 }
 
 function isCancellationUpdate(obj: Record<string, unknown>): boolean {
@@ -341,7 +366,7 @@ async function handleInvoicePaid(
   issuer: LicenseIssuer,
 ): Promise<DispatchOutcome> {
   const customerId = getString(obj, "customer");
-  const subscriptionId = getString(obj, "subscription");
+  const subscriptionId = extractInvoiceSubscription(obj);
   if (!customerId || !subscriptionId) {
     return {
       status: 200,
@@ -358,8 +383,32 @@ async function handleInvoicePaid(
 }
 
 /**
- * Invoice events carry the renewal period end inside
- * `lines.data[0].period.end` rather than at the top level.
+ * Read the related subscription id from an Invoice object, tolerant of API version drift.
+ *
+ * Legacy: `invoice.subscription` at top level.
+ * Dahlia+ (2026-04-22 onward): moved to
+ * `invoice.parent.subscription_details.subscription` — Stripe re-shaped invoices
+ * to express their relationship to a subscription (or other parent) via a typed
+ * `parent` discriminator.
+ *
+ * Returning `null` falls through to the "invoice.paid without subscription"
+ * acceptedWithIssue 200, which the wrapper logs.
+ */
+function extractInvoiceSubscription(
+  obj: Record<string, unknown>,
+): string | null {
+  const parent = obj.parent as
+    | { subscription_details?: { subscription?: unknown } }
+    | undefined;
+  const newPath = parent?.subscription_details?.subscription;
+  if (typeof newPath === "string") return newPath;
+  return getString(obj, "subscription");
+}
+
+/**
+ * Read the renewal period end from an Invoice's line items. Legacy and dahlia
+ * both expose this at `lines.data[0].period.end` (the field itself didn't move
+ * in dahlia), but kept as a small helper for symmetry and forward-readability.
  */
 function extractInvoicePeriodEnd(
   obj: Record<string, unknown>,
@@ -441,6 +490,28 @@ export async function handleStripeWebhook(
         ? (outcome.body as { error: string }).error
         : "dispatch failed";
     return serverError(errMsg, "DispatchFailed", outcome.status, traceId, method);
+  }
+  // 200-with-issue paths return success to Stripe (so it stops retrying) but
+  // represent silent operational gaps — most often missing metadata or an
+  // API-version drift in the event payload shape. Surface them in runtime
+  // logs so they don't go unnoticed. We deliberately do not change status —
+  // returning 5xx would cause Stripe to retry indefinitely on an issue that
+  // is operator-side, not transient.
+  if (
+    outcome.status === 200 &&
+    typeof outcome.body === "object" &&
+    outcome.body !== null &&
+    "issue" in outcome.body &&
+    typeof (outcome.body as { issue: unknown }).issue === "string"
+  ) {
+    logError({
+      route: ROUTE,
+      method,
+      status: 200,
+      traceId,
+      errClass: "AcceptedWithIssue",
+      errMsg: (outcome.body as { issue: string }).issue,
+    });
   }
   return jsonResponse(outcome.body, outcome.status);
 }

--- a/tests/core/stripe/webhook-handler.test.ts
+++ b/tests/core/stripe/webhook-handler.test.ts
@@ -8,7 +8,9 @@ import {
   subscriptionCreatedEvent,
   subscriptionDeletedEvent,
   subscriptionUpdatedEvent,
+  subscriptionUpdatedEventDahlia,
   invoicePaidEvent,
+  invoicePaidEventDahlia,
   customEvent,
   type StripeFixture,
 } from "@/core/stripe/test-fixtures";
@@ -221,6 +223,180 @@ describe("handleStripeWebhook", () => {
       customerId: CUSTOMER_ID,
       subscriptionId: SUBSCRIPTION_ID,
       expirySec,
+    });
+  });
+
+  describe("API version drift — Stripe 2026-04-22 dahlia payload shapes", () => {
+    it("reads current_period_end from items.data[0] when top-level is missing (dahlia subscription.updated)", async () => {
+      const expirySec = nowSec() + 30 * 24 * 60 * 60;
+      const fixture = subscriptionUpdatedEventDahlia({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        status: "active",
+        cancel_at_period_end: false,
+        current_period_end: expirySec,
+      });
+      const res = await handleStripeWebhook(
+        postFixture(fixture, nowSec()),
+        makeConfig(issuer),
+      );
+      expect(res.status).toBe(200);
+      expect(issuer.recordRenewal).toHaveBeenCalledWith({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        expirySec,
+      });
+    });
+
+    it("still reads top-level current_period_end (legacy subscription.updated, regression check)", async () => {
+      const expirySec = nowSec() + 30 * 24 * 60 * 60;
+      const fixture = subscriptionUpdatedEvent({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        status: "active",
+        cancel_at_period_end: false,
+        current_period_end: expirySec,
+      });
+      const res = await handleStripeWebhook(
+        postFixture(fixture, nowSec()),
+        makeConfig(issuer),
+      );
+      expect(res.status).toBe(200);
+      expect(issuer.recordRenewal).toHaveBeenCalledWith({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        expirySec,
+      });
+    });
+
+    it("reads subscription from parent.subscription_details (dahlia invoice.paid)", async () => {
+      const expirySec = nowSec() + 30 * 24 * 60 * 60;
+      const fixture = invoicePaidEventDahlia({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        current_period_end: expirySec,
+      });
+      const res = await handleStripeWebhook(
+        postFixture(fixture, nowSec()),
+        makeConfig(issuer),
+      );
+      expect(res.status).toBe(200);
+      expect(issuer.recordRenewal).toHaveBeenCalledWith({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        expirySec,
+      });
+    });
+
+    it("still reads top-level subscription on invoice.paid (legacy regression check)", async () => {
+      const expirySec = nowSec() + 30 * 24 * 60 * 60;
+      const fixture = invoicePaidEvent({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        current_period_end: expirySec,
+      });
+      const res = await handleStripeWebhook(
+        postFixture(fixture, nowSec()),
+        makeConfig(issuer),
+      );
+      expect(res.status).toBe(200);
+      expect(issuer.recordRenewal).toHaveBeenCalledWith({
+        customerId: CUSTOMER_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        expirySec,
+      });
+    });
+  });
+
+  describe("acceptedWithIssue — silent 200 paths are surfaced via logError", () => {
+    it("logs a structured AcceptedWithIssue line when extractTier returns null (Missing tier metadata on price)", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        // Build a subscription.created fixture with no tier on the price
+        // metadata — this is the exact failure mode that bit production
+        // on 2026-05-15. The handler returns 200 (Stripe stops retrying)
+        // but should also emit a structured log so the operator sees it.
+        const event = {
+          id: "evt_no_tier_meta",
+          type: "customer.subscription.created",
+          data: {
+            object: {
+              id: SUBSCRIPTION_ID,
+              customer: CUSTOMER_ID,
+              items: { data: [{ price: { metadata: {} } }] },
+            },
+          },
+        };
+        const sigTs = nowSec();
+        const body = JSON.stringify(event);
+        const { createHmac } = await import("node:crypto");
+        const sig = createHmac("sha256", SECRET)
+          .update(`${sigTs}.${body}`)
+          .digest("hex");
+        const req = new Request(ENDPOINT, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Stripe-Signature": `t=${sigTs},v1=${sig}`,
+          },
+          body,
+        });
+        const res = await handleStripeWebhook(req, makeConfig(issuer));
+        expect(res.status).toBe(200);
+        const respBody = await res.json();
+        expect(respBody).toEqual({
+          ok: true,
+          issue: "Missing tier metadata on price",
+        });
+
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        const logged = JSON.parse(consoleError.mock.calls[0][0] as string);
+        expect(logged.route).toBe("/api/stripe/webhook");
+        expect(logged.status).toBe(200);
+        expect(logged.errClass).toBe("AcceptedWithIssue");
+        expect(logged.errMsg).toBe("Missing tier metadata on price");
+        expect(logged.traceId).toMatch(/^req_[0-9a-f]+$/);
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("does NOT log on the plain {ok:true} success path (no false positives)", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const fixture = subscriptionCreatedEvent({
+          customerId: CUSTOMER_ID,
+          subscriptionId: SUBSCRIPTION_ID,
+          tier: "personal",
+        });
+        await handleStripeWebhook(
+          postFixture(fixture, nowSec()),
+          makeConfig(issuer),
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it("does NOT log on the {ok:true, ignored: <type>} unknown-event-type path", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        const fixture = customEvent("charge.refunded");
+        await handleStripeWebhook(
+          postFixture(fixture, nowSec()),
+          makeConfig(issuer),
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes two production bugs that hit the first real customer purchase on 2026-05-15, both caused by API-field movement in the Stripe 2026-04-22.dahlia API version pinned on our live webhook.

- **invoice.paid** event 200ed with body \`{\"ok\":true,\"ignored\":\"invoice.paid without subscription\"}\` because dahlia moved \`invoice.subscription\` → \`invoice.parent.subscription_details.subscription\`.
- **customer.subscription.updated** would similarly fail at renewal because dahlia moved \`subscription.current_period_end\` → per-item \`subscription.items.data[0].current_period_end\`. Untreated, this would block every customer from sync ~31 days after issuance, even though their subscription is paid.

Plus adds observability so future silent 200s become visible.

## Changes

- **\`extractInvoiceSubscription\`** — tries dahlia path first, falls back to legacy.
- **\`extractSubscriptionCurrentPeriodEnd\`** — tries per-item first, falls back to legacy top-level.
- **\`acceptedWithIssue\` paths now emit \`logError\`** with \`errClass: \"AcceptedWithIssue\"\` so they surface in Vercel runtime logs. Status stays 200 (Stripe must stop retrying on operator-side gaps).
- New fixtures \`subscriptionUpdatedEventDahlia\` and \`invoicePaidEventDahlia\` for testing the new shapes.

## Test plan

- [x] 32 webhook-handler tests passing (was 25). New: dahlia path for subscription.updated, legacy regression for same, dahlia path for invoice.paid, legacy regression for same, log assertion on AcceptedWithIssue, no-log on plain success, no-log on ignored event.
- [x] Full unit/integration suite: 2061 passing.
- [x] \`npx tsc --noEmit\` clean.

## Manual verification (post-merge)

After production deploys, the next time Stripe fires \`customer.subscription.updated\` (e.g. user changes payment method) or \`invoice.paid\` (e.g. next renewal), our handler will correctly call \`recordRenewal\` instead of silently no-opping. If a similar API drift returns in the future, the Vercel runtime logs will show an \`AcceptedWithIssue\` entry instead of an invisible 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)