### PR TITLE
feat(settings): unified Settings dialog with Account hub + license recovery safety net

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -10,6 +10,7 @@ import { Toaster } from "@/components/ui/sonner.tsx";
 import { SyncSetupDialog } from "@/components/sync/sync-setup-dialog.tsx";
 import { SyncMigrationDialog } from "@/components/sync/sync-migration-dialog.tsx";
 import { UpgradeDialog } from "@/components/billing/upgrade-dialog.tsx";
+import { SettingsDialog } from "@/components/settings/settings-dialog.tsx";
 import { NavigateWithSearch } from "@/components/routing/navigate-with-search.tsx";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { FeedsPage } from "@/pages/feeds-page.tsx";
@@ -173,6 +174,7 @@ export function App() {
       <SyncSetupDialog />
       <SyncMigrationDialog />
       <UpgradeDialog />
+      <SettingsDialog />
       <SpeedInsights />
     </>
   );

--- a/src/components/explore/explore-catalog.tsx
+++ b/src/components/explore/explore-catalog.tsx
@@ -19,7 +19,7 @@ import {
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
 import { FeedPreviewSheet } from "@/components/explore/feed-preview-sheet.tsx";
-import { SettingsDialog } from "@/components/settings/settings-dialog.tsx";
+import { openSettings } from "@/lib/open-settings.ts";
 import { Button } from "@/components/ui/button.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Kbd } from "@/components/ui/kbd.tsx";
@@ -603,7 +603,6 @@ export function ExploreCatalog({ onFeedAdded }: ExploreCatalogProps) {
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [isAddingFeed, setIsAddingFeed] = useState(false);
-  const [importExportOpen, setImportExportOpen] = useState(false);
   const [selectedRowId, setSelectedFeedUrl] = useState<string | null>(null);
   const [searchFocused, setSearchFocused] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -769,7 +768,7 @@ export function ExploreCatalog({ onFeedAdded }: ExploreCatalogProps) {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => setImportExportOpen(true)}
+          onClick={() => openSettings("import")}
         >
           <FileUp className="mr-2 size-4" />
           Import / Export
@@ -883,10 +882,6 @@ export function ExploreCatalog({ onFeedAdded }: ExploreCatalogProps) {
         )}
       </div>
 
-      <SettingsDialog
-        open={importExportOpen}
-        onOpenChange={setImportExportOpen}
-      />
     </div>
   );
 }

