### PR TITLE
fix(routing): preserve search string on deeplink-eligible redirects

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router";
+import { BrowserRouter, Routes, Route } from "react-router";
 import { useAppStore } from "@/stores/app-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useArticleStore } from "@/stores/article-store.ts";
@@ -9,6 +9,7 @@ import { generatePassphrase } from "@/core/crypto/passphrase-generator.ts";
 import { Toaster } from "@/components/ui/sonner.tsx";
 import { SyncSetupDialog } from "@/components/sync/sync-setup-dialog.tsx";
 import { SyncMigrationDialog } from "@/components/sync/sync-migration-dialog.tsx";
+import { NavigateWithSearch } from "@/components/routing/navigate-with-search.tsx";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { FeedsPage } from "@/pages/feeds-page.tsx";
 import { BillingSuccess } from "@/pages/billing-success.tsx";
@@ -159,7 +160,7 @@ export function App() {
             <Route path="/stats" element={<FeedsPage />} />
             <Route path="/billing/success" element={<BillingSuccess />} />
             <Route path="/billing/cancelled" element={<BillingCancelled />} />
-            <Route path="*" element={<Navigate to="/feeds" replace />} />
+            <Route path="*" element={<NavigateWithSearch to="/feeds" />} />
           </Routes>
         </AppInit>
         <Toaster position="bottom-center" />

--- a/src/components/routing/navigate-with-search.tsx
+++ b/src/components/routing/navigate-with-search.tsx
@@ -1,0 +1,26 @@
+/**
+ * <NavigateWithSearch> — like react-router's <Navigate> but preserves the
+ * query string.
+ *
+ * The vanilla <Navigate to="/feeds"> drops the search string because `to`
+ * is a pathname-only target. This bit the production deeplink flow:
+ * `https://my.feedzero.app/?subscribe=personal-monthly` matched the
+ * catchall `path="*"` route, which redirected to `/feeds` and silently
+ * dropped `?subscribe=...`. SubscribeDeeplink then ran at the next route
+ * with no params, so no Stripe Checkout session ever fired from the
+ * deeplink path.
+ *
+ * Use this anywhere the redirect should carry the user's intent forward
+ * — deeplinks, share links, bookmarked URLs with state in the query.
+ */
+import { Navigate, useLocation } from "react-router";
+
+interface NavigateWithSearchProps {
+  to: string;
+  replace?: boolean;
+}
+
+export function NavigateWithSearch({ to, replace = true }: NavigateWithSearchProps) {
+  const { search } = useLocation();
+  return <Navigate to={{ pathname: to, search }} replace={replace} />;
+}

--- a/src/pages/feeds-page.tsx
+++ b/src/pages/feeds-page.tsx
@@ -56,7 +56,7 @@ function SidebarKeyboardToggle() {
 export function FeedsPage() {
   const { feedId, articleId } = useParams();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
   const isExplorePage = pathname === "/explore";
   const isStatsPage = pathname === "/stats";
   const isDesktop = useIsDesktop();
@@ -134,11 +134,11 @@ export function FeedsPage() {
     if (feedId) return;
     if (!feedsLoaded) return;
     if (feedCount <= 1) {
-      navigate("/explore", { replace: true });
+      navigate({ pathname: "/explore", search }, { replace: true });
       return;
     }
-    navigate(`/feeds/${ALL_FEEDS_ID}`, { replace: true });
-  }, [isExplorePage, isStatsPage, feedId, feedsLoaded, feedCount, navigate]);
+    navigate({ pathname: `/feeds/${ALL_FEEDS_ID}`, search }, { replace: true });
+  }, [isExplorePage, isStatsPage, feedId, feedsLoaded, feedCount, navigate, search]);
 
   const isLoadingArticles = useArticleStore((s) => s.isLoading);
 

