### PR TITLE
feat(polish): dynamic mask width + operator alerting (NEXT-STEPS #7, #9)

### DIFF
--- a/src/components/settings/account-tab.tsx
+++ b/src/components/settings/account-tab.tsx
@@ -49,10 +49,29 @@ function formatRenewal(expirySec: number): string {
   });
 }
 
-// Preserve the fz_ prefix and the dot separator so the format hint is
-// legible while the secret part is opaque. Width matches a typical token
-// so the layout doesn't jump on reveal/hide.
-const MASKED_TOKEN = "fz_••••••••••••••.••••••••••••";
+/**
+ * Mask the token to the SAME character width as the real token, preserving
+ * the `fz_` prefix and the `.` separator. Same width = no layout jitter
+ * when the user toggles reveal/hide.
+ *
+ * Format: `fz_<payload>.<sig>` → `fz_••••.••••` with dot-counts derived
+ * from the actual payload and sig lengths.
+ */
+function maskToken(token: string): string {
+  const PREFIX = "fz_";
+  if (!token.startsWith(PREFIX)) {
+    // Fallback for malformed tokens — match overall width, opaque.
+    return "•".repeat(Math.max(token.length, 8));
+  }
+  const body = token.slice(PREFIX.length);
+  const dotIdx = body.indexOf(".");
+  if (dotIdx < 0) {
+    return PREFIX + "•".repeat(body.length);
+  }
+  const payloadLen = dotIdx;
+  const sigLen = body.length - dotIdx - 1;
+  return `${PREFIX}${"•".repeat(payloadLen)}.${"•".repeat(sigLen)}`;
+}
 
 export function AccountTab() {
   const tier = useLicenseStore((s) => s.tier);
@@ -169,7 +188,7 @@ function PaidView({ tier, onSignOut }: PaidViewProps) {
             </label>
             <div className="flex items-center gap-2">
               <code className="flex-1 text-xs font-mono bg-muted px-2 py-1.5 rounded overflow-x-auto whitespace-nowrap">
-                {revealed ? token : MASKED_TOKEN}
+                {revealed ? token : maskToken(token)}
               </code>
               <Button
                 type="button"

--- a/src/utils/log-error.ts
+++ b/src/utils/log-error.ts
@@ -59,4 +59,26 @@ export function logError(fields: ErrorLogFields): void {
   }
   safe.ts = new Date().toISOString();
   console.error(JSON.stringify(safe));
+
+  // Operator alert for silent webhook failures. When the Stripe webhook
+  // returns 200 with errClass="AcceptedWithIssue", the customer never
+  // hears about it but the license never issues. We can't have those
+  // hide in the log noise. Best-effort POST to the operator's webhook
+  // (Slack, Discord, etc.) so the next paying customer's incident
+  // becomes a notification.
+  //
+  // Fire-and-forget. Failure to alert MUST NOT crash the request handler
+  // that called us.
+  if (fields.errClass === "AcceptedWithIssue") {
+    const url = process.env.OPERATOR_ALERT_URL;
+    if (url) {
+      void fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(safe),
+      }).catch(() => {
+        // swallow — alert failures don't propagate
+      });
+    }
+  }
 }

--- a/tests/components/settings/account-tab.test.tsx
+++ b/tests/components/settings/account-tab.test.tsx
@@ -157,6 +157,22 @@ describe("<AccountTab>", () => {
     });
   });
 
