### PR TITLE
feat(free-tier): 25-feed quota + sidebar indicator + OPML refusal + stats self-host tolerance

### DIFF
--- a/src/components/feeds/quota-indicator.tsx
+++ b/src/components/feeds/quota-indicator.tsx
@@ -1,0 +1,49 @@
+/**
+ * Free-tier quota footer for the sidebar.
+ *
+ * Renders only for hosted Free users. Paid users and self-hosters see
+ * nothing — the cap doesn't apply to them, and a quota chip would be
+ * visual noise. At or above the cap, the indicator surfaces an Upgrade
+ * link pointing at the Personal monthly deeplink so the user can convert
+ * inline without leaving the sidebar.
+ *
+ * Reads tier from `useLicenseStore` and the feed count from `useFeedStore`
+ * so it stays in sync with adds/removes without prop drilling.
+ */
+
+import { useFeedStore } from "@/stores/feed-store";
+import { useLicenseStore } from "@/stores/license-store";
+import { isSelfHosted } from "@/core/features/self-hosted";
+import { FREE_FEED_LIMIT } from "@/core/features/quotas";
+import { cn } from "@/lib/utils";
+
+export function QuotaIndicator() {
+  const tier = useLicenseStore((s) => s.tier);
+  const count = useFeedStore((s) => s.feeds.length);
+
+  if (tier !== "free") return null;
+  if (isSelfHosted()) return null;
+
+  const atOrOverLimit = count >= FREE_FEED_LIMIT;
+
+  return (
+    <div
+      className={cn(
+        "text-muted-foreground border-sidebar-border flex items-center justify-between border-t px-3 py-2 text-xs",
+        atOrOverLimit && "text-destructive",
+      )}
+    >
+      <span>
+        {count} / {FREE_FEED_LIMIT} feeds
+      </span>
+      {atOrOverLimit && (
+        <a
+          href="/?subscribe=personal-monthly"
+          className="text-primary font-medium hover:underline"
+        >
+          Upgrade
+        </a>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -32,6 +32,7 @@ import { Kbd } from "@/components/ui/kbd.tsx";
 import { useIsOnline } from "@/hooks/use-online.ts";
 import { SettingsMenu } from "@/components/settings/settings-menu.tsx";
 import { SidebarBody } from "@/components/layout/sidebar-body.tsx";
+import { QuotaIndicator } from "@/components/feeds/quota-indicator.tsx";
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onFeedSelect?: (feedId: string) => void;
@@ -240,6 +241,7 @@ export function AppSidebar({ onFeedSelect, ...props }: AppSidebarProps) {
         </SidebarContent>
 
         <SidebarFooter>
+          <QuotaIndicator />
           <LocalStorageWarning />
           <SidebarMenu>
             <SidebarMenuItem>

--- a/src/components/settings/import-view.tsx
+++ b/src/components/settings/import-view.tsx
@@ -13,6 +13,9 @@ import {
   selectCurrentUrl,
 } from "@/stores/import-store";
 import { useFeedStore } from "@/stores/feed-store";
+import { useLicenseStore } from "@/stores/license-store";
+import { isSelfHosted } from "@/core/features/self-hosted";
+import { checkFeedQuota, quotaErrorMessage } from "@/core/features/quotas";
 import { ImportProgress } from "./import-progress";
 import { ImportResults } from "./import-results";
 
@@ -98,6 +101,20 @@ export function ImportView({ onClose }: ImportViewProps) {
       const urls = await extractUrls(content);
       if (urls.length === 0) {
         setParseError("No valid feed URLs found");
+        return;
+      }
+
+      // Upfront quota check. The feed-store also gates per-URL, but doing
+      // it once here lets us refuse cleanly before kicking off a loop that
+      // would partially succeed and surface N cryptic per-URL failures.
+      const quota = checkFeedQuota({
+        currentCount: useFeedStore.getState().feeds.length,
+        delta: urls.length,
+        tier: useLicenseStore.getState().tier,
+        isSelfHosted: isSelfHosted(),
+      });
+      if (!quota.ok) {
+        setParseError(quotaErrorMessage(quota));
         return;
       }
 

--- a/src/components/stats/stats-page.tsx
+++ b/src/components/stats/stats-page.tsx
@@ -145,18 +145,22 @@ function ErrorState() {
 }
 
 async function loadAll(): Promise<StatsData> {
+  // /api/stats-sync is the only required endpoint — vault count is meaningful
+  // local data that every deployment can resolve. The catalog endpoints are
+  // optional: self-hosters who don't wire the Upstash catalog adapter get
+  // 404s, and the page should still render rather than show a hard error.
   const [popular, count, sync] = await Promise.all([
-    fetchJson<{ ok: boolean; feeds?: CatalogFeedDTO[]; error?: string }>(
+    fetchJsonOptional<{ ok: boolean; feeds?: CatalogFeedDTO[]; error?: string }>(
       `/api/catalog?action=popular&limit=${TOP_FEED_LIMIT}`,
     ),
-    fetchJson<{ ok: boolean; count?: number; error?: string }>(`/api/catalog?action=count`),
+    fetchJsonOptional<{ ok: boolean; count?: number; error?: string }>(`/api/catalog?action=count`),
     fetchJson<{ ok: boolean; vaults?: number; error?: string }>(`/api/stats-sync`),
   ]);
-  if (!popular.ok || !count.ok || !sync.ok) throw new Error("stats endpoint failed");
+  if (!sync.ok) throw new Error("stats endpoint failed");
   return {
     vaults: sync.vaults ?? 0,
-    totalFeeds: count.count ?? 0,
-    topFeeds: popular.feeds ?? [],
+    totalFeeds: count?.count ?? 0,
+    topFeeds: popular?.feeds ?? [],
   };
 }
 
@@ -164,6 +168,18 @@ async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return (await res.json()) as T;
+}
+
+/** Returns null on any error — for endpoints whose absence should be a soft
+ * degradation, not a hard failure. */
+async function fetchJsonOptional<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
 }
 
 function hostFromUrl(url: string): string {

--- a/src/core/features/quotas.ts
+++ b/src/core/features/quotas.ts
@@ -1,0 +1,75 @@
+/**
+ * Quota gating — currently the 25-feed cap on hosted Free.
+ *
+ * Distinct from `feature-gates.ts` because quotas are continuous (a count
+ * compared against a limit) rather than binary (do I have this capability).
+ * Both modules share the same `Tier` model from license-store and the same
+ * self-hosted bypass from `self-hosted.ts`.
+ *
+ * Honor-system enforcement: the server cannot read decrypted feed count out
+ * of the zero-knowledge sync vault, so the limit lives in the client. A
+ * determined user could fork and strip the gate, which is effectively
+ * self-hosting; the price-vs-friction calculus resolves the same way (see
+ * ADR 012 for the open-core rationale).
+ */
+
+import type { Tier } from "./feature-gates";
+
+/** Maximum feed subscriptions on hosted Free tier. */
+export const FREE_FEED_LIMIT = 25;
+
+export type QuotaCheck =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "free-quota-exceeded";
+      limit: number;
+      current: number;
+      delta: number;
+    };
+
+export interface FeedQuotaArgs {
+  /** Current feed count on the user's account. */
+  currentCount: number;
+  /** Number of feeds about to be added (1 for addFeed, N for OPML import). */
+  delta?: number;
+  tier: Tier;
+  isSelfHosted: boolean;
+}
+
+/**
+ * Decide whether adding `delta` (default 1) more feeds is allowed under the
+ * current tier and self-hosted state.
+ *
+ * Returns `ok: true` when:
+ *  - the user is on a paid tier (personal or pro),
+ *  - the user is self-hosted (the FREE_FEED_LIMIT cap doesn't apply to
+ *    operators running their own server), or
+ *  - the total after the add is at or below FREE_FEED_LIMIT.
+ *
+ * Returns a structured error otherwise so the UI can render an Upgrade prompt
+ * with the actual numbers.
+ */
+export function checkFeedQuota(args: FeedQuotaArgs): QuotaCheck {
+  const delta = args.delta ?? 1;
+  if (args.tier !== "free") return { ok: true };
+  if (args.isSelfHosted) return { ok: true };
+  if (args.currentCount + delta > FREE_FEED_LIMIT) {
+    return {
+      ok: false,
+      reason: "free-quota-exceeded",
+      limit: FREE_FEED_LIMIT,
+      current: args.currentCount,
+      delta,
+    };
+  }
+  return { ok: true };
+}
+
+/** Human-readable quota error message for surfaces that need it inline. */
+export function quotaErrorMessage(check: Exclude<QuotaCheck, { ok: true }>): string {
+  if (check.delta === 1) {
+    return `You've reached the Free limit of ${check.limit} feeds. Subscribe to Personal for unlimited, or self-host with VITE_SELF_HOSTED=1.`;
+  }
+  return `Importing ${check.delta} feeds would exceed the Free limit of ${check.limit} (you have ${check.current}). Subscribe to Personal for unlimited, or self-host with VITE_SELF_HOSTED=1.`;
+}

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -20,6 +20,7 @@ import { useArticleStore } from "./article-store.ts";
 import { useLicenseStore } from "./license-store.ts";
 import { gateState } from "../core/features/feature-gates.ts";
 import { isSelfHosted } from "../core/features/self-hosted.ts";
+import { checkFeedQuota, quotaErrorMessage } from "../core/features/quotas.ts";
 import { CHANGELOG_FEED_URL, LOCAL_STORAGE } from "../utils/constants.ts";
 import { pickNextFolderColor } from "../lib/folder-colors.ts";
 import { toast } from "sonner";
@@ -112,6 +113,20 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
   },
 
   addFeed: async (url) => {
+    // Free hosted users are capped at 25 feed subscriptions (ADR 013).
+    // Personal/Pro and self-hosted bypass. Check BEFORE touching the
+    // ingestion pipeline so we don't half-add a feed then fail late.
+    const quota = checkFeedQuota({
+      currentCount: get().feeds.length,
+      tier: useLicenseStore.getState().tier,
+      isSelfHosted: isSelfHosted(),
+    });
+    if (!quota.ok) {
+      const message = quotaErrorMessage(quota);
+      set({ error: message });
+      return { ok: false, error: message } as const;
+    }
+
     set({ isLoading: true, error: null });
     const result = await addFeedFlow(url);
     if (!result.ok) {

--- a/tests/components/feeds/quota-indicator.test.tsx
+++ b/tests/components/feeds/quota-indicator.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QuotaIndicator } from "@/components/feeds/quota-indicator";
+import { useFeedStore } from "@/stores/feed-store";
+import { useLicenseStore } from "@/stores/license-store";
+
+vi.mock("@/core/features/self-hosted", () => ({
+  isSelfHosted: vi.fn(() => false),
+}));
+
+import { isSelfHosted } from "@/core/features/self-hosted";
+
+function renderInRouter() {
+  return render(
+    <MemoryRouter>
+      <QuotaIndicator />
+    </MemoryRouter>,
+  );
+}
+
+function seedFeeds(count: number): void {
+  const feeds = Array.from({ length: count }, (_, i) => ({
+    id: `feed-${i}`,
+    url: `https://example.com/${i}.xml`,
+    title: `Feed ${i}`,
+    description: "",
+    lastUpdated: 0,
+  }));
+  useFeedStore.setState({
+    feeds: feeds as never,
+    selectedFeedId: null,
+    isLoading: false,
+    error: null,
+  });
+}
+
+describe("QuotaIndicator", () => {
+  beforeEach(() => {
+    seedFeeds(0);
+    useLicenseStore.setState({ tier: "free", verifying: false });
+    vi.mocked(isSelfHosted).mockReturnValue(false);
+  });
+
+  it("renders nothing for paid users (no quota applies)", () => {
+    useLicenseStore.setState({ tier: "personal", verifying: false });
+    seedFeeds(12);
+    const { container } = renderInRouter();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for self-hosted users (operator bypass)", () => {
+    vi.mocked(isSelfHosted).mockReturnValue(true);
+    seedFeeds(40);
+    const { container } = renderInRouter();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the current count vs limit for free hosted users", () => {
+    seedFeeds(7);
+    renderInRouter();
+    // Tolerant of "7 / 25", "7 of 25", "7 / 25 feeds" etc.
+    expect(screen.getByText(/\b7\b/)).toBeInTheDocument();
+    expect(screen.getByText(/25/)).toBeInTheDocument();
+  });
+
+  it("offers an Upgrade link when at or above the limit", () => {
+    seedFeeds(25);
+    renderInRouter();
+    const upgrade = screen.getByRole("link", { name: /upgrade/i });
+    expect(upgrade.getAttribute("href")).toMatch(/subscribe=personal-monthly/);
+  });
+
+  it("does not offer an Upgrade link below the limit", () => {
+    seedFeeds(20);
+    renderInRouter();
+    expect(screen.queryByRole("link", { name: /upgrade/i })).toBeNull();
+  });
+});

--- a/tests/components/settings/import-view-quota.test.tsx
+++ b/tests/components/settings/import-view-quota.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Quota refusal for OPML / URL-list import.
+ *
+ * The feed-store already gates addFeed per-URL — but for a 30-URL OPML on a
+ * free user at 0 feeds, that means the user gets 25 successes + 5 cryptic
+ * "limit exceeded" failures. ImportView pre-checks the total upfront and
+ * refuses with a clear error before kicking off the loop.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImportView } from "@/components/settings/import-view";
+import { useFeedStore } from "@/stores/feed-store";
+import { useLicenseStore } from "@/stores/license-store";
+import { useImportStore } from "@/stores/import-store";
+
+vi.mock("@/core/features/self-hosted", () => ({
+  isSelfHosted: vi.fn(() => false),
+}));
+
+vi.mock("@/core/opml/url-list-parser", async () => {
+  const actual = await vi.importActual<typeof import("@/core/opml/url-list-parser")>(
+    "@/core/opml/url-list-parser",
+  );
+  return actual;
+});
+
+function seedFreeFeeds(count: number): void {
+  const feeds = Array.from({ length: count }, (_, i) => ({
+    id: `feed-${i}`,
+    url: `https://example.com/${i}.xml`,
+    title: `Feed ${i}`,
+    description: "",
+    lastUpdated: 0,
+  }));
+  useFeedStore.setState({
+    feeds: feeds as never,
+    selectedFeedId: null,
+    isLoading: false,
+    error: null,
+  });
+}
+
+describe("ImportView quota refusal", () => {
+  let addFeedMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    useLicenseStore.setState({ tier: "free", verifying: false });
+    seedFreeFeeds(20);
+    addFeedMock = vi.fn().mockResolvedValue({ ok: true });
+    useFeedStore.setState({ addFeed: addFeedMock } as never);
+    // import-store progresses to a "complete" view after a successful import;
+    // leaving that state would render the results panel instead of the form
+    // on the next test's render. Reset between tests.
+    useImportStore.getState().reset();
+  });
+
+  it("refuses upfront when URL list would push total past the free-tier cap, without calling addFeed", async () => {
+    const user = userEvent.setup();
+    render(<ImportView onClose={() => {}} />);
+
+    // Switch to text-input mode so we can paste a URL list synchronously.
+    await user.click(screen.getByLabelText(/paste text/i));
+
+    const ten = Array.from(
+      { length: 10 },
+      (_, i) => `https://example.com/import-${i}.xml`,
+    ).join("\n");
+    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    await user.click(textarea);
+    await user.paste(ten);
+
+    await user.click(screen.getByRole("button", { name: /import feeds/i }));
+
+    // Tolerant of "exceed", "limit", "25"; what matters is that the user is
+    // told why and no addFeed call sneaks through.
+    expect(
+      await screen.findByText(/limit|exceed|25/i),
+    ).toBeInTheDocument();
+    expect(addFeedMock).not.toHaveBeenCalled();
+  });
+
+  it("imports normally when the count fits within the cap", async () => {
+    const user = userEvent.setup();
+    seedFreeFeeds(20);
+    useFeedStore.setState({ addFeed: addFeedMock } as never);
+    render(<ImportView onClose={() => {}} />);
+
+    await user.click(screen.getByLabelText(/paste text/i));
+    const four = Array.from(
+      { length: 4 },
+      (_, i) => `https://example.com/fits-${i}.xml`,
+    ).join("\n");
+    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    await user.click(textarea);
+    await user.paste(four);
+
+    await user.click(screen.getByRole("button", { name: /import feeds/i }));
+
+    // 20 + 4 = 24, under the 25 cap — addFeed runs for each URL.
+    expect(addFeedMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("allows large imports for paid users (cap doesn't apply)", async () => {
+    const user = userEvent.setup();
+    useLicenseStore.setState({ tier: "personal", verifying: false });
+    seedFreeFeeds(20);
+    useFeedStore.setState({ addFeed: addFeedMock } as never);
+    render(<ImportView onClose={() => {}} />);
+
+    await user.click(screen.getByLabelText(/paste text/i));
+    const fifty = Array.from(
+      { length: 50 },
+      (_, i) => `https://example.com/paid-${i}.xml`,
+    ).join("\n");
+    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    await user.click(textarea);
+    await user.paste(fifty);
+
+    await user.click(screen.getByRole("button", { name: /import feeds/i }));
+
+    expect(addFeedMock).toHaveBeenCalledTimes(50);
+  });
+});

--- a/tests/components/stats/stats-page.test.tsx
+++ b/tests/components/stats/stats-page.test.tsx
@@ -123,6 +123,27 @@ describe("StatsPage", () => {
     });
   });
 
+  it("degrades gracefully when /api/catalog is missing (self-hosted mode without catalog backend)", async () => {
+    // Self-hosters who haven't wired Upstash catalog storage get 404s on
+    // /api/catalog/*. The page should still render the local stats it CAN
+    // resolve (vault count) instead of bricking the whole route.
+    globalThis.fetch = vi.fn(async (input: unknown) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/stats-sync")) {
+        return new Response(JSON.stringify({ ok: true, vaults: 7 }), { status: 200 });
+      }
+      // /api/catalog/* — not configured in this deployment
+      return new Response(JSON.stringify({ ok: false, error: "not configured" }), { status: 404 });
+    });
+    renderStats();
+    await waitFor(() => {
+      // Vault count still renders
+      expect(screen.getByText(/7/)).toBeInTheDocument();
+    });
+    // No "Couldn't load stats" hard error
+    expect(screen.queryByTestId("stats-error")).toBeNull();
+  });
+
   it("renders a loading state initially", async () => {
     let resolvePopular: (value: Response) => void;
     globalThis.fetch = vi.fn(async (input) => {

--- a/tests/core/features/quotas.test.ts
+++ b/tests/core/features/quotas.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  FREE_FEED_LIMIT,
+  checkFeedQuota,
+  quotaErrorMessage,
+} from "@/core/features/quotas";
+
+describe("checkFeedQuota", () => {
+  describe("free tier (hosted)", () => {
+    it("allows adds when under the limit", () => {
+      const result = checkFeedQuota({
+        currentCount: 10,
+        tier: "free",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("allows the exact boundary add (24 → 25)", () => {
+      const result = checkFeedQuota({
+        currentCount: FREE_FEED_LIMIT - 1,
+        tier: "free",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("blocks the add that would cross the limit (25 → 26)", () => {
+      const result = checkFeedQuota({
+        currentCount: FREE_FEED_LIMIT,
+        tier: "free",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("free-quota-exceeded");
+        expect(result.limit).toBe(FREE_FEED_LIMIT);
+        expect(result.current).toBe(FREE_FEED_LIMIT);
+        expect(result.delta).toBe(1);
+      }
+    });
+
+    it("blocks bulk imports that would exceed the limit", () => {
+      // User has 20, importing 10 more would land at 30
+      const result = checkFeedQuota({
+        currentCount: 20,
+        delta: 10,
+        tier: "free",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.delta).toBe(10);
+      }
+    });
+
+    it("allows bulk imports that land exactly at the limit", () => {
+      const result = checkFeedQuota({
+        currentCount: 15,
+        delta: 10,
+        tier: "free",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("blocks adds even at zero count if delta exceeds limit", () => {
+      const result = checkFeedQuota({
+        currentCount: 0,
+        delta: 100,
+        tier: "free",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("personal tier", () => {
+    it("allows adds with no count limit", () => {
+      const result = checkFeedQuota({
+        currentCount: 5000,
+        tier: "personal",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("allows bulk imports with no count limit", () => {
+      const result = checkFeedQuota({
+        currentCount: 100,
+        delta: 1000,
+        tier: "personal",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("pro tier", () => {
+    it("allows adds with no count limit", () => {
+      const result = checkFeedQuota({
+        currentCount: 5000,
+        tier: "pro",
+        isSelfHosted: false,
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("self-hosted bypass", () => {
+    it("allows adds for self-hosted Free user with high count", () => {
+      const result = checkFeedQuota({
+        currentCount: 5000,
+        tier: "free",
+        isSelfHosted: true,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("allows self-hosted bulk imports of any size", () => {
+      const result = checkFeedQuota({
+        currentCount: 0,
+        delta: 10000,
+        tier: "free",
+        isSelfHosted: true,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("paid + self-hosted is still unlimited (precedence doesn't matter)", () => {
+      const result = checkFeedQuota({
+        currentCount: 999,
+        tier: "personal",
+        isSelfHosted: true,
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+});
+
+describe("quotaErrorMessage", () => {
+  it("formats a single-add message", () => {
+    const msg = quotaErrorMessage({
+      ok: false,
+      reason: "free-quota-exceeded",
+      limit: 25,
+      current: 25,
+      delta: 1,
+    });
+    expect(msg).toContain("25 feeds");
+    expect(msg).toContain("Personal");
+    expect(msg).toContain("self-host");
+  });
+
+  it("formats a bulk-import message naming the import size", () => {
+    const msg = quotaErrorMessage({
+      ok: false,
+      reason: "free-quota-exceeded",
+      limit: 25,
+      current: 10,
+      delta: 20,
+    });
+    expect(msg).toContain("Importing 20 feeds");
+    expect(msg).toContain("you have 10");
+    expect(msg).toContain("Personal");
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,42 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+// Node 22+ ships an experimental `localStorage` global that is `undefined`
+// unless launched with `--localstorage-file`. Defined as a non-configurable
+// accessor on globalThis, it blocks vitest's happy-dom environment from
+// copying `window.localStorage` onto the global scope. Bare `localStorage.x`
+// calls in tests (e.g. tests/stores/license-store.test.ts) therefore
+// resolve to Node's undefined global instead of happy-dom's Storage.
+//
+// Plain assignment goes through Node's setter (no-op). defineProperty
+// replaces the descriptor outright. We install a minimal in-memory shim
+// rather than reaching into happy-dom internals, because vitest's env
+// also drops `window.localStorage` for the same reason — there is nothing
+// reliable to bridge from.
+class InMemoryStorage implements Storage {
+  private store: Record<string, string> = {};
+  get length(): number { return Object.keys(this.store).length; }
+  clear(): void { this.store = {}; }
+  getItem(key: string): string | null { return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null; }
+  setItem(key: string, value: string): void { this.store[key] = String(value); }
+  removeItem(key: string): void { delete this.store[key]; }
+  key(index: number): string | null { return Object.keys(this.store)[index] ?? null; }
+}
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  Object.defineProperty(globalThis, name, {
+    value: new InMemoryStorage(),
+    writable: true,
+    configurable: true,
+  });
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, name, {
+      value: (globalThis as unknown as Record<string, Storage>)[name],
+      writable: true,
+      configurable: true,
+    });
+  }
+}
+
 afterEach(() => {
   cleanup();
 });

--- a/tests/stores/feed-store.test.ts
+++ b/tests/stores/feed-store.test.ts
@@ -204,6 +204,95 @@ describe("feed-store", () => {
 
       expect(result).toEqual({ ok: true, value: undefined });
     });
+
+    describe("Free quota gate (hard cutover at 25 feeds)", () => {
+      function seedFeeds(n: number) {
+        const feeds = Array.from({ length: n }, (_, i) =>
+          mockFeed(`f${i}`, `Feed ${i}`),
+        );
+        useFeedStore.setState({ feeds });
+      }
+
+      it("blocks addFeed on hosted Free when already at 25 feeds", async () => {
+        useLicenseStore.setState({ tier: "free", verifying: false });
+        seedFeeds(25);
+
+        const result = await useFeedStore
+          .getState()
+          .addFeed("https://new.com/feed");
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error).toMatch(/Free limit of 25/);
+        }
+        expect(addFeedFlow).not.toHaveBeenCalled();
+      });
+
+      it("allows addFeed on hosted Free at 24 feeds (boundary)", async () => {
+        useLicenseStore.setState({ tier: "free", verifying: false });
+        seedFeeds(24);
+        const feed = mockFeed("new", "New Feed");
+        vi.mocked(addFeedFlow).mockResolvedValue({
+          ok: true,
+          value: { feed, articles: [] },
+        });
+        vi.mocked(getFeeds).mockResolvedValue({
+          ok: true,
+          value: [...useFeedStore.getState().feeds, feed],
+        });
+
+        const result = await useFeedStore
+          .getState()
+          .addFeed("https://new.com/feed");
+
+        expect(result.ok).toBe(true);
+        expect(addFeedFlow).toHaveBeenCalledOnce();
+      });
+
+      it("does NOT block Personal user with 100 feeds", async () => {
+        useLicenseStore.setState({ tier: "personal", verifying: false });
+        seedFeeds(100);
+        const feed = mockFeed("new", "New Feed");
+        vi.mocked(addFeedFlow).mockResolvedValue({
+          ok: true,
+          value: { feed, articles: [] },
+        });
+        vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [feed] });
+
+        const result = await useFeedStore
+          .getState()
+          .addFeed("https://new.com/feed");
+
+        expect(result.ok).toBe(true);
+      });
+
+      it("does NOT block self-hosted Free user with 100 feeds", async () => {
+        useLicenseStore.setState({ tier: "free", verifying: false });
+        vi.mocked(isSelfHosted).mockReturnValue(true);
+        seedFeeds(100);
+        const feed = mockFeed("new", "New Feed");
+        vi.mocked(addFeedFlow).mockResolvedValue({
+          ok: true,
+          value: { feed, articles: [] },
+        });
+        vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [feed] });
+
+        const result = await useFeedStore
+          .getState()
+          .addFeed("https://new.com/feed");
+
+        expect(result.ok).toBe(true);
+      });
+
+      it("sets store.error so a Settings indicator can render the quota warning", async () => {
+        useLicenseStore.setState({ tier: "free", verifying: false });
+        seedFeeds(25);
+
+        await useFeedStore.getState().addFeed("https://new.com/feed");
+
+        expect(useFeedStore.getState().error).toMatch(/Free limit of 25/);
+      });
+    });
   });
 
   describe("removeFeed", () => {


### PR DESCRIPTION
## Summary

Completes the free-tier launch posture: enforces the 25-feed cap users see on the new /pricing page, surfaces the count + Upgrade affordance in the sidebar, refuses OPML imports that would exceed the cap upfront, and makes the Stats page tolerant of missing /api/catalog for self-hosters.

- **\`src/core/features/quotas.ts\`** + tests — pure \`checkFeedQuota({currentCount, delta, tier, isSelfHosted})\` with structured error and the friendly message helper. Free tier only; paid + self-hosted are exempt.
- **\`feed-store.addFeed\`** — pre-gates the network round-trip. Existing behavior; no change to non-Free callers.
- **\`<QuotaIndicator>\`** — sidebar footer chip. Hidden for paid + self-hosted. Below cap: \`N / 25 feeds\`. At-or-over cap: link to \`?subscribe=personal-monthly\`.
- **\`ImportView\`** — pre-checks the proposed delta against the cap before kicking off the addFeed loop. Without this, a 30-URL OPML on an empty free account would 25-succeed-then-5-fail with cryptic per-URL errors.
- **\`StatsPage\`** — \`/api/catalog\` endpoints are now treated as optional (popular feeds + total feeds). \`/api/stats-sync\` (vault count) remains required. Self-hosters who haven't wired Upstash catalog storage see a working stats page instead of \`Couldn't load stats\`.

Companion landing-repo PR adds the Self-host "Or" tier on /pricing, the homepage pricing section update, and the /docs/self-hosting guide that the new card links to.

## Test plan
- [x] \`npm test\` — 2121 passing, 0 failing
- [x] \`npx tsc --noEmit\` clean
- [x] 5 QuotaIndicator tests cover the free/paid/self-hosted matrix + Upgrade link visibility
- [x] 3 ImportView quota tests cover refuse-over-cap, allow-under-cap, paid bypass
- [x] 1 new StatsPage test asserts graceful degradation when /api/catalog 404s
- [ ] **Manual smoke after deploy**: on a free hosted account with 24 feeds, add 1 → indicator shows 25/25 with Upgrade link, add another → blocked with quota error; on a free account, paste a 50-URL list → upfront refusal without partial import
- [ ] **Manual smoke**: load /stats on a self-hosted deployment (or with /api/catalog disabled) — page renders vault count, popular feeds section absent or empty, no error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)