### PR TITLE
feat(billing): PR G — 'Log in' wizard for fresh-instance license holders

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,6 +9,7 @@ import { generatePassphrase } from "@/core/crypto/passphrase-generator.ts";
 import { Toaster } from "@/components/ui/sonner.tsx";
 import { SyncMigrationDialog } from "@/components/sync/sync-migration-dialog.tsx";
 import { SettingsDialog } from "@/components/settings/settings-dialog.tsx";
+import { DeviceSetupWizard } from "@/components/billing/device-setup-wizard.tsx";
 import { NavigateWithSearch } from "@/components/routing/navigate-with-search.tsx";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { FeedsPage } from "@/pages/feeds-page.tsx";
@@ -172,6 +173,7 @@ export function App() {
             have router context. */}
         <SyncMigrationDialog />
         <SettingsDialog />
+        <DeviceSetupWizard />
         <Toaster position="bottom-center" />
       </BrowserRouter>
       <SpeedInsights />

--- a/src/components/billing/device-setup-wizard.tsx
+++ b/src/components/billing/device-setup-wizard.tsx
@@ -1,0 +1,245 @@
+/**
+ * <DeviceSetupWizard> — "log in to a fresh instance" with an existing
+ * FeedZero account.
+ *
+ * Two stages:
+ *   1. License entry — paste an `fz_…` token (or recover via email link).
+ *      POST /api/license/verify validates server-side; on success we
+ *      apply the token and advance.
+ *   2. Optional sync restoration — if the user also uses cloud sync,
+ *      they enter their passphrase to decrypt their vault. Skip is
+ *      always available (license is already applied).
+ *
+ * Why a wizard and not two separate dialogs:
+ *   The license token and the sync passphrase are TWO different
+ *   credentials by design (the server can recover the license; it
+ *   cannot recover the passphrase — that's the E2E privacy guarantee).
+ *   But the user wants ONE "log me into FeedZero" ceremony. The wizard
+ *   makes the two-step nature explicit without making the user navigate
+ *   between disjoint screens.
+ *
+ * Mounted at the app level (alongside <SettingsDialog>); opened via
+ * `openLogin()` from anywhere.
+ */
+import { useState } from "react";
+import { Loader2, KeyRound, CloudDownload } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  setLicenseToken,
+  clearLicenseToken,
+} from "@/core/license/license-token-store";
+import { useLicenseStore } from "@/stores/license-store";
+import { useSyncStore } from "@/stores/sync-store";
+import { useLoginStore } from "@/stores/login-store";
+import { closeLogin } from "@/lib/open-login";
+
+type Stage = "license" | "sync-prompt" | "syncing" | "done";
+
+function isWellFormedToken(token: string): boolean {
+  const trimmed = token.trim();
+  return trimmed.startsWith("fz_") && trimmed.split(".").length === 2;
+}
+
+export function DeviceSetupWizard() {
+  const open = useLoginStore((s) => s.open);
+  const [stage, setStage] = useState<Stage>("license");
+  const [token, setToken] = useState("");
+  const [passphrase, setPassphrase] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  function resetAndClose() {
+    setStage("license");
+    setToken("");
+    setPassphrase("");
+    setError(null);
+    setBusy(false);
+    closeLogin();
+  }
+
+  async function handleVerifyLicense() {
+    setError(null);
+    const trimmed = token.trim();
+    if (!isWellFormedToken(trimmed)) {
+      setError("Invalid license token. Expected format: fz_<...>.<...>");
+      return;
+    }
+    setBusy(true);
+    setLicenseToken(trimmed);
+    try {
+      const res = await fetch("/api/license/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: trimmed }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok) {
+        clearLicenseToken();
+        setError(body.error ?? `License verification failed (${res.status})`);
+        return;
+      }
+      void useLicenseStore.getState().refresh();
+      setStage("sync-prompt");
+    } catch (e) {
+      clearLicenseToken();
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRestoreSync() {
+    if (!passphrase.trim()) {
+      setError("Enter your sync passphrase, or skip this step.");
+      return;
+    }
+    setError(null);
+    setBusy(true);
+    setStage("syncing");
+    const result = await useSyncStore
+      .getState()
+      .switchToExistingCloud(passphrase, "replace");
+    setBusy(false);
+    if (!result.ok) {
+      setError(result.error);
+      setStage("sync-prompt");
+      return;
+    }
+    setStage("done");
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && resetAndClose()}>
+      <DialogContent className="sm:max-w-md">
+        {stage === "license" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Log in</DialogTitle>
+              <DialogDescription>
+                Paste the license token you saved earlier, or recover it by
+                email.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-2">
+              <Label htmlFor="login-token">License token</Label>
+              <Input
+                id="login-token"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="fz_…"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <p className="text-xs text-muted-foreground">
+                Don't have it handy?{" "}
+                <a
+                  href="/billing/recover"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="underline"
+                >
+                  Recover by email →
+                </a>
+              </p>
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <DialogFooter>
+              <Button variant="ghost" onClick={resetAndClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleVerifyLicense} disabled={busy}>
+                {busy ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <KeyRound className="mr-2 size-4" />
+                )}
+                Continue
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {stage === "sync-prompt" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Restore your synced data?</DialogTitle>
+              <DialogDescription>
+                If you also use FeedZero's end-to-end encrypted cloud sync on
+                another device, enter your sync passphrase to decrypt your
+                feeds here. Otherwise, skip — you can always set up sync
+                later from Settings.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-2">
+              <Label htmlFor="login-passphrase">Sync passphrase</Label>
+              <Input
+                id="login-passphrase"
+                type="password"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <DialogFooter>
+              <Button variant="ghost" onClick={resetAndClose}>
+                Skip
+              </Button>
+              <Button onClick={handleRestoreSync} disabled={busy}>
+                <CloudDownload className="mr-2 size-4" />
+                Restore
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {stage === "syncing" && (
+          <div className="flex flex-col items-center justify-center py-8 gap-3 text-sm text-muted-foreground">
+            <Loader2 className="size-6 animate-spin" />
+            Decrypting your synced data…
+          </div>
+        )}
+
+        {stage === "done" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>You're in</DialogTitle>
+              <DialogDescription>
+                Your license is active and your synced feeds are restored.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button onClick={resetAndClose}>Open my feeds</Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/account-upgrade-section.tsx
+++ b/src/components/settings/account-upgrade-section.tsx
@@ -8,12 +8,24 @@
  */
 import { Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { openLogin } from "@/lib/open-login";
 
 export function AccountUpgradeSection() {
   return (
     <div className="space-y-3">
       <p className="text-sm text-muted-foreground">
         Cloud sync, auto-organize, and more — for the price of a coffee.
+      </p>
+
+      <p className="text-xs text-muted-foreground">
+        Already have a FeedZero account?{" "}
+        <button
+          type="button"
+          onClick={openLogin}
+          className="text-primary underline hover:no-underline"
+        >
+          Log in
+        </button>
       </p>
 
       <TierCard

--- a/src/lib/open-login.ts
+++ b/src/lib/open-login.ts
@@ -1,0 +1,17 @@
+/**
+ * Single entry point for "user wants to log in with an existing license."
+ *
+ * Opens <DeviceSetupWizard> — a 2-stage flow that handles license entry
+ * (paste token OR recover via email) and, optionally afterward, sync
+ * restoration. Mirrors openSettings/openUpgrade so every "Log in"
+ * affordance funnels through one place.
+ */
+import { useLoginStore } from "@/stores/login-store";
+
+export function openLogin(): void {
+  useLoginStore.setState({ open: true });
+}
+
+export function closeLogin(): void {
+  useLoginStore.setState({ open: false });
+}

--- a/src/stores/login-store.ts
+++ b/src/stores/login-store.ts
@@ -1,0 +1,19 @@
+/**
+ * Login wizard state — controls visibility of <DeviceSetupWizard>.
+ *
+ * Tiny one-flag store. Lives separately from useSettingsStore because the
+ * login wizard can open in contexts where Settings is not appropriate
+ * (e.g. from the AccountUpgradeSection's secondary "Already have an
+ * account?" link, while Settings is already showing the upgrade view).
+ */
+import { create } from "zustand";
+
+interface LoginStore {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export const useLoginStore = create<LoginStore>((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+}));

--- a/tests/components/billing/device-setup-wizard.test.tsx
+++ b/tests/components/billing/device-setup-wizard.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * <DeviceSetupWizard> — 2-stage "log in to fresh instance" flow.
+ *
+ * Stage 1: license entry
+ *   - Paste token + Continue → POST /api/license/verify
+ *   - "Recover by email" link → opens /billing/recover in a new tab
+ * Stage 2: optional sync restoration
+ *   - "Restore my synced data" → passphrase input → checkVaultExists + pullVault
+ *   - "Skip" → close wizard, license stays applied
+ *
+ * Controlled by useLoginStore; opens via openLogin().
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { DeviceSetupWizard } from "@/components/billing/device-setup-wizard";
+import { useLoginStore } from "@/stores/login-store";
+import { openLogin, closeLogin } from "@/lib/open-login";
+
+const FAKE_TOKEN = "fz_eyJ.signature";
+
+function renderWizard() {
+  return render(
+    <MemoryRouter>
+      <DeviceSetupWizard />
+    </MemoryRouter>,
+  );
+}
+
+describe("<DeviceSetupWizard>", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    useLoginStore.setState({ open: false });
+    localStorage.clear();
+  });
+
+  it("renders nothing when the store is closed", () => {
+    renderWizard();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens on the license-entry step when openLogin() fires", () => {
+    openLogin();
+    renderWizard();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText(/license token/i)).toBeInTheDocument();
+  });
+
+  it("renders a 'Recover by email' link pointing at /billing/recover", () => {
+    openLogin();
+    renderWizard();
+    const link = screen.getByRole("link", { name: /recover.*email|email.*recover/i });
+    expect(link.getAttribute("href")).toBe("/billing/recover");
+  });
+
+  it("rejects malformed tokens client-side without hitting the server", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+    openLogin();
+    renderWizard();
+    fireEvent.change(screen.getByLabelText(/license token/i), {
+      target: { value: "not-a-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/invalid|format/i);
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("on successful license verify, advances to the sync-prompt stage", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        license: { tier: "personal", customerId: "cus_x" },
+      }),
+    });
+    openLogin();
+    renderWizard();
+
+    fireEvent.change(screen.getByLabelText(/license token/i), {
+      target: { value: FAKE_TOKEN },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      // Sync prompt: explains the optional next step
+      expect(screen.getByText(/cloud sync/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /skip/i })).toBeInTheDocument();
+    });
+    globalThis.fetch = originalFetch;
+  });
+
+  it("shows a server-side error when /api/license/verify rejects the token", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ ok: false, error: "License revoked" }),
+    });
+    openLogin();
+    renderWizard();
+
+    fireEvent.change(screen.getByLabelText(/license token/i), {
+      target: { value: FAKE_TOKEN },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/revoked/i);
+    });
+    globalThis.fetch = originalFetch;
+  });
+
+  it("Skip on the sync stage closes the wizard without setting up sync", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        license: { tier: "personal", customerId: "cus_x" },
+      }),
+    });
+    openLogin();
+    renderWizard();
+    fireEvent.change(screen.getByLabelText(/license token/i), {
+      target: { value: FAKE_TOKEN },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    await waitFor(() => screen.getByRole("button", { name: /skip/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /skip/i }));
+    expect(useLoginStore.getState().open).toBe(false);
+    globalThis.fetch = originalFetch;
+  });
+
+  it("closeLogin() closes the wizard", () => {
+    openLogin();
+    renderWizard();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    closeLogin();
+    // Dialog unmounts on close
+    expect(useLoginStore.getState().open).toBe(false);
+  });
+});

