### PR TITLE
fix(billing): stop stranding paying customers on /billing/success

### DIFF
--- a/src/components/billing/license-token-input.tsx
+++ b/src/components/billing/license-token-input.tsx
@@ -1,28 +1,43 @@
 /**
- * License token input — paste-from-email landing pad.
+ * License token input — paste / auto-fill landing for the license token.
  *
- * After Stripe Checkout, the customer receives an email with their
- * `fz_<...>.<...>` license token. They paste it here. We:
- *  1. Shape-validate (refuse obviously-wrong inputs locally — fast feedback)
- *  2. Persist to localStorage
- *  3. Call /api/license/verify to confirm the server accepts it
- *  4. If server rejects (revoked, expired, forged): unset the storage so we
- *     don't keep sending an invalid Bearer header on every sync request.
+ * Two flows feed this component:
+ *  - Post-checkout: /billing/success passes `value={autoFilledToken}` once the
+ *    Stripe webhook has issued the license and /api/license/retrieve returns
+ *    it. The component populates the input from the prop and auto-fires
+ *    verification — no Save click required.
+ *  - Manual paste: a user with a token they exported elsewhere drops it into
+ *    the input and clicks Save. We shape-validate locally then call
+ *    /api/license/verify to confirm the server accepts it.
+ *
+ * If the server rejects (revoked, expired, forged) we unset the stored token
+ * so we don't keep sending an invalid Bearer header on every sync request.
  *
  * Hidden by default — only renders when `paidTierVisible=true` (driven by
  * `import.meta.env.VITE_PAID_TIER_VISIBLE` at the call site).
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   setLicenseToken,
   clearLicenseToken,
   getLicenseToken,
 } from "@/core/license/license-token-store";
 import { useLicenseStore } from "@/stores/license-store";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export interface LicenseTokenInputProps {
   paidTierVisible: boolean;
+  /**
+   * Optional caller-supplied token. When this transitions from empty to a
+   * well-formed value, the component mirrors it into the input and auto-runs
+   * the same verify path as a manual Save. Used by /billing/success after the
+   * webhook hands us a freshly minted token.
+   */
+  value?: string;
 }
 
 interface VerifiedLicense {
@@ -30,33 +45,44 @@ interface VerifiedLicense {
   customerId: string;
 }
 
-export function LicenseTokenInput({ paidTierVisible }: LicenseTokenInputProps) {
-  const [token, setToken] = useState(() => getLicenseToken() ?? "");
+function isWellFormed(token: string): boolean {
+  const trimmed = token.trim();
+  return trimmed.startsWith("fz_") && trimmed.split(".").length === 2;
+}
+
+export function LicenseTokenInput({
+  paidTierVisible,
+  value,
+}: LicenseTokenInputProps) {
+  const [token, setToken] = useState(() => value ?? getLicenseToken() ?? "");
   const [verified, setVerified] = useState<VerifiedLicense | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const autoVerifiedFor = useRef<string | null>(null);
 
-  if (!paidTierVisible) return null;
+  // Mirror the caller-supplied token into local state. Guarded so we don't
+  // clobber user input on every parent re-render — only meaningful changes
+  // (non-empty + different from what we already have) overwrite. `token` is
+  // deliberately excluded from deps: this effect responds to *external*
+  // changes, not to typing in the field.
+  useEffect(() => {
+    if (value && value !== token) {
+      setToken(value);
+    }
+  }, [value]);
 
-  async function onSave() {
+  async function runVerify(candidate: string): Promise<void> {
     setBusy(true);
     setError(null);
     setVerified(null);
 
-    // Local shape-check first — fast feedback before network round-trip.
-    const trimmed = token.trim();
-    if (
-      !trimmed.startsWith("fz_") ||
-      trimmed.split(".").length !== 2
-    ) {
-      setError(
-        'Invalid license token. Expected format: fz_<...>.<...>',
-      );
+    const trimmed = candidate.trim();
+    if (!isWellFormed(trimmed)) {
+      setError("Invalid license token. Expected format: fz_<...>.<...>");
       setBusy(false);
       return;
     }
 
-    // Persist optimistically — verify next.
     setLicenseToken(trimmed);
 
     try {
@@ -67,7 +93,6 @@ export function LicenseTokenInput({ paidTierVisible }: LicenseTokenInputProps) {
       });
       const body = await res.json();
       if (!res.ok || !body.ok) {
-        // Server rejected — un-persist so we don't send a bad Bearer forever.
         clearLicenseToken();
         setError(body.error ?? `License verification failed (${res.status})`);
         return;
@@ -76,8 +101,6 @@ export function LicenseTokenInput({ paidTierVisible }: LicenseTokenInputProps) {
         tier: body.license.tier,
         customerId: body.license.customerId,
       });
-      // Wake the centralized license store so the sidebar chip and any
-      // gated UI update without a page reload.
       void useLicenseStore.getState().refresh();
     } catch (e) {
       clearLicenseToken();
@@ -87,41 +110,66 @@ export function LicenseTokenInput({ paidTierVisible }: LicenseTokenInputProps) {
     }
   }
 
+  // Auto-verify when `value` arrives from the parent (post-checkout flow).
+  // Guarded by `autoVerifiedFor` so re-renders of the parent don't re-fire.
+  useEffect(() => {
+    if (!value || !isWellFormed(value)) return;
+    if (autoVerifiedFor.current === value) return;
+    autoVerifiedFor.current = value;
+    void runVerify(value);
+  }, [value]);
+
+  if (!paidTierVisible) return null;
+
+  async function onSave() {
+    await runVerify(token);
+  }
+
   function onClear() {
     clearLicenseToken();
     setToken("");
     setVerified(null);
     setError(null);
+    autoVerifiedFor.current = null;
     void useLicenseStore.getState().refresh();
   }
 
   return (
-    <div>
-      <label htmlFor="license-token-input">License token</label>
-      <input
-        id="license-token-input"
-        type="text"
-        value={token}
-        onChange={(e) => setToken(e.target.value)}
-        placeholder="fz_..."
-        autoComplete="off"
-        spellCheck={false}
-      />
-      <button type="button" onClick={onSave} disabled={busy}>
-        Save
-      </button>
-      <button type="button" onClick={onClear} disabled={busy}>
-        Clear
-      </button>
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="license-token-input">License token</Label>
+        <Input
+          id="license-token-input"
+          type="text"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="fz_..."
+          autoComplete="off"
+          spellCheck={false}
+          aria-invalid={error !== null}
+        />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="ghost" onClick={onClear} disabled={busy}>
+          Clear
+        </Button>
+        <Button type="button" onClick={onSave} disabled={busy}>
+          {busy ? "Saving…" : "Save"}
+        </Button>
+      </div>
       {verified && (
-        <div role="status" aria-live="polite">
-          Active: {verified.tier} (customer {verified.customerId})
-        </div>
+        <Alert>
+          <AlertDescription role="status" aria-live="polite">
+            Active: {verified.tier} (customer {verified.customerId})
+          </AlertDescription>
+        </Alert>
       )}
       {error && (
-        <div role="alert" aria-live="polite">
-          {error}
-        </div>
+        <Alert variant="destructive">
+          <AlertDescription role="alert" aria-live="polite">
+            {error}
+          </AlertDescription>
+        </Alert>
       )}
     </div>
   );

--- a/src/pages/billing-success.tsx
+++ b/src/pages/billing-success.tsx
@@ -9,38 +9,58 @@
  * license token asynchronously. If the customer lands here before the
  * webhook has finished, there is nothing yet to display. We close that gap
  * by polling `/api/license/retrieve?sessionId=...` every 3s for up to 30s,
- * auto-filling the LicenseTokenInput once the token arrives.
+ * piping the resulting token into LicenseTokenInput which auto-verifies it
+ * server-side.
  *
- * UX contract:
- *  - Confirmation heading so the customer knows the payment landed.
- *  - LicenseTokenInput inline so they can verify/paste their token. With
- *    polling wired, the typical flow is "wait a few seconds → token
- *    appears" — manual paste is the fallback for any edge case.
- *  - "Manage subscription" button opens the Stripe Customer Portal so
- *    customers can self-serve cancel, update payment method, view invoices.
- *  - Stripe session ID echoed in plain text for support debugging.
- *  - A clear way back to the reader.
+ * UX states the user can see:
+ *  - polling  — spinner + "Retrieving your license…". The default visible
+ *    state while we wait on the webhook → Upstash → re-sign chain.
+ *  - success  — checkmark alert + populated, auto-verified input.
+ *  - timeout  — destructive alert that exposes the session id as a support
+ *    diagnostic, and invites the user to paste a token they may already have.
+ *
+ * The session id is intentionally NOT rendered as page chrome on the happy
+ * path. It only appears inside the timeout alert, where it serves a purpose.
  */
 
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
+import { Loader2, CheckCircle2, AlertTriangle } from "lucide-react";
 import { LicenseTokenInput } from "@/components/billing/license-token-input";
 import {
   getLicenseToken,
   setLicenseToken,
 } from "@/core/license/license-token-store";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 
 const POLL_INTERVAL_MS = 3000;
 const POLL_MAX_DURATION_MS = 30_000;
 
+type Phase = "polling" | "success" | "timeout";
+
 export function BillingSuccess() {
   const [searchParams] = useSearchParams();
   const sessionId = searchParams.get("session_id");
-  const [autoFilledToken, setAutoFilledToken] = useState<string | null>(null);
+  const [autoFilledToken, setAutoFilledToken] = useState<string | null>(() =>
+    getLicenseToken(),
+  );
+  const [phase, setPhase] = useState<Phase>(() => {
+    if (getLicenseToken()) return "success";
+    if (sessionId) return "polling";
+    return "success";
+  });
   const [portalBusy, setPortalBusy] = useState(false);
   const [portalError, setPortalError] = useState<string | null>(null);
 
-  useTokenAutoFill(sessionId, setAutoFilledToken);
+  useTokenAutoFill(
+    sessionId,
+    (token) => {
+      setAutoFilledToken(token);
+      setPhase("success");
+    },
+    () => setPhase("timeout"),
+  );
 
   async function onManageSubscription() {
     if (!sessionId) return;
@@ -69,53 +89,83 @@ export function BillingSuccess() {
   }
 
   return (
-    <div className="mx-auto max-w-xl p-8 space-y-6">
+    <div className="mx-auto max-w-xl space-y-6 p-8">
       <h1 className="text-2xl font-semibold">
         Thanks for subscribing to FeedZero
       </h1>
 
-      <p>
-        Your payment has been processed. Your license token is shown below —
-        save it somewhere safe; you'll need it to activate sync on every
-        device you use.
+      <p className="text-muted-foreground">
+        Your payment was processed. We&apos;ve activated sync on this device —
+        nothing else to do.
       </p>
 
-      {autoFilledToken && (
-        <p role="status" aria-live="polite" className="text-sm">
-          We retrieved your token automatically. Click <strong>Save</strong>{" "}
-          below to activate sync.
-        </p>
+      {phase === "polling" && (
+        <Alert>
+          <Loader2 className="animate-spin" />
+          <AlertDescription role="status" aria-live="polite">
+            Retrieving your license… this normally takes a few seconds.
+          </AlertDescription>
+        </Alert>
       )}
 
-      <LicenseTokenInput paidTierVisible={true} />
+      {phase === "success" && autoFilledToken && (
+        <Alert>
+          <CheckCircle2 />
+          <AlertDescription role="status" aria-live="polite">
+            Your subscription is active. We&apos;ve saved your license to this
+            browser.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {phase === "timeout" && sessionId && (
+        <Alert variant="destructive">
+          <AlertTriangle />
+          <AlertDescription role="alert" aria-live="polite">
+            We couldn&apos;t retrieve your license automatically. If you have
+            your token, paste it below. Otherwise email{" "}
+            <a
+              href="mailto:support@feedzero.app"
+              className="underline underline-offset-2"
+            >
+              support@feedzero.app
+            </a>{" "}
+            and quote session <code>{sessionId}</code>.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <LicenseTokenInput
+        paidTierVisible={true}
+        value={autoFilledToken ?? undefined}
+      />
 
       {sessionId && (
         <div className="space-y-2">
-          <button
+          <Button
             type="button"
+            variant="outline"
             onClick={onManageSubscription}
             disabled={portalBusy}
             aria-busy={portalBusy}
           >
             {portalBusy ? "Opening…" : "Manage subscription"}
-          </button>
+          </Button>
           {portalError && (
-            <div role="alert" aria-live="polite">
-              {portalError}
-            </div>
+            <Alert variant="destructive">
+              <AlertDescription role="alert" aria-live="polite">
+                {portalError}
+              </AlertDescription>
+            </Alert>
           )}
         </div>
       )}
 
-      {sessionId && (
-        <p className="text-sm text-muted-foreground">
-          Stripe session: <code>{sessionId}</code>
-        </p>
-      )}
-
-      <p>
-        <a href="/feeds">Back to FeedZero</a>
-      </p>
+      <div>
+        <Button asChild>
+          <a href="/feeds">Continue to FeedZero</a>
+        </Button>
+      </div>
     </div>
   );
 }
@@ -127,11 +177,13 @@ export function BillingSuccess() {
  *
  * The polling deliberately fires the FIRST request synchronously on mount —
  * if the webhook is already done, we want the token to appear instantly, not
- * after a 3-second wait.
+ * after a 3-second wait. On deadline exhaustion, `onTimeout` lets the parent
+ * switch to the timeout-state UI rather than silently giving up.
  */
 function useTokenAutoFill(
   sessionId: string | null,
   onFilled: (token: string) => void,
+  onTimeout: () => void,
 ): void {
   const stopped = useRef(false);
 
@@ -142,6 +194,14 @@ function useTokenAutoFill(
 
     const deadline = Date.now() + POLL_MAX_DURATION_MS;
     let timer: ReturnType<typeof setTimeout> | null = null;
+
+    function scheduleNextOrTimeout(): void {
+      if (Date.now() + POLL_INTERVAL_MS < deadline) {
+        timer = setTimeout(attempt, POLL_INTERVAL_MS);
+      } else {
+        onTimeout();
+      }
+    }
 
     async function attempt(): Promise<void> {
       if (stopped.current) return;
@@ -159,15 +219,9 @@ function useTokenAutoFill(
             return;
           }
         }
-        // 202 pending OR 4xx (still worth one retry — webhook may catch up).
-        if (Date.now() + POLL_INTERVAL_MS < deadline) {
-          timer = setTimeout(attempt, POLL_INTERVAL_MS);
-        }
+        scheduleNextOrTimeout();
       } catch {
-        // Network blip — try again until the deadline.
-        if (Date.now() + POLL_INTERVAL_MS < deadline) {
-          timer = setTimeout(attempt, POLL_INTERVAL_MS);
-        }
+        scheduleNextOrTimeout();
       }
     }
 
@@ -177,5 +231,5 @@ function useTokenAutoFill(
       stopped.current = true;
       if (timer) clearTimeout(timer);
     };
-  }, [sessionId, onFilled]);
+  }, [sessionId, onFilled, onTimeout]);
 }

--- a/tests/components/billing/license-token-input.test.tsx
+++ b/tests/components/billing/license-token-input.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { LicenseTokenInput } from "@/components/billing/license-token-input";
 
@@ -89,6 +89,73 @@ describe("LicenseTokenInput", () => {
     render(<LicenseTokenInput paidTierVisible={true} />);
     await userEvent.click(screen.getByRole("button", { name: /clear/i }));
     expect(localStorageMock.getItem("feedzero:license-token")).toBeNull();
+  });
+
+  describe("auto-fill via `value` prop", () => {
+    it("when value prop is provided, the input shows that value", () => {
+      render(
+        <LicenseTokenInput paidTierVisible={true} value="fz_provided.token" />,
+      );
+      const input = screen.getByPlaceholderText(/fz_/i) as HTMLInputElement;
+      expect(input.value).toBe("fz_provided.token");
+    });
+
+    it("when value prop transitions to a well-formed token, auto-fires verify; re-render with the same value does NOT re-fire", async () => {
+      const { rerender } = render(
+        <LicenseTokenInput paidTierVisible={true} value="" />,
+      );
+      const fetchMock = (globalThis.fetch as unknown) as ReturnType<typeof vi.fn>;
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      function verifyCallCount(): number {
+        return fetchMock.mock.calls.filter((c) =>
+          c[0].toString().includes("/api/license/verify"),
+        ).length;
+      }
+
+      rerender(
+        <LicenseTokenInput
+          paidTierVisible={true}
+          value="fz_autofilled.token"
+        />,
+      );
+
+      // We expect at least one verify (the component's own) and possibly a
+      // follow-on from useLicenseStore.refresh() on success. Either way it
+      // happens — not zero. The "exactly once per token change" invariant is
+      // checked below by comparing counts across rerenders.
+      await waitFor(() => {
+        expect(verifyCallCount()).toBeGreaterThan(0);
+      });
+      const countAfterFirst = verifyCallCount();
+
+      rerender(
+        <LicenseTokenInput
+          paidTierVisible={true}
+          value="fz_autofilled.token"
+        />,
+      );
+      await new Promise((r) => setTimeout(r, 30));
+      // A second rerender with the same token must NOT trigger another verify.
+      // The store's own refresh() may still fire from the initial Save, so we
+      // lock the count against drift rather than expecting a literal number.
+      expect(verifyCallCount()).toBe(countAfterFirst);
+    });
+
+    it("does NOT auto-verify when value prop is a malformed token (shape-check guards us)", async () => {
+      const { rerender } = render(
+        <LicenseTokenInput paidTierVisible={true} value="" />,
+      );
+      rerender(
+        <LicenseTokenInput paidTierVisible={true} value="not-a-token" />,
+      );
+      await new Promise((r) => setTimeout(r, 20));
+      const fetchMock = (globalThis.fetch as unknown) as ReturnType<typeof vi.fn>;
+      const verifyCalls = fetchMock.mock.calls.filter((c) =>
+        c[0].toString().includes("/api/license/verify"),
+      );
+      expect(verifyCalls).toHaveLength(0);
+    });
   });
 
   it("when /api/license/verify returns 401 revoked, surfaces the error AND removes the token", async () => {

--- a/tests/pages/billing-success.test.tsx
+++ b/tests/pages/billing-success.test.tsx
@@ -50,11 +50,65 @@ describe("BillingSuccess page", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the masked Stripe session_id when present (lets the user confirm Stripe acked)", () => {
-    renderWithRoute("/billing/success?session_id=cs_test_a1b2c3d4e5f6");
-    // Expose enough of the session id to verify, but not in a UX-heavy way —
-    // matters mostly for support debugging.
-    expect(screen.getByText(/cs_test_a1b2c3d4e5f6/)).toBeInTheDocument();
+  it("does NOT render the session id as page chrome on the polling-state happy path", async () => {
+    // 202 forever — page stays in polling-state until the deadline.
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: false, pending: true }), {
+        status: 202,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      renderWithRoute("/billing/success?session_id=cs_test_a1b2c3d4e5f6");
+
+      // Let the first poll complete + React commit.
+      await new Promise((r) => setTimeout(r, 50));
+
+      // The session id used to be rendered as chrome under the input — that
+      // was visual noise on an already-broken-looking page. It must only
+      // appear in support-diagnostic copy (the timeout alert), never as
+      // chrome on the happy or still-polling path.
+      expect(
+        screen.queryByText(/cs_test_a1b2c3d4e5f6/),
+      ).not.toBeInTheDocument();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("when the auto-retrieve deadline passes, surfaces the session id INSIDE the timeout alert as a support diagnostic", async () => {
+    // 4xx response triggers the same retry-or-deadline branch as 202 but is
+    // faster to exhaust through the deadline because each attempt resolves
+    // immediately (no JSON.parse on a 200 body).
+    const fetchMock = vi.fn(async () =>
+      new Response("nope", { status: 404 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      // Force the deadline to a single-tick value so the loop exits on the
+      // first attempt without us having to drive 30 seconds of fake timers.
+      // We do this by stubbing Date.now to advance past the deadline after
+      // the first call.
+      const realNow = Date.now;
+      let calls = 0;
+      vi.spyOn(Date, "now").mockImplementation(() => {
+        calls += 1;
+        return realNow() + (calls > 1 ? 60_000 : 0);
+      });
+
+      renderWithRoute("/billing/success?session_id=cs_test_a1b2c3d4e5f6");
+
+      const alert = await screen.findByText(
+        /couldn.t retrieve your license/i,
+      );
+      expect(alert.textContent).toContain("cs_test_a1b2c3d4e5f6");
+    } finally {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    }
   });
 
   it("renders a link back to the app", () => {
@@ -83,6 +137,87 @@ describe("BillingSuccess page", () => {
       const allText = document.body.textContent ?? "";
       expect(allText).not.toMatch(/check your email/i);
     });
+
+    it("does not promise that the token is shown 'somewhere safe' the user is responsible for", () => {
+      renderWithRoute("/billing/success?session_id=cs_test_xyz");
+      const allText = document.body.textContent ?? "";
+      // The old copy said "save it somewhere safe; you'll need it to activate
+      // sync on every device". There is no other place to fetch the token
+      // from yet, so this sets up a wild-goose-chase failure mode when the
+      // user reasonably trusts us. Replace with honest "we activated sync on
+      // this device" copy.
+      expect(allText).not.toMatch(/save it somewhere safe/i);
+    });
+  });
+
+  describe("phase UI", () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it("renders a 'Retrieving your license…' alert while polling", async () => {
+      const fetchMock = vi.fn(async () =>
+        new Response(JSON.stringify({ ok: false, pending: true }), {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderWithRoute("/billing/success?session_id=cs_test_xyz");
+
+      const alert = await screen.findByRole("alert");
+      expect(alert.textContent ?? "").toMatch(/retrieving/i);
+    });
+
+    it("auto-fills the LicenseTokenInput and auto-verifies once retrieve returns 200", async () => {
+      const fetchMock = vi.fn(
+        async (input: RequestInfo | URL, _init?: RequestInit) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url.includes("/api/license/retrieve")) {
+            return new Response(
+              JSON.stringify({ ok: true, token: "fz_payload.signature" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          if (url.includes("/api/license/verify")) {
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                license: { tier: "personal", customerId: "cus_x" },
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          return new Response("{}", { status: 200 });
+        },
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderWithRoute("/billing/success?session_id=cs_test_xyz");
+
+      // The input must end up populated with the retrieved token — without
+      // this, the user clicks Save on an empty box and gets a fake error.
+      await waitFor(() => {
+        const input = screen.getByPlaceholderText(/fz_/i) as HTMLInputElement;
+        expect(input.value).toBe("fz_payload.signature");
+      });
+
+      // verify must fire without a Save click — the auto-fill IS the action.
+      await waitFor(() => {
+        const verifyCalls = fetchMock.mock.calls.filter((c) =>
+          c[0].toString().includes("/api/license/verify"),
+        );
+        expect(verifyCalls.length).toBeGreaterThan(0);
+      });
+
+      // Success copy renders the tier from the verify response.
+      expect(await screen.findByText(/active.*personal/i)).toBeInTheDocument();
+    });
   });
 
   describe("token auto-retrieval after Stripe webhook fires", () => {
@@ -102,6 +237,19 @@ describe("BillingSuccess page", () => {
           if (url.includes("/api/license/retrieve")) {
             return new Response(
               JSON.stringify({ ok: true, token: "fz_payload.signature" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          if (url.includes("/api/license/verify")) {
+            // The auto-fill path now chains directly into verify; the input
+            // would clear the token on a verify failure, so we have to mock
+            // a happy verify response to keep the localStorage assertion
+            // below meaningful.
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                license: { tier: "personal", customerId: "cus_x" },
+              }),
               { status: 200, headers: { "Content-Type": "application/json" } },
             );
           }


### PR DESCRIPTION
## Summary

A real customer paid $5 in production on 2026-05-16 and landed on `/billing/success` that looked broken: unstyled, empty input field, and a misleading "Invalid license token" error — even though the server-side license had been minted correctly and `/api/license/retrieve` had returned the token. This hotfix unbreaks the last mile.

## Root causes

1. **Auto-filled token never reached the input.** `<LicenseTokenInput>` initialized its `token` state from localStorage **once at mount**. The auto-fill polling wrote to localStorage *after* mount, so the input stayed empty. The "Click Save to activate" copy then lied — Save on an empty input tripped the local shape-check and rendered "Invalid license token".
2. **Zero CSS classes on the inner chrome.** Tailwind was loading (outer wrapper used `mx-auto max-w-xl p-8 space-y-6`) but `<LicenseTokenInput>`, the "Manage subscription" button, and "Back to FeedZero" link had no `className` anywhere.
3. **Raw `cs_live_…` session id rendered as page chrome** — visual noise on an already-broken page.
4. **No phase UI** — polling, success, and 30s-timeout all looked identical (empty input).

## Fix

- `<LicenseTokenInput>` accepts an optional `value` prop. On transition to a well-formed token it mirrors into the input AND auto-fires the same verify path as a manual Save click. A `useRef` guard ensures re-renders don't double-fire.
- `<BillingSuccess>` exposes an explicit `polling | success | timeout` phase machine:
  - **polling** — spinner + "Retrieving your license…"
  - **success** — checkmark + "Your subscription is active. We've saved your license to this browser."
  - **timeout** — destructive alert with session id as support diagnostic + paste fallback
- Replaced raw HTML elements with shadcn `<Label>`, `<Input>`, `<Button>`, `<Alert>` primitives.
- Dropped the "save it somewhere safe" copy that implied a recovery path that doesn't exist yet.

## Test plan

- [x] `npx vitest run tests/components/billing/license-token-input.test.tsx tests/pages/billing-success.test.tsx` — 25 pass, including 3 new auto-fill tests and 4 new phase-UI / copy-honesty tests
- [x] `npm test` full suite — 2183 pass, 0 fail, 26 skipped (smoke only)
- [x] `npx tsc --noEmit` clean
- [ ] Manual visual verification with `npm run dev` + Stripe test mode — pending reviewer (the remote container can't run a real browser)
- [ ] Production smoke after deploy — one live test purchase against `my.feedzero.app`, confirm spinner → success → populated input, no raw `cs_…` chrome; refund + cancel via Stripe dashboard

## Out of scope (queued as follow-ups)

- **Settings → Account tab** so closing the success tab is no longer fatal (separate PR).
- **Cross-device license recovery** via Stripe Customer Portal magic link (separate ADR + PR).
- **Operator alerting on `acceptedWithIssue`** (separate PR).
- **Customer recovery for the affected user** — out-of-band action: confirm `LicenseRecord` exists in Upstash for `cus_UWmKd26vBjf6UM` and email the token directly.

https://claude.ai/code/session_01Gv7w25LwX2xjChiSCzwTM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gv7w25LwX2xjChiSCzwTM9)_