+  describe("masked-token width matches actual token (no layout jitter on reveal)", () => {
+    it("mask preserves fz_ prefix and the dot, with mask width matching token width", () => {
+      const token = makeToken("personal");
+      setLicenseToken(token);
+      useLicenseStore.setState({ tier: "personal", verifying: false });
+      render(<AccountTab />);
+
+      const codeEl = document.querySelector("code");
+      expect(codeEl).not.toBeNull();
+      const maskedText = codeEl!.textContent ?? "";
+      expect(maskedText.startsWith("fz_")).toBe(true);
+      expect(maskedText).toContain(".");
+      expect(maskedText.length).toBe(token.length);
+    });
+  });
+
   describe("Phase B: inline upgrade + sync sections", () => {
     it("free tier renders the full upgrade tier comparison inline (not just a Subscribe button)", () => {
       useLicenseStore.setState({ tier: "free", verifying: false });

--- a/tests/core/utils/log-error.test.ts
+++ b/tests/core/utils/log-error.test.ts
@@ -67,6 +67,109 @@ describe("logError", () => {
     expect(raw).not.toContain("should-not-appear-in-logs-ever");
   });
 
+  describe("operator alerting for silent webhook failures", () => {
+    let originalFetch: typeof fetch;
+    let originalAlertUrl: string | undefined;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      originalAlertUrl = process.env.OPERATOR_ALERT_URL;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+      if (originalAlertUrl === undefined) {
+        delete process.env.OPERATOR_ALERT_URL;
+      } else {
+        process.env.OPERATOR_ALERT_URL = originalAlertUrl;
+      }
+    });
+
+    it("POSTs to OPERATOR_ALERT_URL when errClass is AcceptedWithIssue", async () => {
+      process.env.OPERATOR_ALERT_URL = "https://hooks.example.com/operator";
+      const fetchMock = vi.fn().mockResolvedValue(new Response("ok"));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      logError({
+        route: "/api/stripe/webhook",
+        method: "POST",
+        status: 200,
+        traceId: "req_alert",
+        errClass: "AcceptedWithIssue",
+        errMsg: "Missing tier metadata on price",
+      });
+
+      // Alert is fire-and-forget; flush microtasks
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://hooks.example.com/operator");
+      expect(init.method).toBe("POST");
+      const body = JSON.parse(init.body as string);
+      expect(body.errClass).toBe("AcceptedWithIssue");
+      expect(body.errMsg).toBe("Missing tier metadata on price");
+      expect(body.traceId).toBe("req_alert");
+    });
+
+    it("does NOT POST when errClass is something else (only silent-failure paths alert)", async () => {
+      process.env.OPERATOR_ALERT_URL = "https://hooks.example.com/operator";
+      const fetchMock = vi.fn();
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      logError({
+        route: "/api/sync",
+        method: "PUT",
+        status: 500,
+        traceId: "req_normal_err",
+        errClass: "StorageError",
+        errMsg: "disk full",
+      });
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("is a silent no-op when OPERATOR_ALERT_URL is unset", async () => {
+      delete process.env.OPERATOR_ALERT_URL;
+      const fetchMock = vi.fn();
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      logError({
+        route: "/api/stripe/webhook",
+        method: "POST",
+        status: 200,
+        traceId: "req_x",
+        errClass: "AcceptedWithIssue",
+        errMsg: "Missing line item period.end",
+      });
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("swallows alert-channel failures (don't crash the original handler)", async () => {
+      process.env.OPERATOR_ALERT_URL = "https://hooks.example.com/operator";
+      const fetchMock = vi.fn().mockRejectedValue(new Error("hook down"));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      expect(() =>
+        logError({
+          route: "/api/stripe/webhook",
+          method: "POST",
+          status: 200,
+          traceId: "req_alert_fail",
+          errClass: "AcceptedWithIssue",
+          errMsg: "boom",
+        }),
+      ).not.toThrow();
+
+      await new Promise((r) => setTimeout(r, 10));
+      // Alert was attempted but it failing didn't propagate
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
   it("does NOT emit other PII-like fields (customerId, email, ip, token)", () => {
     logError({
       route: "/api/stripe/webhook",

--- a/tests/smoke/license-recovery.test.ts
+++ b/tests/smoke/license-recovery.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+/**
+ * Smoke test: cross-device license recovery endpoints are reachable and
+ * return the expected structured-error shapes.
+ *
+ * Covers what unit tests can't — that the Vercel deployment actually has
+ * /api/license/recover and /api/license/issue-from-recovery wired through
+ * the dispatcher. A unit-green + smoke-red here means the routes
+ * compiled but didn't deploy (the dispatcher regression we already hit
+ * once for recover during PR #83).
+ *
+ * Doesn't exercise the happy path (no real Stripe portal session
+ * creation, no real magic-link email) — just verifies the public-facing
+ * boundary returns the right shape for invalid inputs. Sufficient signal
+ * that the endpoint is live AND the error path is the one we shipped.
+ *
+ * Skipped by default. Run with `SMOKE_TESTS=1 npx vitest run tests/smoke/`.
+ */
+
+const SKIP = !process.env.SMOKE_TESTS;
+const BASE_URL = process.env.SMOKE_BASE_URL ?? "https://my.feedzero.app";
+
+describe.skipIf(SKIP)("production license-recovery endpoints (live)", () => {
+  it("/api/license/recover returns 200 + enumeration-safe shape for unknown email", async () => {
+    const res = await fetch(`${BASE_URL}/api/license/recover`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        // A clearly-fake email that should not match any Stripe customer
+        email: `smoke-test-${Date.now()}@invalid.example.com`,
+      }),
+    });
+    // Endpoint registered: handler returns 200 with no portalUrl
+    // (enumeration protection — same shape as a real customer would get
+    // pre-portal-session-creation, so an observer can't distinguish).
+    // If we get 404 here, the dispatcher arm for "recover" was dropped.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    // Unknown email → no portalUrl
+    expect(body.portalUrl).toBeUndefined();
+  }, 15_000);
+
+  it("/api/license/recover rejects malformed email — 400 + traceId", async () => {
+    const res = await fetch(`${BASE_URL}/api/license/recover`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+  }, 10_000);
+
+  it("/api/license/issue-from-recovery rejects missing recoveryToken — 400 + traceId", async () => {
+    const res = await fetch(`${BASE_URL}/api/license/issue-from-recovery`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+  }, 10_000);
+
+  it("/api/license/issue-from-recovery rejects a forged recoveryToken — 401 + traceId", async () => {
+    // Garbage token signed with no key. Should fail signature verification
+    // (we use HMAC; the forged signature can't possibly verify).
+    const forged =
+      "eyJjdXN0b21lcklkIjoiY3VzX2F0dGFja2VyIiwiZXhwIjo5OTk5OTk5OTk5fQ.signature_garbage";
+    const res = await fetch(`${BASE_URL}/api/license/issue-from-recovery`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recoveryToken: forged }),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.traceId).toMatch(/^req_[0-9a-f]+$/);
+  }, 10_000);
+});


### PR DESCRIPTION
## Summary

Two small high-value improvements + one new smoke test.

**NEXT-STEPS #7 — Mask width matches token width**
AccountTab's masked license display was a fixed 26-character bullet string. Real tokens vary in length, so reveal/hide caused visible layout shift. \`maskToken()\` now derives dot counts from actual payload + sig lengths → zero shift.

**NEXT-STEPS #9 — Operator alerting + smoke test**
- \`logError()\` POSTs the same structured fields to \`OPERATOR_ALERT_URL\` (env var) when \`errClass\` is \`"AcceptedWithIssue"\`. Fire-and-forget; failures swallowed. The Stripe webhook returns \`AcceptedWithIssue\` when an event is structurally fine but we can't issue a license (missing tier metadata, etc.) — until now those incidents only surfaced when a customer complained.
- New \`tests/smoke/license-recovery.test.ts\` hits the live deployment's \`/api/license/recover\` and \`/api/license/issue-from-recovery\` and asserts structured-error shapes. Catches the dispatcher-route-dropped regression pattern we hit during PR #83.

## To turn alerting on (post-merge)

\`vercel env add OPERATOR_ALERT_URL production\` → paste your Slack/Discord/Zapier webhook URL. No code change required.

## Test plan
- [x] \`npm test\` — 2253 passing (4 new alert tests + 1 new mask-width test + 4 new smoke tests skipped by default)
- [x] \`npx tsc --noEmit\` clean
- [ ] **Post-deploy**: \`SMOKE_TESTS=1 npx vitest run tests/smoke/license-recovery.test.ts\` to verify live endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)