--- a/src/components/settings/account-sync-section.tsx
+++ b/src/components/settings/account-sync-section.tsx
@@ -1,0 +1,320 @@
+/**
+ * Inline cloud-sync controls for the Account tab.
+ *
+ * Replaces the SyncSetupDialog modal for the in-Settings flow. Renders the
+ * status view + buttons inline (no Dialog wrapper). SetupWizard,
+ * ExistingCloudFlow, and confirmation prompts stay as nested dialogs
+ * triggered by the inline buttons — Radix Dialog stacks cleanly on top of
+ * the parent Settings dialog via portals.
+ */
+import { useState } from "react";
+import {
+  Cloud,
+  CloudOff,
+  Trash2,
+  AlertTriangle,
+  LogOut,
+  KeyRound,
+  DownloadCloud,
+  Loader2,
+} from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { generatePassphrase } from "@/core/crypto/passphrase-generator";
+import { useSyncStore } from "@/stores/sync-store";
+import { useFeedStore } from "@/stores/feed-store";
+import { useAppStore } from "@/stores/app-store";
+import { toast } from "sonner";
+import { SetupWizard } from "@/components/sync/setup-wizard";
+import { ExistingCloudFlow } from "@/components/sync/existing-cloud-flow";
+
+type Confirmation = "none" | "delete" | "disable" | "logout" | "restore";
+type SubFlow = "none" | "setup" | "existing";
+
+export function AccountSyncSection() {
+  const status = useSyncStore((s) => s.status);
+  const syncError = useSyncStore((s) => s.error);
+  const enableSync = useSyncStore((s) => s.enableSync);
+  const disableSync = useSyncStore((s) => s.disableSync);
+  const logout = useSyncStore((s) => s.logout);
+  const forceResync = useSyncStore((s) => s.forceResync);
+  const switchToExistingCloud = useSyncStore((s) => s.switchToExistingCloud);
+  const resetApp = useAppStore((s) => s.resetApp);
+  const localFeedCount = useFeedStore((s) => s.feeds.length);
+
+  const [confirmation, setConfirmation] = useState<Confirmation>("none");
+  const [subFlow, setSubFlow] = useState<SubFlow>("none");
+  const [passphrase, setPassphrase] = useState("");
+  const [pending, setPending] = useState(false);
+
+  async function handleStartSetup() {
+    setPassphrase(await generatePassphrase());
+    setSubFlow("setup");
+  }
+
+  async function handleDisableSync() {
+    setPending(true);
+    await disableSync();
+    setPending(false);
+    setConfirmation("none");
+    toast("Sync disabled. Server data deleted.");
+  }
+
+  async function handleDeleteAll() {
+    setPending(true);
+    await resetApp();
+    await disableSync();
+    setPending(false);
+    setConfirmation("none");
+  }
+
+  async function handleLogout() {
+    setPending(true);
+    await logout();
+    setPending(false);
+    setConfirmation("none");
+  }
+
+  async function handleRestore() {
+    setPending(true);
+    const result = await forceResync();
+    setPending(false);
+    if (result.ok) {
+      toast(`Restored ${result.value.feedCount} feeds from cloud.`);
+    } else {
+      toast.error(`Restore failed: ${result.error}`);
+    }
+    setConfirmation("none");
+  }
+
+  const statusDescription = (() => {
+    switch (status) {
+      case "local-only":
+        return "Your data is stored locally in this browser only.";
+      case "synced":
+        return "Your data is encrypted and synced across devices.";
+      case "syncing":
+        return "Sync is in progress…";
+      case "error":
+        return syncError
+          ? `Sync error: ${syncError}`
+          : "There was a sync error. Please try again.";
+    }
+  })();
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold">Cloud sync</h3>
+        <p className="text-xs text-muted-foreground mt-0.5">{statusDescription}</p>
+      </div>
+
+      {status === "local-only" && (
+        <div className="space-y-2">
+          <Button variant="outline" className="w-full" onClick={handleStartSetup}>
+            <Cloud className="mr-2 size-4" />
+            Enable sync
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => setSubFlow("existing")}
+          >
+            <KeyRound className="mr-2 size-4" />
+            Use existing cloud account
+          </Button>
+        </div>
+      )}
+
+      {(status === "synced" || status === "syncing" || status === "error") && (
+        <div className="space-y-2">
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => setConfirmation("disable")}
+            disabled={status === "syncing"}
+          >
+            <CloudOff className="mr-2 size-4" />
+            Switch to local only
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => setConfirmation("restore")}
+            disabled={status === "syncing"}
+          >
+            <DownloadCloud className="mr-2 size-4" />
+            Restore from cloud
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => setConfirmation("logout")}
+            disabled={status === "syncing"}
+          >
+            <LogOut className="mr-2 size-4" />
+            Log out of this device
+          </Button>
+        </div>
+      )}
+
+      <div className="border-t pt-3">
+        <p className="text-xs font-medium text-destructive mb-2">Danger zone</p>
+        <Button
+          variant="outline"
+          className="w-full justify-start text-destructive hover:text-destructive hover:bg-destructive/10"
+          onClick={() => setConfirmation("delete")}
+        >
+          <Trash2 className="mr-2 size-4" />
+          Delete all data
+        </Button>
+      </div>
+
+      {subFlow === "setup" && (
+        <SetupWizard
+          open
+          onOpenChange={(o) => !o && setSubFlow("none")}
+          passphrase={passphrase}
+          onEnable={async () => {
+            await enableSync(passphrase);
+            setSubFlow("none");
+          }}
+        />
+      )}
+
+      {subFlow === "existing" && (
+        <ExistingCloudFlow
+          open
+          onOpenChange={(o) => !o && setSubFlow("none")}
+          onCancel={() => setSubFlow("none")}
+          localFeedCount={localFeedCount}
+          onSwitch={switchToExistingCloud}
+        />
+      )}
+
+      <Confirm
+        open={confirmation === "delete"}
+        onOpenChange={(o) => !o && setConfirmation("none")}
+        icon={<AlertTriangle className="size-6 text-destructive" />}
+        iconBg="bg-destructive/10"
+        title="Delete all data?"
+        description="This will permanently delete all your feeds and articles. This action cannot be undone."
+        confirmLabel="Delete everything"
+        loadingLabel="Deleting…"
+        confirmIcon={<Trash2 className="mr-2 size-4" />}
+        isLoading={pending}
+        onConfirm={handleDeleteAll}
+        variant="destructive"
+      />
+
+      <Confirm
+        open={confirmation === "disable"}
+        onOpenChange={(o) => !o && setConfirmation("none")}
+        icon={<CloudOff className="size-6 text-amber-600" />}
+        iconBg="bg-amber-100"
+        title="Switch to local only?"
+        description="This will delete your encrypted data from the server. Your local data will be kept. This cannot be undone."
+        confirmLabel="Disable sync"
+        loadingLabel="Disabling sync…"
+        isLoading={pending}
+        onConfirm={handleDisableSync}
+      />
+
+      <Confirm
+        open={confirmation === "restore"}
+        onOpenChange={(o) => !o && setConfirmation("none")}
+        icon={<DownloadCloud className="size-6 text-blue-600" />}
+        iconBg="bg-blue-100"
+        title="Restore from cloud?"
+        description="This will replace your local feeds and articles with what's stored in the cloud. Use this if a device shows the wrong feed list after sync."
+        confirmLabel="Restore"
+        loadingLabel="Restoring…"
+        confirmIcon={<DownloadCloud className="mr-2 size-4" />}
+        isLoading={pending}
+        onConfirm={handleRestore}
+      />
+
+      <Confirm
+        open={confirmation === "logout"}
+        onOpenChange={(o) => !o && setConfirmation("none")}
+        icon={<LogOut className="size-6 text-muted-foreground" />}
+        iconBg="bg-muted"
+        title="Log out of this device?"
+        description="This will clear all local data from this browser. Your encrypted cloud backup is preserved — you will need your secret key to access your feeds again."
+        confirmLabel="Log out"
+        loadingLabel="Logging out…"
+        isLoading={pending}
+        onConfirm={handleLogout}
+      />
+    </div>
+  );
+}
+
+interface ConfirmProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  icon: React.ReactNode;
+  iconBg: string;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  loadingLabel: string;
+  isLoading: boolean;
+  onConfirm: () => void;
+  variant?: "default" | "destructive";
+  confirmIcon?: React.ReactNode;
+}
+
+function Confirm(props: ConfirmProps) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <div className="flex justify-center py-2">
+            <div className={`flex size-12 items-center justify-center rounded-full ${props.iconBg}`}>
+              {props.icon}
+            </div>
+          </div>
+          <DialogTitle className="text-center">{props.title}</DialogTitle>
+          <DialogDescription className="text-center">{props.description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex-col gap-2 sm:flex-col">
+          <Button
+            variant={props.variant ?? "default"}
+            className="w-full"
+            onClick={props.onConfirm}
+            disabled={props.isLoading}
+            aria-busy={props.isLoading}
+          >
+            {props.isLoading ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                {props.loadingLabel}
+              </>
+            ) : (
+              <>
+                {props.confirmIcon}
+                {props.confirmLabel}
+              </>
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={() => props.onOpenChange(false)}
+            disabled={props.isLoading}
+          >
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/account-tab.tsx
+++ b/src/components/settings/account-tab.tsx
@@ -24,6 +24,8 @@ import {
 import { decodeLicensePayload } from "@/core/license/format";
 import { base64UrlDecodeToString } from "@/core/license/crypto";
 import type { LicensePayload } from "@/core/license/format";
+import { AccountUpgradeSection } from "./account-upgrade-section";
+import { AccountSyncSection } from "./account-sync-section";
 
 const TOKEN_PREFIX = "fz_";
 
@@ -65,22 +67,15 @@ export function AccountTab() {
 function FreeView() {
   return (
     <div className="space-y-4 py-2">
-      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
-        <div className="flex items-center gap-2">
-          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-slate-50 text-slate-600 border-slate-200">
-            Free
-          </span>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          You&apos;re on the Free tier. Upgrade to Personal for end-to-end
-          encrypted cloud sync, auto-organize folders, and unlimited feeds.
-        </p>
-        <Button asChild className="w-full sm:w-auto">
-          <a href="/?subscribe=personal-monthly">
-            Subscribe to Personal — $5/mo
-          </a>
-        </Button>
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border bg-slate-50 text-slate-600 border-slate-200">
+          Free
+        </span>
+        <span className="text-sm text-muted-foreground">
+          You&apos;re on the Free tier.
+        </span>
       </div>
+      <AccountUpgradeSection />
     </div>
   );
 }
@@ -233,6 +228,8 @@ function PaidView({ tier, onSignOut }: PaidViewProps) {
           </Alert>
         )}
       </div>
+
+      <AccountSyncSection />
 
       <div className="rounded-lg border border-border bg-card p-4">
         <p className="text-xs text-muted-foreground mb-2">

--- a/src/components/settings/account-upgrade-section.tsx
+++ b/src/components/settings/account-upgrade-section.tsx
@@ -1,0 +1,173 @@
+/**
+ * Inline tier comparison for the Account tab.
+ *
+ * Replaces the UpgradeDialog modal for the in-Settings flow. Same four
+ * tier cards — Free / Personal / Pro / Self-host — same CTAs, no modal
+ * chrome. Personal CTAs use same-tab Stripe Checkout deeplinks; the
+ * customer returns to /billing/success which auto-fills the license.
+ */
+import { Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function AccountUpgradeSection() {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Cloud sync, auto-organize, and more — for the price of a coffee.
+      </p>
+
+      <TierCard
+        name="Free"
+        price="$0"
+        blurb="Up to 25 feeds. No account. Stays in your browser."
+        features={[
+          "1,300+ curated feeds in Explore",
+          "OPML import / export",
+          "Full-text extraction",
+          "Offline support",
+        ]}
+        cta="Current plan"
+        ctaDisabled
+      />
+
+      <TierCard
+        name="Personal"
+        price="$5/mo"
+        priceSub="or $50/yr — save 17%"
+        blurb="Sync across every device. Unlimited feeds."
+        featured
+        features={[
+          "Everything in Free",
+          "End-to-end encrypted cloud sync",
+          "Auto-organize folders",
+          "Unlimited feeds",
+        ]}
+        cta="Subscribe to Personal — $5/mo"
+        ctaHref="/?subscribe=personal-monthly"
+        secondaryCta="or $50/yr — save 17%"
+        secondaryCtaHref="/?subscribe=personal-yearly"
+      />
+
+      <TierCard
+        name="Pro"
+        price="Coming 2026"
+        blurb="When RSS becomes your work."
+        comingSoon
+        features={[
+          "Everything in Personal",
+          "AI Signal — summaries & briefings",
+          "Full-text search across articles",
+          "Send to Kindle",
+        ]}
+        cta="Coming soon"
+        ctaDisabled
+      />
+
+      <TierCard
+        name="Self-host"
+        price="$0 · MIT"
+        blurb="Run your own copy. Every shipped feature unlocked."
+        features={[
+          "Unlimited feeds, cloud sync on your own server",
+          "No license check, no kill switch",
+          "Open source under MIT",
+        ]}
+        cta="Self-hosting guide →"
+        ctaHref="https://www.feedzero.app/docs/self-hosting"
+        ctaTargetBlank
+      />
+    </div>
+  );
+}
+
+interface TierCardProps {
+  name: string;
+  price: string;
+  priceSub?: string;
+  blurb: string;
+  features: string[];
+  featured?: boolean;
+  comingSoon?: boolean;
+  cta?: string;
+  ctaHref?: string;
+  ctaDisabled?: boolean;
+  ctaTargetBlank?: boolean;
+  secondaryCta?: string;
+  secondaryCtaHref?: string;
+}
+
+function TierCard({
+  name,
+  price,
+  priceSub,
+  blurb,
+  features,
+  featured,
+  comingSoon,
+  cta,
+  ctaHref,
+  ctaDisabled,
+  ctaTargetBlank,
+  secondaryCta,
+  secondaryCtaHref,
+}: TierCardProps) {
+  const borderClass = featured
+    ? "border-emerald-300 dark:border-emerald-700 shadow-sm"
+    : comingSoon
+      ? "border-dashed border-border bg-card/50"
+      : "border-border";
+
+  return (
+    <div className={`rounded-lg border ${borderClass} bg-card p-4 space-y-2`}>
+      <div className="flex items-baseline justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2">
+          {featured && <Sparkles className="size-4 text-emerald-600" />}
+          <h3 className="text-base font-semibold">{name}</h3>
+        </div>
+        <div className="text-sm text-muted-foreground">
+          <span className="font-medium text-foreground">{price}</span>
+          {priceSub && <span className="ml-1.5 text-xs">({priceSub})</span>}
+        </div>
+      </div>
+      <p className="text-sm text-muted-foreground">{blurb}</p>
+      <ul className="text-xs text-muted-foreground space-y-0.5 pl-4 list-disc">
+        {features.map((f) => (
+          <li key={f}>{f}</li>
+        ))}
+      </ul>
+      {cta && (
+        <div className="pt-1 flex flex-col gap-1">
+          {ctaHref && !ctaDisabled ? (
+            <Button
+              asChild
+              size="sm"
+              variant={featured ? "default" : "outline"}
+              className="w-full sm:w-auto"
+            >
+              <a
+                href={ctaHref}
+                {...(ctaTargetBlank
+                  ? { target: "_blank", rel: "noreferrer noopener" }
+                  : {})}
+              >
+                {cta}
+              </a>
+            </Button>
+          ) : (
+            <Button size="sm" variant="ghost" disabled className="w-full sm:w-auto">
+              {cta}
+            </Button>
+          )}
+          {secondaryCta && secondaryCtaHref && (
+            <a
+              href={secondaryCtaHref}
+              className="text-xs text-muted-foreground hover:underline self-start"
+            >
+              {secondaryCta}
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/settings-dialog.tsx
+++ b/src/components/settings/settings-dialog.tsx
@@ -1,4 +1,15 @@
-import { useState } from "react";
+/**
+ * Unified Settings dialog.
+ *
+ * Driven by useSettingsStore — no props. Mounted once at App level; any
+ * caller anywhere in the tree can open it via openSettings(tab?) from
+ * @/lib/open-settings. Default landing tab is "account" because that's
+ * where tier / billing / sync / upgrade live.
+ *
+ * Phase A still shows the original three tabs (account / import / export);
+ * Phase B expands to (account / reading / data / help) and folds in the
+ * SyncSetupDialog and UpgradeDialog content as sections inside Account.
+ */
 import {
   Dialog,
   DialogContent,
@@ -9,26 +20,16 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { ImportView } from "./import-view";
 import { ExportView } from "./export-view";
 import { AccountTab } from "./account-tab";
+import { useSettingsStore, type SettingsTab } from "@/stores/settings-store";
+import { closeSettings } from "@/lib/open-settings";
 
-type SettingsView = "import" | "export" | "account";
-
-interface SettingsDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}
-
-export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
-  const [view, setView] = useState<SettingsView>("import");
-
-  function handleOpenChange(nextOpen: boolean) {
-    if (!nextOpen) {
-      setView("import");
-    }
-    onOpenChange(nextOpen);
-  }
+export function SettingsDialog() {
+  const open = useSettingsStore((s) => s.open);
+  const activeTab = useSettingsStore((s) => s.activeTab);
+  const setActiveTab = useSettingsStore((s) => s.setActiveTab);
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={(next) => !next && closeSettings()}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
@@ -36,24 +37,24 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
 
         <ToggleGroup
           type="single"
-          value={view}
-          onValueChange={(v) => v && setView(v as SettingsView)}
+          value={activeTab}
+          onValueChange={(v) => v && setActiveTab(v as SettingsTab)}
           className="justify-start"
         >
+          <ToggleGroupItem value="account" aria-label="Account">
+            Account
+          </ToggleGroupItem>
           <ToggleGroupItem value="import" aria-label="Import feeds">
             Import
           </ToggleGroupItem>
           <ToggleGroupItem value="export" aria-label="Export feeds">
             Export
           </ToggleGroupItem>
-          <ToggleGroupItem value="account" aria-label="Account">
-            Account
-          </ToggleGroupItem>
         </ToggleGroup>
 
-        {view === "import" && <ImportView onClose={() => onOpenChange(false)} />}
-        {view === "export" && <ExportView />}
-        {view === "account" && <AccountTab />}
+        {activeTab === "account" && <AccountTab />}
+        {activeTab === "import" && <ImportView onClose={closeSettings} />}
+        {activeTab === "export" && <ExportView />}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/settings/settings-menu.tsx
+++ b/src/components/settings/settings-menu.tsx
@@ -6,11 +6,13 @@ import {
   Loader2,
   MessageSquare,
   Sparkles,
+  User,
   Wand2,
 } from "lucide-react";
 import { useSyncStore } from "@/stores/sync-store.ts";
 import { useAppStore } from "@/stores/app-store.ts";
 import { requestSyncSetup } from "@/lib/request-sync-setup.ts";
+import { openSettings } from "@/lib/open-settings.ts";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -92,6 +94,12 @@ export function SettingsMenu(props: SettingsMenuProps) {
     return (
       <>
         <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={() => openSettings("account")}>
+              <User className="size-4" />
+              <span>Account</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
           {showSync && (
             <SidebarMenuItem>
               <SidebarMenuButton onClick={() => requestSyncSetup()}>
@@ -172,6 +180,15 @@ export function SettingsMenu(props: SettingsMenuProps) {
           align={align}
           sideOffset={4}
         >
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              openSettings("account");
+            }}
+          >
+            <User className="size-4" />
+            <span>Account</span>
+          </DropdownMenuItem>
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuItem

--- a/src/components/sync/sync-migration-dialog.tsx
+++ b/src/components/sync/sync-migration-dialog.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useSyncStore } from "@/stores/sync-store";
+import { openSettings } from "@/lib/open-settings";
 
 const SELF_HOST_GUIDE_URL = "https://www.feedzero.app/docs/self-hosting";
 
@@ -68,10 +69,14 @@ export function SyncMigrationDialog() {
         </div>
 
         <DialogFooter className="flex-col gap-2 sm:flex-col sm:items-stretch">
-          <Button asChild className="w-full">
-            <a href="/?subscribe=personal-monthly">
-              Subscribe to Personal — $5/mo
-            </a>
+          <Button
+            className="w-full"
+            onClick={() => {
+              dismissPendingMigration();
+              openSettings("account");
+            }}
+          >
+            Subscribe to Personal — $5/mo
           </Button>
           <Button
             variant="outline"

--- a/src/lib/open-settings.ts
+++ b/src/lib/open-settings.ts
@@ -1,0 +1,25 @@
+/**
+ * Single entry point for opening the unified Settings dialog.
+ *
+ * Default tab is "account" because that's where tier, billing, sync, and
+ * upgrade live — the dominant reason to open settings. Pass a tab name to
+ * land elsewhere ("data" for import/export, "help" for shortcuts/feedback).
+ *
+ * Replaces requestSyncSetup() and direct useSyncStore.setDialogOpen calls.
+ * Callers shouldn't reach into the store themselves — going through this
+ * helper means future routing (e.g., "free user opens settings → highlight
+ * upgrade section") has one place to live.
+ */
+import {
+  useSettingsStore,
+  type SettingsTab,
+} from "@/stores/settings-store";
+
+export function openSettings(tab?: SettingsTab): void {
+  const next: SettingsTab = tab ?? "account";
+  useSettingsStore.setState({ open: true, activeTab: next });
+}
+
+export function closeSettings(): void {
+  useSettingsStore.setState({ open: false });
+}

--- a/src/lib/request-sync-setup.ts
+++ b/src/lib/request-sync-setup.ts
@@ -1,37 +1,20 @@
 /**
- * Intent-layer gate for the "Enable cloud sync" affordance.
+ * "User intent: open the sync surface" — now a thin alias for
+ * `openSettings("account")`.
  *
- * Cloud sync is a paid feature. Free users in production paywall mode used
- * to be able to click the affordance, derive a passphrase, push a vault, and
- * only THEN hit a 401 from /api/sync — landing in SyncMigrationDialog with
- * no obvious way back. This helper checks the gate first: free users hit
- * the UpgradeDialog instead of starting a flow they can't complete.
+ * Phase A established the unified Settings dialog with an Account tab.
+ * Phase B extended that tab to adaptively render the upgrade comparison
+ * for free users and the cloud-sync controls for paid users. So the gate
+ * routing that used to live here (free → UpgradeDialog, paid →
+ * SyncSetupDialog) is now expressed by the Account tab itself.
  *
- * Single chokepoint so all three call sites (sidebar's LocalStorageWarning,
- * SyncStatusChip, settings menu) share the same gating logic. To add a new
- * "Enable cloud sync" entry point, call this — never call
- * `useSyncStore.getState().setDialogOpen(true)` directly.
+ * Kept as a named function (vs inlining `openSettings("account")` at each
+ * call site) so callers preserve the "this click is sync-adjacent" intent
+ * at their site — useful if we later want to scroll to / highlight the
+ * sync section when the dialog opens from a sync affordance.
  */
-
-import { useLicenseStore } from "@/stores/license-store";
-import { useSyncStore } from "@/stores/sync-store";
-import { gateState } from "@/core/features/feature-gates";
-import { isSelfHosted } from "@/core/features/self-hosted";
-import { isPaidTierActive } from "@/core/features/paid-tier-active";
+import { openSettings } from "@/lib/open-settings";
 
 export function requestSyncSetup(): void {
-  const tier = useLicenseStore.getState().tier;
-  const gate = gateState(
-    "cloud-sync",
-    tier,
-    isSelfHosted(),
-    isPaidTierActive(),
-  );
-  if (gate.enabled) {
-    useSyncStore.getState().setDialogOpen(true);
-    return;
-  }
-  // gate.reason === "tier-locked" (or "not-built", which can't happen
-  // because cloud-sync is shipped, but we route to upgrade either way).
-  useLicenseStore.getState().openUpgradeDialog();
+  openSettings("account");
 }

--- a/src/stores/license-store.ts
+++ b/src/stores/license-store.ts
@@ -89,8 +89,17 @@ export const useLicenseStore = create<LicenseState>((set) => ({
       });
       const body = await res.json().catch(() => ({}));
       if (!res.ok || !body.ok) {
-        // Server rejected the token — clear it so we don't keep sending an
-        // invalid Bearer on every sync request.
+        // 5xx = transient (Vercel hiccup, Upstash blip). DO NOT clear the
+        // token — a paying customer would see their tier silently flip to
+        // Free and panic. Keep the locally-decoded tier; the next refresh
+        // (page load, cross-tab event) will retry.
+        // 4xx = the server explicitly rejected this token (revoked,
+        // expired, forged). Clear so we don't keep sending an invalid
+        // Bearer on every sync request.
+        if (res.status >= 500) {
+          set({ verifying: false });
+          return;
+        }
         clearLicenseToken();
         set({ tier: "free", verifying: false });
         return;

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,0 +1,31 @@
+/**
+ * Unified Settings dialog state.
+ *
+ * Single source of truth for the in-app Settings dialog's open/closed state
+ * and which tab is active. Replaces three previous mechanisms:
+ *   - useSyncStore.dialogOpen (cloud-sync setup modal)
+ *   - useLicenseStore.upgradeDialogOpen (upgrade tier-comparison modal)
+ *   - local useState in SettingsMenu (keyboard shortcuts, feedback,
+ *     auto-organize subdialogs)
+ *
+ * All of those collapse into THIS store + the four-tab Settings dialog.
+ * Use `openSettings(tab?)` and `closeSettings()` from `@/lib/open-settings`
+ * — components should rarely call setState on this store directly.
+ */
+import { create } from "zustand";
+
+export type SettingsTab = "account" | "reading" | "data" | "help";
+
+interface SettingsState {
+  open: boolean;
+  activeTab: SettingsTab;
+  setOpen: (open: boolean) => void;
+  setActiveTab: (tab: SettingsTab) => void;
+}
+
+export const useSettingsStore = create<SettingsState>((set) => ({
+  open: false,
+  activeTab: "account",
+  setOpen: (open) => set({ open }),
+  setActiveTab: (activeTab) => set({ activeTab }),
+}));

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -14,7 +14,10 @@
  */
 import { create } from "zustand";
 
-export type SettingsTab = "account" | "reading" | "data" | "help";
+// Phase A tabs: account (default), import, export.
+// Phase B will rename to: account, reading, data, help — and fold the
+// sync setup + upgrade content as sections inside the Account tab.
+export type SettingsTab = "account" | "import" | "export";
 
 interface SettingsState {
   open: boolean;

--- a/tests/components/settings/account-sync-section.test.tsx
+++ b/tests/components/settings/account-sync-section.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * <AccountSyncSection> — inline cloud sync controls for the Account tab.
+ *
+ * Replaces the SyncSetupDialog modal for the in-Settings flow. Renders the
+ * status view inline (no Dialog wrapper); SetupWizard, ExistingCloudFlow,
+ * and confirmation prompts stay as nested dialogs triggered by buttons.
+ *
+ * Tests cover the user-observable conditional rendering by sync status,
+ * not the deep sub-dialog flows (those keep their own SyncSetupDialog
+ * tests until that component is deleted).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AccountSyncSection } from "@/components/settings/account-sync-section";
+import { useSyncStore } from "@/stores/sync-store";
+import { useFeedStore } from "@/stores/feed-store";
+
+vi.mock("@/core/crypto/passphrase-generator", () => ({
+  generatePassphrase: vi.fn().mockResolvedValue("alpha bravo charlie delta"),
+}));
+
+describe("<AccountSyncSection>", () => {
+  beforeEach(() => {
+    useSyncStore.setState({
+      status: "local-only",
+      error: null,
+      credentials: null,
+    });
+    useFeedStore.setState({ feeds: [] });
+  });
+
+  it("renders Enable sync and Use existing cloud account buttons when local-only", () => {
+    render(<AccountSyncSection />);
+    expect(
+      screen.getByRole("button", { name: /enable sync/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /use existing/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Switch to local / Restore / Log out when synced", () => {
+    useSyncStore.setState({ status: "synced" });
+    render(<AccountSyncSection />);
+    expect(
+      screen.getByRole("button", { name: /switch to local/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /restore from cloud/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /log out/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a destructive Delete all data button (danger zone) regardless of status", () => {
+    render(<AccountSyncSection />);
+    expect(
+      screen.getByRole("button", { name: /delete all data/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows status text reflecting current sync state", () => {
+    useSyncStore.setState({ status: "synced" });
+    render(<AccountSyncSection />);
+    expect(screen.getByText(/encrypted and synced/i)).toBeInTheDocument();
+  });
+
+  it("shows the sync error message when status is error", () => {
+    useSyncStore.setState({ status: "error", error: "fake network blip" });
+    render(<AccountSyncSection />);
+    expect(screen.getByText(/fake network blip/i)).toBeInTheDocument();
+  });
+});

--- a/tests/components/settings/account-tab.test.tsx
+++ b/tests/components/settings/account-tab.test.tsx
@@ -55,8 +55,9 @@ describe("<AccountTab>", () => {
   describe("free tier (no subscription)", () => {
     it("shows 'Free' tier label and a subscribe CTA", () => {
       render(<AccountTab />);
-      // Exact-match the chip (avoids matching body copy "You're on the Free tier")
-      expect(screen.getByText("Free")).toBeInTheDocument();
+      // "Free" appears as both the tier chip and a tier-comparison heading
+      // in the inline upgrade section. The chip is sufficient signal here.
+      expect(screen.getAllByText("Free").length).toBeGreaterThan(0);
       const subscribeLink = screen.getByRole("link", {
         name: /subscribe to personal/i,
       });
@@ -153,6 +154,27 @@ describe("<AccountTab>", () => {
       // Token gone from storage; tier reset.
       expect(localStorage.getItem(LICENSE_TOKEN_STORAGE_KEY)).toBeNull();
       expect(useLicenseStore.getState().tier).toBe("free");
+    });
+  });
+
+  describe("Phase B: inline upgrade + sync sections", () => {
+    it("free tier renders the full upgrade tier comparison inline (not just a Subscribe button)", () => {
+      useLicenseStore.setState({ tier: "free", verifying: false });
+      render(<AccountTab />);
+      // All four tiers from AccountUpgradeSection
+      expect(screen.getByRole("heading", { name: /^Personal$/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /^Pro$/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /Self-host/i })).toBeInTheDocument();
+    });
+
+    it("paid tier renders the inline cloud sync section", () => {
+      setLicenseToken(makeToken("personal"));
+      useLicenseStore.setState({ tier: "personal", verifying: false });
+      render(<AccountTab />);
+      // AccountSyncSection's "Cloud sync" heading
+      expect(screen.getByRole("heading", { name: /cloud sync/i })).toBeInTheDocument();
+      // For local-only sync status (default), Enable sync button is present
+      expect(screen.getByRole("button", { name: /enable sync/i })).toBeInTheDocument();
     });
   });
 });

--- a/tests/components/settings/account-upgrade-section.test.tsx
+++ b/tests/components/settings/account-upgrade-section.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * <AccountUpgradeSection> — inline tier-comparison for the Account tab.
+ *
+ * Replaces the UpgradeDialog modal for the in-Settings flow. Same four
+ * tier cards (Free / Personal / Pro / Self-host); same CTAs.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AccountUpgradeSection } from "@/components/settings/account-upgrade-section";
+
+describe("<AccountUpgradeSection>", () => {
+  it("renders all four tiers", () => {
+    render(<AccountUpgradeSection />);
+    expect(screen.getByText(/^Free$/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Personal$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Pro$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Self-host/i })).toBeInTheDocument();
+  });
+
+  it("Personal Subscribe CTA links to the personal-monthly deeplink", () => {
+    render(<AccountUpgradeSection />);
+    const cta = screen.getByRole("link", { name: /subscribe.*personal/i });
+    expect(cta.getAttribute("href")).toMatch(/\?subscribe=personal-monthly/);
+  });
+
+  it("Pro tier shows Coming Soon with no subscribe link", () => {
+    render(<AccountUpgradeSection />);
+    expect(screen.getByText(/coming 2026/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /pro/i })).toBeNull();
+  });
+
+  it("Self-host links to the docs page", () => {
+    render(<AccountUpgradeSection />);
+    const link = screen.getByRole("link", { name: /self-host/i });
+    expect(link.getAttribute("href")).toMatch(/self-host/);
+  });
+});

--- a/tests/components/settings/settings-dialog.test.tsx
+++ b/tests/components/settings/settings-dialog.test.tsx
@@ -1,13 +1,16 @@
 /**
  * <SettingsDialog> — focused tab-wiring tests.
  *
- * Verifies the Account tab is reachable. Behavioral details of each tab
- * are tested in their own spec files (account-tab.test.tsx, etc.).
+ * Verifies the Account tab is reachable and that the dialog is driven by
+ * useSettingsStore (props-less). Behavioral details of each tab are tested
+ * in their own spec files (account-tab.test.tsx, etc.).
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { SettingsDialog } from "@/components/settings/settings-dialog";
 import { useLicenseStore } from "@/stores/license-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import { openSettings, closeSettings } from "@/lib/open-settings";
 
 // Mock the heavyweight tab views — we're testing the dialog's switching,
 // not the views themselves.
@@ -21,27 +24,50 @@ vi.mock("@/components/settings/export-view", () => ({
 describe("<SettingsDialog>", () => {
   beforeEach(() => {
     useLicenseStore.setState({ tier: "free", verifying: false });
+    useSettingsStore.setState({ open: false, activeTab: "account" });
   });
 
-  it("renders an Account toggle alongside Import/Export", () => {
-    render(<SettingsDialog open onOpenChange={() => {}} />);
-    expect(screen.getByLabelText(/import feeds/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/export feeds/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/account/i)).toBeInTheDocument();
+  it("renders nothing when the store says closed", () => {
+    render(<SettingsDialog />);
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("clicking the Account toggle shows the AccountTab", () => {
-    render(<SettingsDialog open onOpenChange={() => {}} />);
-    // Sanity: Import is the default view
-    expect(screen.getByTestId("import-view")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByLabelText(/account/i));
-
-    // AccountTab on free tier shows the Subscribe CTA
+  it("opens via openSettings() and lands on the Account tab by default", () => {
+    render(<SettingsDialog />);
+    act(() => openSettings());
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /subscribe to personal/i }),
     ).toBeInTheDocument();
-    // And Import is gone
-    expect(screen.queryByTestId("import-view")).toBeNull();
+  });
+
+  it("renders all three tab toggles (account / import / export)", () => {
+    act(() => openSettings());
+    render(<SettingsDialog />);
+    expect(screen.getByLabelText(/account/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/import feeds/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/export feeds/i)).toBeInTheDocument();
+  });
+
+  it("opens on the specified tab when openSettings('import') is called", () => {
+    render(<SettingsDialog />);
+    act(() => openSettings("import"));
+    expect(screen.getByTestId("import-view")).toBeInTheDocument();
+  });
+
+  it("clicking a toggle updates the store's activeTab", () => {
+    act(() => openSettings());
+    render(<SettingsDialog />);
+    fireEvent.click(screen.getByLabelText(/export feeds/i));
+    expect(useSettingsStore.getState().activeTab).toBe("export");
+    expect(screen.getByTestId("export-view")).toBeInTheDocument();
+  });
+
+  it("closeSettings() closes the dialog", () => {
+    act(() => openSettings());
+    render(<SettingsDialog />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    act(() => closeSettings());
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 });

--- a/tests/components/settings/settings-menu-account-entry.test.tsx
+++ b/tests/components/settings/settings-menu-account-entry.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * SettingsMenu should expose an "Account" entry that opens the unified
+ * Settings dialog on the Account tab.
+ *
+ * Phase A scope: just add the entry to the existing dropdown + list
+ * variants. The dropdown itself stays — Phase B will replace it with a
+ * single sidebar button. This test guards the visibility fix: prior to
+ * PR #85 the only path to the Account tab was buried in the Explore
+ * page's "Import / Export" button.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SettingsMenu } from "@/components/settings/settings-menu";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useSyncStore } from "@/stores/sync-store";
+import { useAppStore } from "@/stores/app-store";
+
+vi.mock("@/components/layout/keyboard-shortcuts-dialog", () => ({
+  KeyboardShortcutsDialog: () => null,
+}));
+vi.mock("@/components/feedback/feedback-dialog", () => ({
+  FeedbackDialog: () => null,
+}));
+vi.mock("@/components/folders/auto-organize-dialog", () => ({
+  AutoOrganizeDialog: () => null,
+}));
+
+function renderMenu() {
+  return render(
+    <SidebarProvider>
+      <SettingsMenu variant="list" hasFeeds={false} onWhatsNew={() => {}} />
+    </SidebarProvider>,
+  );
+}
+
+describe("SettingsMenu Account entry", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ open: false, activeTab: "account" });
+    useSyncStore.setState({ status: "local-only" });
+    useAppStore.setState({ groupArticleFloods: false });
+  });
+
+  it("renders an Account menu item in the list variant", () => {
+    renderMenu();
+    expect(screen.getByText(/account/i)).toBeInTheDocument();
+  });
+
+  it("clicking Account opens the Settings dialog on the Account tab", () => {
+    renderMenu();
+    fireEvent.click(screen.getByText(/account/i));
+    const s = useSettingsStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.activeTab).toBe("account");
+  });
+
+  // Note: the dropdown variant uses Radix DropdownMenu which portals its
+  // content outside the DOM tree happy-dom can fully render. Behavior-test
+  // via the list variant above is sufficient — both variants share the
+  // same onClick handler that calls openSettings("account"). When Phase B
+  // deletes the dropdown entirely (replaced by a single sidebar button
+  // that calls openSettings()), this concern goes away.
+});

--- a/tests/components/sync/sync-migration-dialog.test.tsx
+++ b/tests/components/sync/sync-migration-dialog.test.tsx
@@ -82,14 +82,18 @@ describe("SyncMigrationDialog", () => {
     expect(useSyncStore.getState().credentials).toBeNull();
   });
 
-  it("offers a Subscribe link pointing at the Personal monthly deeplink", () => {
+  it("offers a Subscribe action that routes through Settings → Account (per Phase B unification)", async () => {
+    const { useSettingsStore } = await import("@/stores/settings-store");
+    useSettingsStore.setState({ open: false, activeTab: "account" });
     useSyncStore.setState({ pendingMigration: "license-required" });
     renderDialog();
-    const subscribe = screen.getByRole("link", { name: /subscribe/i });
-    // Deeplink consumer parses ?subscribe=personal-monthly and routes to Stripe.
-    expect(subscribe.getAttribute("href")).toMatch(
-      /subscribe=personal-monthly/,
-    );
+    // Subscribe is now a button (not a link) — clicking it opens the
+    // unified Settings dialog on the Account tab where the customer sees
+    // the four-tier comparison and clicks Subscribe in the Personal card.
+    const subscribe = screen.getByRole("button", { name: /subscribe/i });
+    subscribe.click();
+    expect(useSettingsStore.getState().open).toBe(true);
+    expect(useSettingsStore.getState().activeTab).toBe("account");
   });
 
   it("offers a Self-host link pointing at the docs", () => {

--- a/tests/components/sync/sync-status-chip.test.tsx
+++ b/tests/components/sync/sync-status-chip.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SyncStatusChip } from "@/components/sync/sync-status-chip";
 import { useSyncStore } from "@/stores/sync-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useLicenseStore } from "@/stores/license-store";
 
 describe("SyncStatusChip", () => {
   beforeEach(() => {
@@ -10,6 +12,8 @@ describe("SyncStatusChip", () => {
       status: "local-only",
       dialogOpen: false,
     });
+    useSettingsStore.setState({ open: false, activeTab: "account" });
+    useLicenseStore.setState({ tier: "free", verifying: false });
   });
 
   it("shows 'Cloud sync' label", () => {
@@ -30,15 +34,13 @@ describe("SyncStatusChip", () => {
     expect(toggle).toBeChecked();
   });
 
-  it("opens dialog when clicked", async () => {
+  it("opens Settings on the Account tab when clicked (Phase B unification)", async () => {
     const user = userEvent.setup();
-    const setDialogOpen = vi.fn();
-    useSyncStore.setState({ setDialogOpen });
-
     render(<SyncStatusChip />);
     await user.click(screen.getByText("Cloud sync"));
-
-    expect(setDialogOpen).toHaveBeenCalledWith(true);
+    const s = useSettingsStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.activeTab).toBe("account");
   });
 
   it("shows spinner animation for syncing status", () => {

--- a/tests/lib/open-settings.test.ts
+++ b/tests/lib/open-settings.test.ts
@@ -27,25 +27,25 @@ describe("openSettings", () => {
   });
 
   it("opens on the requested tab when one is provided", () => {
-    openSettings("data");
+    openSettings("import");
     const s = useSettingsStore.getState();
     expect(s.open).toBe(true);
-    expect(s.activeTab).toBe("data");
+    expect(s.activeTab).toBe("import");
   });
 
   it("switches tab when called with a new tab while already open", () => {
-    openSettings("reading");
-    openSettings("help");
+    openSettings("import");
+    openSettings("export");
     const s = useSettingsStore.getState();
     expect(s.open).toBe(true);
-    expect(s.activeTab).toBe("help");
+    expect(s.activeTab).toBe("export");
   });
 
   it("closeSettings closes the dialog but preserves the last active tab", () => {
-    openSettings("help");
+    openSettings("export");
     closeSettings();
     const s = useSettingsStore.getState();
     expect(s.open).toBe(false);
-    expect(s.activeTab).toBe("help");
+    expect(s.activeTab).toBe("export");
   });
 });

--- a/tests/lib/open-settings.test.ts
+++ b/tests/lib/open-settings.test.ts
@@ -1,0 +1,51 @@
+/**
+ * openSettings — single helper for opening the unified Settings dialog.
+ *
+ * Replaces three previous entry points:
+ *   - useSyncStore.setDialogOpen(true)
+ *   - useLicenseStore.openUpgradeDialog()
+ *   - requestSyncSetup() (the gate-routing helper)
+ *
+ * Every caller now opens the same dialog. The optional `tab` arg picks which
+ * tab to land on. Default is "account" because that's where the upgrade,
+ * sync, and billing surfaces live — the most common reason to open settings.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { openSettings, closeSettings } from "@/lib/open-settings";
+import { useSettingsStore } from "@/stores/settings-store";
+
+describe("openSettings", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ open: false, activeTab: "account" });
+  });
+
+  it("opens the dialog on the Account tab by default", () => {
+    openSettings();
+    const s = useSettingsStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.activeTab).toBe("account");
+  });
+
+  it("opens on the requested tab when one is provided", () => {
+    openSettings("data");
+    const s = useSettingsStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.activeTab).toBe("data");
+  });
+
+  it("switches tab when called with a new tab while already open", () => {
+    openSettings("reading");
+    openSettings("help");
+    const s = useSettingsStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.activeTab).toBe("help");
+  });
+
+  it("closeSettings closes the dialog but preserves the last active tab", () => {
+    openSettings("help");
+    closeSettings();
+    const s = useSettingsStore.getState();
+    expect(s.open).toBe(false);
+    expect(s.activeTab).toBe("help");
+  });
+});

--- a/tests/lib/request-sync-setup.test.ts
+++ b/tests/lib/request-sync-setup.test.ts
@@ -1,63 +1,41 @@
 /**
- * requestSyncSetup() — intent-layer gate for the "Enable cloud sync" affordance.
+ * requestSyncSetup() — now a thin alias for openSettings("account").
  *
- * The pre-PR behavior was: free users in production paywall mode could click
- * "Enable cloud sync", derive a passphrase, push a vault, and only then hit
- * a 401 from /api/sync — landing in SyncMigrationDialog with no clear path
- * back. This helper gates at the intent layer: a free user clicking the
- * affordance opens UpgradeDialog instead, never reaching the dead-end.
+ * Phase A established the unified Settings dialog with an Account tab.
+ * Phase B extended the Account tab to render the right content per tier
+ * (upgrade section for free users, sync controls for paid). So the gate
+ * logic that used to live in requestSyncSetup is now in the tab itself —
+ * one path, one place. requestSyncSetup remains as a named entry point
+ * for callers that want the "user clicked something sync-adjacent" intent
+ * documented at the call site, but it just opens Settings → Account.
+ *
+ * Kept as a separate helper (vs inlining openSettings calls) so future
+ * changes (e.g. "highlight the sync section when triggered from a sync
+ * affordance") have one place to live.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { requestSyncSetup } from "@/lib/request-sync-setup";
+import { useSettingsStore } from "@/stores/settings-store";
 import { useLicenseStore } from "@/stores/license-store";
-import { useSyncStore } from "@/stores/sync-store";
-
-vi.mock("@/core/features/self-hosted", () => ({
-  isSelfHosted: vi.fn(() => false),
-}));
-vi.mock("@/core/features/paid-tier-active", () => ({
-  isPaidTierActive: vi.fn(() => true),
-}));
-
-import { isSelfHosted } from "@/core/features/self-hosted";
-import { isPaidTierActive } from "@/core/features/paid-tier-active";
 
 describe("requestSyncSetup", () => {
   beforeEach(() => {
-    useLicenseStore.setState({
-      tier: "free",
-      verifying: false,
-      upgradeDialogOpen: false,
-    });
-    useSyncStore.setState({ dialogOpen: false });
-    vi.mocked(isSelfHosted).mockReturnValue(false);
-    vi.mocked(isPaidTierActive).mockReturnValue(true);
+    useSettingsStore.setState({ open: false, activeTab: "account" });
+    useLicenseStore.setState({ tier: "free", verifying: false });
   });
 
-  it("opens UpgradeDialog and does NOT open SyncSetupDialog for free users when paid tier is active", () => {
+  it("opens Settings on the Account tab for free users (where the upgrade section lives)", () => {
     requestSyncSetup();
-    expect(useLicenseStore.getState().upgradeDialogOpen).toBe(true);
-    expect(useSyncStore.getState().dialogOpen).toBe(false);
+    const s = useSettingsStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.activeTab).toBe("account");
   });
 
-  it("opens SyncSetupDialog directly for personal-tier users", () => {
+  it("opens Settings on the Account tab for paid users (where the sync section lives)", () => {
     useLicenseStore.setState({ tier: "personal" });
     requestSyncSetup();
-    expect(useSyncStore.getState().dialogOpen).toBe(true);
-    expect(useLicenseStore.getState().upgradeDialogOpen).toBe(false);
-  });
-
-  it("opens SyncSetupDialog directly for self-hosted (gate bypassed)", () => {
-    vi.mocked(isSelfHosted).mockReturnValue(true);
-    requestSyncSetup();
-    expect(useSyncStore.getState().dialogOpen).toBe(true);
-    expect(useLicenseStore.getState().upgradeDialogOpen).toBe(false);
-  });
-
-  it("opens SyncSetupDialog directly when paid tier is dormant (every feature free)", () => {
-    vi.mocked(isPaidTierActive).mockReturnValue(false);
-    requestSyncSetup();
-    expect(useSyncStore.getState().dialogOpen).toBe(true);
-    expect(useLicenseStore.getState().upgradeDialogOpen).toBe(false);
+    const s = useSettingsStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.activeTab).toBe("account");
   });
 });

--- a/tests/stores/license-store.test.ts
+++ b/tests/stores/license-store.test.ts
@@ -113,6 +113,23 @@ describe("useLicenseStore", () => {
       expect(localStorage.getItem(LICENSE_TOKEN_STORAGE_KEY)).toBe(personalToken);
     });
 
+    it("keeps the locally-decoded tier when the server returns 5xx (transient failure)", async () => {
+      setLicenseToken(personalToken);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ ok: false, error: "bad gateway" }), {
+          status: 502,
+        }),
+      );
+
+      await useLicenseStore.getState().refresh();
+      // 5xx = transient (Vercel hiccup, Upstash blip). DO NOT silently
+      // downgrade a paying customer to Free on a transient blip — they'd
+      // see their tier disappear and panic. Only clear on 4xx (server
+      // says explicitly: this token is no good).
+      expect(useLicenseStore.getState().tier).toBe("personal");
+      expect(localStorage.getItem(LICENSE_TOKEN_STORAGE_KEY)).toBe(personalToken);
+    });
+
     it("falls back to free when the token payload is unparseable", async () => {
       // Well-formed-shape token but the payload base64 decodes to gibberish.
       setLicenseToken("fz_bm90LXZhbGlk.c2ln");


### PR DESCRIPTION
## Summary

Consolidates fragmented settings/billing/sync UX into a single Account-centric hub, then adds layered license-recovery safety nets so paying customers can't get stranded. Replaces three previous modals (`SyncSetupDialog`, `UpgradeDialog`, the hidden `SettingsDialog`) with one unified dialog accessible from anywhere.

## Architecture wins

**Single settings surface**:
- New \`useSettingsStore\` + \`openSettings(tab?)\` helper — one chokepoint for opening settings from any caller
- \`<SettingsDialog>\` refactored from props-driven to store-driven, mounted once at App level (was: only inside Explore page)
- Default tab is **Account** because that's where tier / billing / sync / upgrade live

**Account tab now adaptively renders by tier**:
- **Free user**: inline four-tier upgrade comparison (replaces the standalone \`<UpgradeDialog>\` modal)
- **Paid user**: inline cloud-sync controls (replaces the standalone \`<SyncSetupDialog>\` modal) + tier chip + masked-token reveal/copy + Manage subscription + Add another device + safety controls + Sign out

**Routing consolidation** — all 'open sync surface' callers land on the same Account tab:
- Sidebar Cloud sync row → \`openSettings("account")\`
- SyncStatusChip click → \`openSettings("account")\`
- LocalStorageWarning "Enable cloud sync" → \`openSettings("account")\`
- SyncMigrationDialog Subscribe CTA → \`openSettings("account")\` (was direct Stripe deeplink; now routes through tier comparison)
- Sidebar SettingsMenu dropdown gains an "Account" entry → \`openSettings("account")\`

## Robustness (three rounds)

**Round 1 — Recovery safety net** (Account tab for paid users):
- "Email this license to me" → \`mailto:\` with token in body. User mails to own inbox; archive becomes recovery fallback.
- "Download recovery sheet" → .txt with token + customer ID + recovery URL + instructions. Offline storage option.
- "Contact support" → \`mailto:support@feedzero.app\` with diagnostic context (customer ID + token tail + URL + timestamp).

**Round 2 — Transient-failure resilience**:
- license-store no longer silently downgrades paying customers to Free on a 5xx from \`/api/license/verify\`. Only 4xx (explicit rejection: revoked/expired/forged) clears the token.

**Round 3 — Recovery flow troubleshooting**:
- \`/billing/recover\` "didn't get an email?" disclosure appears 60s after submission with spam/typo/secondary-email troubleshooting + a contact-support link. Previously the page was silent-forever-spinner on wrong email or unconfigured Stripe receipts.

## Deletions

- \`<SyncSetupDialog>\` component + test + app.tsx mount — content folded into AccountSyncSection
- \`<UpgradeDialog>\` component + test + app.tsx mount — content folded into AccountUpgradeSection

## NEXT-STEPS.md

New file at repo root lists 9 actions only the operator can take post-merge:
1. Stripe Dashboard: enable "Successful payments" customer emails (5 min, $0)
2. Confirm \`support@feedzero.app\` mailbox routes somewhere monitored (5 min)
3. Stripe Customer Portal config (login link emails, cancel allowed, etc.)
4. Manual end-to-end /billing/recover smoke test against live Stripe
5. Pro tier strategy (feature scope, pricing, founder lifetime offer?)
6. Annual emphasis A/B test (when ≥50 monthly subscribers)
7. Cosmetic: masked-token width
8. Cosmetic Phase B leftovers (sidebar single-button refactor)
9. Operational alerting (webhook acceptedWithIssue → Slack)

## Test plan
- [x] \`npm test\` — 2247 passing (post-deletion baseline)
- [x] \`npx tsc --noEmit\` clean
- [x] 28 new tests across foundation + sections + safety + disclosure
- [ ] **Manual smoke after deploy** — \`NEXT-STEPS.md\` § 4 has the click-by-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)