--- a/tests/components/settings/account-upgrade-section.test.tsx
+++ b/tests/components/settings/account-upgrade-section.test.tsx
@@ -34,4 +34,18 @@ describe("<AccountUpgradeSection>", () => {
     const link = screen.getByRole("link", { name: /self-host/i });
     expect(link.getAttribute("href")).toMatch(/self-host/);
   });
+
+  it("offers a secondary 'Already have an account? Log in' affordance that opens the device wizard", async () => {
+    // When a free user is routed to the upgrade Plan card via the chokepoint,
+    // they should ALSO see a path to log in if they already have a license
+    // (e.g. they bought on another device). Otherwise they might re-purchase.
+    const { useLoginStore } = await import("@/stores/login-store.ts");
+    useLoginStore.setState({ open: false });
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    render(<AccountUpgradeSection />);
+    const loginBtn = screen.getByRole("button", { name: /log in/i });
+    await user.click(loginBtn);
+    expect(useLoginStore.getState().open).toBe(true);
+  });
 });

--- a/tests/lib/open-login.test.ts
+++ b/tests/lib/open-login.test.ts
@@ -1,0 +1,33 @@
+/**
+ * openLogin — single entry point for "I already have an account."
+ *
+ * Mirrors openSettings/openUpgrade. Every "Log in" affordance funnels
+ * through this helper so future routing decisions (analytics, A/B,
+ * tier-aware variants) have one place to live.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { openLogin, closeLogin } from "@/lib/open-login";
+import { useLoginStore } from "@/stores/login-store";
+
+describe("openLogin", () => {
+  beforeEach(() => {
+    useLoginStore.setState({ open: false });
+  });
+
+  it("opens the device setup wizard", () => {
+    openLogin();
+    expect(useLoginStore.getState().open).toBe(true);
+  });
+
+  it("closeLogin closes the wizard", () => {
+    openLogin();
+    closeLogin();
+    expect(useLoginStore.getState().open).toBe(false);
+  });
+
+  it("opening when already open is idempotent", () => {
+    openLogin();
+    openLogin();
+    expect(useLoginStore.getState().open).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the discoverability gap a license holder hits on a fresh device. Before: they had to know to visit /billing/recover AND then Settings → Account separately. Now there's a single "Log in" ceremony.

### What ships
- **<DeviceSetupWizard>** — 2-stage dialog:
  1. Paste license token → server-verify → apply (or "Recover by email →" link to /billing/recover)
  2. Optional sync restoration — passphrase input → decrypt cloud vault. Skippable.
  3. Done.
- **`openLogin()` helper** — mirrors the `openSettings` / `openUpgrade` chokepoint pattern.
- **AccountUpgradeSection** now renders "Already have a FeedZero account? **Log in**" above the tier cards. Free users routed through the upgrade chokepoint (from PR B) see the login path right next to Subscribe — closes the loop where someone could mistakenly re-purchase.

### Architectural note
The license token and sync passphrase are *different credentials by design* — server can recover the license; cannot recover the passphrase (E2E privacy guarantee). Merging them is impossible without sacrificing privacy. The wizard makes the two-step nature explicit without forcing the user to navigate between disjoint screens — "feels like one ceremony" while staying honest about the architecture.

## Test plan
- [x] `npm test` — 2273 pass / 30 skipped / 0 fail
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: install on fresh browser → open Settings → Account → see "Already have an account? Log in"
- [ ] Click → paste token → verify → see sync prompt
- [ ] Skip sync → land in /feeds with license active
- [ ] Restore sync with correct passphrase → feeds decrypted
- [ ] Restore sync with wrong passphrase → error + retry

Builds on PR #92 (A) and #93 (B). Independent of #94 (D) and #95 (F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)