### PR TITLE
fix(billing): wrap safety-controls buttons to prevent Settings horizontal scroll

### DIFF
--- a/src/components/settings/account-safety-controls.tsx
+++ b/src/components/settings/account-safety-controls.tsx
@@ -108,7 +108,7 @@ export function AccountSafetyControls({
           offline.
         </p>
       </div>
-      <div className="flex flex-col sm:flex-row gap-2">
+      <div className="flex flex-wrap gap-2">
         <Button asChild variant="outline" size="sm">
           <a href={buildEmailMyselfHref(token)}>
             <Mail className="mr-2 size-4" />

--- a/tests/components/settings/account-safety-controls.test.tsx
+++ b/tests/components/settings/account-safety-controls.test.tsx
@@ -52,6 +52,17 @@ describe("<AccountSafetyControls>", () => {
     expect(decodeURIComponent(href)).toContain(CUSTOMER_ID);
   });
 
+  it("button row uses flex-wrap so long labels don't overflow the dialog (no horizontal scroll)", () => {
+    const { container } = render(
+      <AccountSafetyControls token={TOKEN} customerId={CUSTOMER_ID} />,
+    );
+    // Three buttons with verbose labels ("Email this license to me",
+    // "Download recovery sheet", "Contact support") exceed sm:max-w-lg
+    // when forced inline. Use flex-wrap so they stack gracefully instead.
+    const row = container.querySelector("div.flex.flex-wrap");
+    expect(row).not.toBeNull();
+  });
+
   it("uses the operator support email in mailto links", () => {
     render(<AccountSafetyControls token={TOKEN} customerId={CUSTOMER_ID} />);
     const supportLink = screen.getByRole("link", { name: /contact support/i });


### PR DESCRIPTION
## What

The Account tab's "If you ever lose access" panel rendered three buttons (Email this license to me / Download recovery sheet / Contact support) inline at sm:flex-row, which exceeded the Settings dialog's max-w-lg and caused horizontal scroll.

## Why

\`flex-col\` → \`sm:flex-row\` was fine for two-button rows but doesn't scale to three verbose labels.

## Fix

Swap to \`flex-wrap\`. Buttons stack onto multiple lines when they don't fit. Added structural test to catch regressions.

## Test plan
- [x] \`npm test\` passes; new test asserts \`flex-wrap\` is present
- [x] \`npx tsc --noEmit\` clean
- [ ] Visual check on deploy: Settings → Account on a paid account, no horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)