--- a/tests/components/routing/navigate-with-search.test.tsx
+++ b/tests/components/routing/navigate-with-search.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * <NavigateWithSearch> preserves the query string when redirecting.
+ *
+ * The fix targets a real production bug: clicking
+ * https://my.feedzero.app/?subscribe=personal-monthly hit the catchall
+ * `<Route path="*" element={<Navigate to="/feeds" replace />} />` which
+ * dropped the search string. SubscribeDeeplink then ran at /explore with
+ * no ?subscribe= param and silently no-op'd — zero Stripe Checkout
+ * sessions created from any deeplink path.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router";
+import { NavigateWithSearch } from "@/components/routing/navigate-with-search";
+
+let capturedSearch = "";
+let capturedPath = "";
+
+function LocationCapture() {
+  const loc = useLocation();
+  capturedPath = loc.pathname;
+  capturedSearch = loc.search;
+  return null;
+}
+
+function renderAt(initialUrl: string) {
+  capturedPath = "";
+  capturedSearch = "";
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <Routes>
+        <Route path="/feeds" element={<LocationCapture />} />
+        <Route path="*" element={<NavigateWithSearch to="/feeds" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("NavigateWithSearch", () => {
+  it("preserves the search string when redirecting", () => {
+    renderAt("/?subscribe=personal-monthly");
+
+    expect(capturedPath).toBe("/feeds");
+    expect(capturedSearch).toBe("?subscribe=personal-monthly");
+  });
+
+  it("redirects with an empty search string when there was none", () => {
+    renderAt("/some-stale-bookmark");
+
+    expect(capturedPath).toBe("/feeds");
+    expect(capturedSearch).toBe("");
+  });
+
+  it("preserves multiple search params (forward-compatibility — e.g. ?subscribe=x&utm_source=y)", () => {
+    renderAt("/?subscribe=personal-yearly&utm_source=newsletter");
+
+    expect(capturedPath).toBe("/feeds");
+    expect(capturedSearch).toBe("?subscribe=personal-yearly&utm_source=newsletter");
+  });
+});

--- a/tests/pages/feeds-page-behavior.test.tsx
+++ b/tests/pages/feeds-page-behavior.test.tsx
@@ -67,11 +67,13 @@ function makeArticle(id: string, feedId = "feed-1"): Article {
 }
 
 let currentUrl = "";
+let currentSearch = "";
 
 /** Captures the current URL on each render. */
 function LocationCapture() {
   const loc = useLocation();
   currentUrl = loc.pathname;
+  currentSearch = loc.search;
   return null;
 }
 
@@ -206,6 +208,22 @@ describe("FeedsPage behavior — desktop", () => {
 
     // Observable: folder feed is selected in store state
     expect(useFeedStore.getState().selectedFeedId).toBe(folderFeedId);
+  });
+
+  it("preserves the query string when auto-redirecting to /explore (deeplink survives)", async () => {
+    // Production bug: landing on /feeds?subscribe=personal-monthly with 0 or 1
+    // feeds triggered an auto-redirect to /explore that dropped the search
+    // string. SubscribeDeeplink then ran at /explore with no ?subscribe= and
+    // no Stripe Checkout fired. Search must survive both this redirect and
+    // the catchall in app.tsx (covered by NavigateWithSearch tests).
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+
+    renderPage("/feeds?subscribe=personal-monthly");
+
+    await vi.waitFor(() => {
+      expect(currentUrl).toBe("/explore");
+    });
+    expect(currentSearch).toBe("?subscribe=personal-monthly");
   });
 
   it("auto-navigates to /explore when only one feed exists (starter state)", async () => {


### PR DESCRIPTION
## Summary

Production hotfix. Clicking \`https://my.feedzero.app/?subscribe=personal-monthly\` — the Subscribe CTA on \`/pricing\`, the Upgrade link in \`<QuotaIndicator>\`, the Subscribe CTA in \`<SyncMigrationDialog>\` — landed users inside the app at \`/explore\` with **nothing happening**. Zero Stripe Checkout sessions ever fired from the deeplink path.

## Root cause

The deeplink URL hits \`/\` which matches the catchall route:

\`\`\`tsx
<Route path="*" element={<Navigate to="/feeds" replace />} />
\`\`\`

\`<Navigate>\`'s \`to\` prop is pathname-only — the search string is dropped on redirect. Then \`<FeedsPage>\`'s first-launch auto-redirect forwards \`/feeds\` → \`/explore\` via \`navigate("/explore", { replace: true })\`, which also drops the search.

By the time \`<SubscribeDeeplink>\`'s useEffect runs at \`/explore\`, the URL has no \`?subscribe=\` param, \`parseSubscribeIntent\` returns null, the consumer silently no-ops.

## Fix

1. New \`<NavigateWithSearch>\` wrapper that passes \`{ pathname, search }\` to \`<Navigate>\`. Used on the catchall.
2. \`<FeedsPage>\` first-launch redirect now passes \`{ pathname: "/explore", search }\` (and same for the \`/feeds/all\` symmetric path).

## Test plan
- [x] 3 \`<NavigateWithSearch>\` tests cover empty-search and multi-param cases
- [x] 1 \`<FeedsPage>\` test asserts the query string survives the first-launch redirect
- [x] \`npx tsc --noEmit\` clean
- [ ] **Manual smoke after deploy**: open \`https://my.feedzero.app/?subscribe=personal-monthly\` in incognito → should redirect through to Stripe Checkout, not silently land on /explore

🤖 Generated with [Claude Code](https://claude.com/claude-code)