### PR TITLE
fix(sync): graceful migration dialog when paywall returns 401 license-required

### DIFF
--- a/docs/decisions/012-open-core-feature-gating.md
+++ b/docs/decisions/012-open-core-feature-gating.md
@@ -30,6 +30,25 @@ A single repo with a small, well-tested gating layer:
 | **Self-hosted** | `VITE_SELF_HOSTED=1` | hidden | bypassed | free (operator's own server) |
 | **Dev / local** | neither | hidden | tier defaults to free; coming-soon features stay locked | free |
 
+### Why two flags (`VITE_PAID_TIER_VISIBLE` + `LAUNCH_PAID_TIER`), not one
+
+They live in different process boundaries and answer different questions:
+
+| Flag | Layer | What it controls | When you flip it |
+|---|---|---|---|
+| `VITE_PAID_TIER_VISIBLE` | **Build-time** (baked into JS bundle by Vite — `import.meta.env`) | Does the **UI** show Subscribe buttons, pricing widgets, license status chip? Pure cosmetic — what users *see*. | First. Existing users see pricing but everything keeps working. |
+| `LAUNCH_PAID_TIER` | **Runtime** (server-side `process.env`) | Does `/api/sync` reject requests without a valid bearer with HTTP 401 `license required`? Hard enforcement — what users *can do*. | Second, after soak. This is the moment "free for everyone" becomes "paid required". |
+
+The two-step exists so you can ship pricing visibility and watch real funnel metrics for a day before flipping enforcement. Collapsing into one flag would forfeit that soak window.
+
+**Post-launch invariant:** both should be `=1` together. If `LAUNCH_PAID_TIER=1` without `VITE_PAID_TIER_VISIBLE=1`, existing users hit 401s with no Subscribe affordance — `SyncMigrationDialog` (the graceful migration UX) still kicks in via `pendingMigration: "license-required"`, but the user never sees a Subscribe button in the chrome.
+
+### Graceful migration off gated features
+
+Any gated feature that can fail mid-session (i.e. has a server-side enforcement path) must surface a recoverable dialog, not a raw error. `cloud-sync` does this via `pendingMigration` + `SyncMigrationDialog`. Pure client-side features (`auto-organize`) degrade in-place — the UI swaps to an Upgrade CTA, the store action toasts and no-ops. Coming-soon features never enter an error path because their code isn't shipped.
+
+Extend `PendingMigration` (currently `"license-required"`) with new discriminants when adding future server-enforced features rather than spawning sibling dialogs.
+
 ### Defense-in-depth at the store boundary
 
 The UI gate (popover offering "Upgrade — $5/mo" instead of "Organize now") is the visible path. Stores also call `gateState` at the action level (`feed-store.applyAutoOrganize`) so that programmatic callers — a future keyboard shortcut, a script in the dev console, an extension — can't bypass the UI check. On a locked action, the store no-ops and toasts.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { CHANGELOG_FEED_URL } from "@/utils/constants.ts";
 import { generatePassphrase } from "@/core/crypto/passphrase-generator.ts";
 import { Toaster } from "@/components/ui/sonner.tsx";
 import { SyncSetupDialog } from "@/components/sync/sync-setup-dialog.tsx";
+import { SyncMigrationDialog } from "@/components/sync/sync-migration-dialog.tsx";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { FeedsPage } from "@/pages/feeds-page.tsx";
 import { BillingSuccess } from "@/pages/billing-success.tsx";
@@ -164,6 +165,7 @@ export function App() {
         <Toaster position="bottom-center" />
       </BrowserRouter>
       <SyncSetupDialog />
+      <SyncMigrationDialog />
       <SpeedInsights />
     </>
   );

--- a/src/components/sync/sync-migration-dialog.tsx
+++ b/src/components/sync/sync-migration-dialog.tsx
@@ -1,0 +1,98 @@
+/**
+ * SyncMigrationDialog — graceful migration off cloud sync after the paywall.
+ *
+ * Existing cloud-sync users who open the app post-launch hit a 401 from
+ * /api/sync ("license required"). Sync store sets pendingMigration to
+ * "license-required"; this dialog renders and gives the user three
+ * non-destructive paths forward:
+ *
+ *   1. Keep reading locally — drops vault keys, switches to local-only.
+ *      The cloud vault is preserved server-side for 90 days so a future
+ *      subscribe can restore it (see Privacy page retention promise).
+ *   2. Subscribe — Personal monthly deeplink into Stripe Checkout. We
+ *      keep the existing passphrase: their vault key still works and a
+ *      successful checkout re-enables sync without re-onboarding.
+ *   3. Self-host — link to the docs; FOSS path retains every feature.
+ *
+ * Mounted once at the App level (see src/app.tsx). It is the canonical
+ * surface for graceful migration off any tier-gated feature — extend
+ * PendingMigration to cover new causes rather than spawning sibling
+ * dialogs.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useSyncStore } from "@/stores/sync-store";
+
+const SELF_HOST_GUIDE_URL = "https://www.feedzero.app/docs/self-hosting";
+
+export function SyncMigrationDialog() {
+  const pendingMigration = useSyncStore((s) => s.pendingMigration);
+  const migrateToLocalOnly = useSyncStore((s) => s.migrateToLocalOnly);
+  const dismissPendingMigration = useSyncStore(
+    (s) => s.dismissPendingMigration,
+  );
+
+  const open = pendingMigration === "license-required";
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) dismissPendingMigration();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Cloud sync is now a Personal feature</DialogTitle>
+          <DialogDescription>
+            Your reading data is safe on this device. To keep syncing across
+            devices, subscribe to Personal — or self-host FeedZero for free
+            and keep every feature.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="text-muted-foreground space-y-3 text-sm">
+          <p>
+            We&apos;ve preserved your encrypted cloud vault for{" "}
+            <strong>90 days</strong>. Subscribe within that window and your
+            existing passphrase will restore everything across devices.
+          </p>
+        </div>
+
+        <DialogFooter className="flex-col gap-2 sm:flex-col sm:items-stretch">
+          <Button asChild className="w-full">
+            <a href="/?subscribe=personal-monthly">
+              Subscribe to Personal — $5/mo
+            </a>
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={async () => {
+              await migrateToLocalOnly();
+            }}
+          >
+            Keep reading locally
+          </Button>
+          <Button asChild variant="ghost" className="w-full">
+            <a
+              href={SELF_HOST_GUIDE_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Self-host instead (free, all features)
+            </a>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/stores/sync-store.ts
+++ b/src/stores/sync-store.ts
@@ -20,6 +20,17 @@ import { ok, err } from "../utils/result.ts";
 
 export type SyncStatus = "local-only" | "syncing" | "synced" | "error";
 
+/**
+ * Why a grace-migration dialog is pending. The store sets this when a sync
+ * action fails in a way the user can recover from without losing reading
+ * data — currently only `license-required` (existing cloud-sync user opens
+ * the app after the paywall launches and the server returns 401 with
+ * `error: "license required"`). Future migration causes (e.g. unverified
+ * vault format, server-side revocation) would extend this union; the UI
+ * renders one `SyncMigrationDialog` keyed off the discriminant.
+ */
+export type PendingMigration = "license-required";
+
 const DEBOUNCE_MS = 5000;
 const MAX_JITTER_MS = 30000;
 
@@ -31,6 +42,8 @@ interface SyncStore {
   error: string | null;
   credentials: SyncCredentials | null;
   dialogOpen: boolean;
+  /** Non-null when sync hit a recoverable wall the user must decide how to handle. See PendingMigration. */
+  pendingMigration: PendingMigration | null;
 
   enableSync: (passphrase: string) => Promise<void>;
   restoreSync: (credentials: SyncCredentials) => void;
@@ -38,6 +51,17 @@ interface SyncStore {
   logout: () => Promise<void>;
   push: () => Promise<void>;
   pull: () => Promise<void>;
+  /**
+   * Switch an existing cloud-sync user to local-only WITHOUT touching the
+   * server vault. Used by the license-required migration flow — the server
+   * vault is unreachable (401), and our retention policy promises 90-day
+   * preservation, so the only safe action is local-side: drop vault keys
+   * (cloud key material), clear in-memory credentials, leave IndexedDB
+   * + DB keys intact so the user keeps reading offline.
+   */
+  migrateToLocalOnly: () => Promise<void>;
+  /** Close the migration dialog without taking any action. */
+  dismissPendingMigration: () => void;
   /**
    * Explicit "replace local with cloud" — bypasses pull's in-flight dedup
    * and the debounced push timer, then refreshes the in-memory feed and
@@ -86,12 +110,28 @@ async function deriveSyncCredentials(
   return ok({ vaultId: vaultIdResult.value, vaultKey: vaultKeyResult.value });
 }
 
+/**
+ * Detects the server's "license required" 401 in a pullVault error string.
+ * sync-handler.ts emits `{"ok":false,"error":"license required",...}` for
+ * authed endpoints when LAUNCH_PAID_TIER=1 and the request lacks a valid
+ * bearer; pullVault wraps that into `Sync pull failed (401): {...}`.
+ *
+ * Substring match (not regex) — the server payload is JSON-encoded and we
+ * only care about the human-readable error field. Future server changes
+ * to the error string need to coordinate with this matcher; see
+ * tests/stores/sync-store.test.ts for the contract.
+ */
+function isLicenseRequiredError(message: string): boolean {
+  return message.includes("license required");
+}
+
 export const useSyncStore = create<SyncStore>((set, get) => ({
   status: "local-only",
   lastSyncedAt: null,
   error: null,
   credentials: null,
   dialogOpen: false,
+  pendingMigration: null,
 
   enableSync: async (passphrase) => {
     // Derive vault keys and persist alongside existing DB keys
@@ -121,6 +161,26 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
       lastSyncedAt: Date.now(),
       error: null,
     });
+  },
+
+  migrateToLocalOnly: async () => {
+    clearPendingTimers();
+    // Intentionally do NOT call deleteVault(credentials) — the server would
+    // 401 (no license) and our retention policy promises 90-day preservation
+    // so the user can recover by subscribing later. Local-side: drop vault
+    // keys, clear credentials, keep IndexedDB + DB keys so reading continues.
+    removeVaultKeys();
+    set({
+      status: "local-only",
+      lastSyncedAt: null,
+      error: null,
+      credentials: null,
+      pendingMigration: null,
+    });
+  },
+
+  dismissPendingMigration: () => {
+    set({ pendingMigration: null });
   },
 
   disableSync: async () => {
@@ -186,7 +246,9 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
       set({ status: "syncing", error: null });
       const pullResult = await pullVault(credentials);
       if (!pullResult.ok) {
-        set({ status: "error", error: pullResult.error });
+        const pendingMigration: PendingMigration | null =
+          isLicenseRequiredError(pullResult.error) ? "license-required" : null;
+        set({ status: "error", error: pullResult.error, pendingMigration });
         return;
       }
 

--- a/tests/components/sync/sync-migration-dialog.test.tsx
+++ b/tests/components/sync/sync-migration-dialog.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { SyncMigrationDialog } from "@/components/sync/sync-migration-dialog";
+import { useSyncStore } from "@/stores/sync-store";
+
+// Minimal sync-service mocks — the dialog itself does not call sync-service,
+// but the store imports it, and importing the store at module-load triggers
+// the type wiring. Stubs keep the test isolated from the network layer.
+vi.mock("@/core/sync/sync-service", () => ({
+  pushVault: vi.fn().mockResolvedValue({ ok: true, value: Date.now() }),
+  pullVault: vi.fn().mockResolvedValue({ ok: false, error: "Not found" }),
+  importVault: vi.fn().mockResolvedValue({ ok: true, value: true }),
+  deleteVault: vi.fn().mockResolvedValue({ ok: true, value: true }),
+  exportVault: vi.fn().mockResolvedValue({ ok: true, value: {} }),
+  mergeVaults: vi.fn().mockReturnValue({ ok: true, value: {} }),
+}));
+
+vi.mock("@/core/storage/key-manager", () => ({
+  addVaultKeys: vi.fn(),
+  removeVaultKeys: vi.fn(),
+  destroyLocal: vi.fn().mockResolvedValue(undefined),
+  rekeyFromPassphrase: vi.fn(),
+}));
+
+vi.mock("@/core/sync/vault-crypto", () => ({
+  deriveVaultId: vi.fn(),
+  deriveVaultKey: vi.fn(),
+}));
+
+function renderDialog() {
+  return render(
+    <MemoryRouter>
+      <SyncMigrationDialog />
+    </MemoryRouter>,
+  );
+}
+
+describe("SyncMigrationDialog", () => {
+  beforeEach(() => {
+    useSyncStore.setState({
+      status: "local-only",
+      credentials: null,
+      pendingMigration: null,
+      error: null,
+    });
+  });
+
+  it("renders nothing when pendingMigration is null", () => {
+    renderDialog();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens the dialog when pendingMigration === 'license-required'", () => {
+    useSyncStore.setState({ pendingMigration: "license-required" });
+    renderDialog();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // Headline communicates the new reality, not a generic error
+    expect(
+      screen.getByText(/cloud sync .* (paid|personal)/i),
+    ).toBeInTheDocument();
+  });
+
+  it("informs the user that the cloud vault is preserved for 90 days", () => {
+    useSyncStore.setState({ pendingMigration: "license-required" });
+    renderDialog();
+    expect(screen.getByText(/90 days/i)).toBeInTheDocument();
+  });
+
+  it("'Keep reading locally' calls migrateToLocalOnly and clears pendingMigration", async () => {
+    const user = userEvent.setup();
+    useSyncStore.setState({ pendingMigration: "license-required" });
+    renderDialog();
+
+    await user.click(
+      screen.getByRole("button", { name: /keep reading locally/i }),
+    );
+
+    expect(useSyncStore.getState().pendingMigration).toBeNull();
+    expect(useSyncStore.getState().status).toBe("local-only");
+    expect(useSyncStore.getState().credentials).toBeNull();
+  });
+
+  it("offers a Subscribe link pointing at the Personal monthly deeplink", () => {
+    useSyncStore.setState({ pendingMigration: "license-required" });
+    renderDialog();
+    const subscribe = screen.getByRole("link", { name: /subscribe/i });
+    // Deeplink consumer parses ?subscribe=personal-monthly and routes to Stripe.
+    expect(subscribe.getAttribute("href")).toMatch(
+      /subscribe=personal-monthly/,
+    );
+  });
+
+  it("offers a Self-host link pointing at the docs", () => {
+    useSyncStore.setState({ pendingMigration: "license-required" });
+    renderDialog();
+    const selfHost = screen.getByRole("link", { name: /self-host/i });
+    const href = selfHost.getAttribute("href") || "";
+    expect(href).toMatch(/feedzero\.app|github\.com|self-host/i);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,42 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+// Node 22+ ships an experimental `localStorage` global that is `undefined`
+// unless launched with `--localstorage-file`. Defined as a non-configurable
+// accessor on globalThis, it blocks vitest's happy-dom environment from
+// copying `window.localStorage` onto the global scope. Bare `localStorage.x`
+// calls in tests (e.g. tests/stores/license-store.test.ts) therefore
+// resolve to Node's undefined global instead of happy-dom's Storage.
+//
+// Plain assignment goes through Node's setter (no-op). defineProperty
+// replaces the descriptor outright. We install a minimal in-memory shim
+// rather than reaching into happy-dom internals, because vitest's env
+// also drops `window.localStorage` for the same reason — there is nothing
+// reliable to bridge from.
+class InMemoryStorage implements Storage {
+  private store: Record<string, string> = {};
+  get length(): number { return Object.keys(this.store).length; }
+  clear(): void { this.store = {}; }
+  getItem(key: string): string | null { return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null; }
+  setItem(key: string, value: string): void { this.store[key] = String(value); }
+  removeItem(key: string): void { delete this.store[key]; }
+  key(index: number): string | null { return Object.keys(this.store)[index] ?? null; }
+}
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  Object.defineProperty(globalThis, name, {
+    value: new InMemoryStorage(),
+    writable: true,
+    configurable: true,
+  });
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, name, {
+      value: (globalThis as unknown as Record<string, Storage>)[name],
+      writable: true,
+      configurable: true,
+    });
+  }
+}
+
 afterEach(() => {
   cleanup();
 });

--- a/tests/stores/sync-store.test.ts
+++ b/tests/stores/sync-store.test.ts
@@ -212,6 +212,89 @@ describe("sync-store", () => {
     });
   });
 
+  describe("license-required migration (existing cloud-sync user post-paywall)", () => {
+    it("sets pendingMigration='license-required' when pull returns a 401 license-required error", async () => {
+      mockPullVault.mockResolvedValue({
+        ok: false,
+        error: 'Sync pull failed (401): {"ok":false,"error":"license required","traceId":"req_be627fd1"}',
+      });
+      useSyncStore.setState({
+        credentials: mockCredentials,
+        pendingMigration: null,
+      });
+
+      await useSyncStore.getState().pull();
+
+      expect(useSyncStore.getState().pendingMigration).toBe("license-required");
+      expect(useSyncStore.getState().status).toBe("error");
+    });
+
+    it("does NOT set pendingMigration for non-license pull failures (network errors etc.)", async () => {
+      mockPullVault.mockResolvedValue({
+        ok: false,
+        error: "Sync pull failed: fetch error",
+      });
+      useSyncStore.setState({
+        credentials: mockCredentials,
+        pendingMigration: null,
+      });
+
+      await useSyncStore.getState().pull();
+
+      expect(useSyncStore.getState().pendingMigration).toBeNull();
+      expect(useSyncStore.getState().status).toBe("error");
+    });
+
+    it("migrateToLocalOnly clears credentials, sets status=local-only, and clears pendingMigration", async () => {
+      useSyncStore.setState({
+        credentials: mockCredentials,
+        status: "error",
+        pendingMigration: "license-required",
+        error: "license required",
+      });
+
+      await useSyncStore.getState().migrateToLocalOnly();
+
+      const s = useSyncStore.getState();
+      expect(s.credentials).toBeNull();
+      expect(s.status).toBe("local-only");
+      expect(s.pendingMigration).toBeNull();
+      expect(s.error).toBeNull();
+    });
+
+    it("migrateToLocalOnly does NOT attempt to delete the server vault (policy: 90-day retention)", async () => {
+      useSyncStore.setState({
+        credentials: mockCredentials,
+        pendingMigration: "license-required",
+      });
+
+      await useSyncStore.getState().migrateToLocalOnly();
+
+      // The server vault delete would 401 anyway (no license) — skipping it
+      // is the whole point. Privacy policy promises 90-day retention then
+      // auto-delete by our retention cron (separate ops surface).
+      expect(mockDeleteVault).not.toHaveBeenCalled();
+    });
+
+    it("dismissPendingMigration clears the flag without changing sync state (user dismissed dialog without choosing)", async () => {
+      useSyncStore.setState({
+        credentials: mockCredentials,
+        status: "error",
+        pendingMigration: "license-required",
+        error: "license required",
+      });
+
+      useSyncStore.getState().dismissPendingMigration();
+
+      const s = useSyncStore.getState();
+      expect(s.pendingMigration).toBeNull();
+      // sync state untouched — user just closed the modal. The dialog can
+      // re-appear on the next pull attempt (which will still 401).
+      expect(s.credentials).toBe(mockCredentials);
+      expect(s.status).toBe("error");
+    });
+  });
+
   describe("forceResync", () => {
     it("returns err when no credentials are set", async () => {
       useSyncStore.setState({ credentials: null });


### PR DESCRIPTION
## Summary

Existing cloud-sync users opening the app after `LAUNCH_PAID_TIER=1` flipped on hit `Sync pull failed (401): license required` and got stuck — no path to switch to local, no path to subscribe. This PR adds the graceful-migration dialog the user [explicitly requested](https://my.feedzero.app).

- **sync-store**: detects `"license required"` in pull errors and raises `pendingMigration: "license-required"`; adds `migrateToLocalOnly()` (drops vault keys, keeps DB keys + IndexedDB, **skips** server delete because the 90-day retention policy covers recovery on re-subscribe) and `dismissPendingMigration()`.
- **`<SyncMigrationDialog>`**: three CTAs — *Subscribe to Personal — \$5/mo*, *Keep reading locally*, *Self-host instead*. Informs about the 90-day cloud retention window. Mounted at App level alongside `SyncSetupDialog`.
- **ADR 012**: documents why we keep both `VITE_PAID_TIER_VISIBLE` (UI cosmetic, build-time) and `LAUNCH_PAID_TIER` (server enforcement, runtime) — the soak window between pricing-visible and enforcement-on is valuable. Records the graceful-migration pattern so future server-enforced gated features extend `PendingMigration` rather than spawning sibling dialogs.
- **tests/setup.ts**: in-memory `Storage` shim works around a Node 22 + happy-dom + vitest interaction where `localStorage` was undefined in tests. Unblocks 10 previously-failing baseline tests in `license-store.test.ts`.

## Test plan
- [x] `npm test` — 2104 passing, 0 failing (was 2094 / 10 failing)
- [x] `npx tsc --noEmit` — clean
- [x] 4 new sync-store tests cover license-required vs other failure paths, no-server-delete invariant, and dismiss semantics
- [x] 6 new `SyncMigrationDialog` tests verify dialog binds to `pendingMigration`, all three CTAs wire correctly, 90-day retention message renders
- [ ] **Manual smoke after deploy**: in production with a free account on a device that previously had cloud sync, confirm dialog appears, "Keep reading locally" transitions to local-only mode without errors, subscribe link goes to Stripe Checkout
- [ ] **Privacy page**: confirm 90-day retention promise is documented (existing language) so the dialog copy isn't writing a new policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)