### PR TITLE
feat(billing): PR H — Danger Zone gates "Delete all data" on subscription state

### DIFF
--- a/src/components/settings/account-sync-section.tsx
+++ b/src/components/settings/account-sync-section.tsx
@@ -31,6 +31,8 @@ import { generatePassphrase } from "@/core/crypto/passphrase-generator";
 import { useSyncStore } from "@/stores/sync-store";
 import { useFeedStore } from "@/stores/feed-store";
 import { useAppStore } from "@/stores/app-store";
+import { useLicenseStore } from "@/stores/license-store";
+import { openPortal } from "@/lib/open-portal";
 import { toast } from "sonner";
 import { SetupWizard } from "@/components/sync/setup-wizard";
 import { ExistingCloudFlow } from "@/components/sync/existing-cloud-flow";
@@ -65,6 +67,65 @@ export function AccountSyncSection() {
     setPending(false);
     setConfirmation("none");
     toast("Sync disabled. Server data deleted.");
+  }
+
+  function DangerZone() {
+    const tier = useLicenseStore((s) => s.tier);
+    const [portalBusy, setPortalBusy] = useState(false);
+    const [portalError, setPortalError] = useState<string | null>(null);
+
+    async function onManageSubscription() {
+      setPortalBusy(true);
+      setPortalError(null);
+      const result = await openPortal();
+      if (!result.ok) {
+        setPortalError(result.error ?? "Couldn't open Stripe portal");
+      }
+      setPortalBusy(false);
+    }
+
+    if (tier !== "free") {
+      // Paid users can't delete data without first canceling the
+      // subscription — otherwise Stripe keeps billing them for an account
+      // they no longer have anywhere to use. Route them to the Customer
+      // Portal first.
+      return (
+        <div className="border-t pt-3 space-y-2">
+          <p className="text-xs font-medium text-destructive">Danger zone</p>
+          <p className="text-xs text-muted-foreground">
+            You have an active subscription. Cancel it in the Stripe
+            Customer Portal before deleting your data — otherwise the
+            subscription stays active with nothing to use it on.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full justify-start"
+            onClick={onManageSubscription}
+            disabled={portalBusy}
+          >
+            {portalBusy ? "Opening Stripe…" : "Manage subscription"}
+          </Button>
+          {portalError && (
+            <p className="text-xs text-destructive">{portalError}</p>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div className="border-t pt-3">
+        <p className="text-xs font-medium text-destructive mb-2">Danger zone</p>
+        <Button
+          variant="outline"
+          className="w-full justify-start text-destructive hover:text-destructive hover:bg-destructive/10"
+          onClick={() => setConfirmation("delete")}
+        >
+          <Trash2 className="mr-2 size-4" />
+          Delete all data
+        </Button>
+      </div>
+    );
   }
 
   async function handleDeleteAll() {
@@ -165,17 +226,8 @@ export function AccountSyncSection() {
         </div>
       )}
 
-      <div className="border-t pt-3">
-        <p className="text-xs font-medium text-destructive mb-2">Danger zone</p>
-        <Button
-          variant="outline"
-          className="w-full justify-start text-destructive hover:text-destructive hover:bg-destructive/10"
-          onClick={() => setConfirmation("delete")}
-        >
-          <Trash2 className="mr-2 size-4" />
-          Delete all data
-        </Button>
-      </div>
+      <DangerZone />
+
 
       {subFlow === "setup" && (
         <SetupWizard

--- a/src/components/settings/account-tab.tsx
+++ b/src/components/settings/account-tab.tsx
@@ -27,6 +27,7 @@ import type { LicensePayload } from "@/core/license/format";
 import { AccountUpgradeSection } from "./account-upgrade-section";
 import { AccountSyncSection } from "./account-sync-section";
 import { AccountLicenseRecovery } from "./account-license-recovery";
+import { openPortal } from "@/lib/open-portal";
 
 const TOKEN_PREFIX = "fz_";
 
@@ -129,26 +130,11 @@ function PaidView({ tier, onSignOut }: PaidViewProps) {
     if (!token) return;
     setPortalBusy(true);
     setPortalError(null);
-    try {
-      const res = await fetch("/api/license/portal", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ returnUrl: window.location.href }),
-      });
-      const body = await res.json();
-      if (!res.ok || !body.ok) {
-        setPortalError(body.error ?? `Portal failed (${res.status})`);
-        return;
-      }
-      window.location.href = body.url;
-    } catch (e) {
-      setPortalError((e as Error).message);
-    } finally {
-      setPortalBusy(false);
+    const result = await openPortal();
+    if (!result.ok) {
+      setPortalError(result.error ?? `Portal failed`);
     }
+    setPortalBusy(false);
   }
 
   function onSignOutClick() {

--- a/src/lib/open-portal.ts
+++ b/src/lib/open-portal.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared helper for opening the Stripe Customer Portal session.
+ *
+ * Two callers need this:
+ *   - AccountTab "Manage subscription" button
+ *   - AccountSyncSection's Danger Zone gate for paid users (PR H)
+ *
+ * Returns `{ ok: true }` on redirect-initiated success, or an error string.
+ * The actual redirect happens here via `window.location.href` — callers
+ * just await and surface errors.
+ */
+import { getLicenseToken } from "@/core/license/license-token-store";
+
+export interface OpenPortalResult {
+  ok: boolean;
+  error?: string;
+}
+
+export async function openPortal(): Promise<OpenPortalResult> {
+  const token = getLicenseToken();
+  if (!token) return { ok: false, error: "No license token available" };
+  try {
+    const res = await fetch("/api/license/portal", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ returnUrl: window.location.href }),
+    });
+    const body = await res.json();
+    if (!res.ok || !body.ok) {
+      return { ok: false, error: body.error ?? `Portal failed (${res.status})` };
+    }
+    window.location.href = body.url;
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}

--- a/tests/components/settings/account-sync-section.test.tsx
+++ b/tests/components/settings/account-sync-section.test.tsx
@@ -14,6 +14,7 @@ import { render, screen } from "@testing-library/react";
 import { AccountSyncSection } from "@/components/settings/account-sync-section";
 import { useSyncStore } from "@/stores/sync-store";
 import { useFeedStore } from "@/stores/feed-store";
+import { useLicenseStore } from "@/stores/license-store";
 
 vi.mock("@/core/crypto/passphrase-generator", () => ({
   generatePassphrase: vi.fn().mockResolvedValue("alpha bravo charlie delta"),
@@ -53,10 +54,41 @@ describe("<AccountSyncSection>", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows a destructive Delete all data button (danger zone) regardless of status", () => {
+  it("shows a destructive Delete all data button when the user is on the Free tier", () => {
+    useLicenseStore.setState({ tier: "free", verifying: false });
     render(<AccountSyncSection />);
     expect(
       screen.getByRole("button", { name: /delete all data/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("HIDES Delete all data and shows a Manage subscription CTA when the user has an active paid subscription", () => {
+    // Why: a paid user clicking Delete would wipe local data but leave the
+    // Stripe subscription orphaned (still billing them with no app to use
+    // it on). Force them through the portal first so cancellation and data
+    // deletion are sequenced safely.
+    useLicenseStore.setState({ tier: "personal", verifying: false });
+    render(<AccountSyncSection />);
+    expect(
+      screen.queryByRole("button", { name: /delete all data/i }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /manage subscription/i }),
+    ).toBeInTheDocument();
+    // Explanatory copy must mention canceling the subscription first
+    expect(
+      screen.getByText(/cancel.*subscription/i),
+    ).toBeInTheDocument();
+  });
+
+  it("paid-tier Pro user also sees the Manage subscription gate (not just personal)", () => {
+    useLicenseStore.setState({ tier: "pro", verifying: false });
+    render(<AccountSyncSection />);
+    expect(
+      screen.queryByRole("button", { name: /delete all data/i }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /manage subscription/i }),
     ).toBeInTheDocument();
   });
 

--- a/tests/components/settings/account-tab.test.tsx
+++ b/tests/components/settings/account-tab.test.tsx
@@ -132,11 +132,17 @@ describe("<AccountTab>", () => {
       });
     });
 
-    it("shows a Manage subscription button (opens Stripe Customer Portal)", () => {
+    it("shows at least one Manage subscription button (opens Stripe Customer Portal)", () => {
+      // Two intentional surfaces for paid users post-PR-H: the primary CTA
+      // in PaidView's header, AND the Danger Zone gate inside
+      // AccountSyncSection (which replaces "Delete all data" with a
+      // "cancel subscription first" message). Both route to the same
+      // /api/license/portal endpoint via openPortal().
       render(<AccountTab />);
-      expect(
-        screen.getByRole("button", { name: /manage subscription/i }),
-      ).toBeInTheDocument();
+      const buttons = screen.getAllByRole("button", {
+        name: /manage subscription/i,
+      });
+      expect(buttons.length).toBeGreaterThanOrEqual(1);
     });
 
     it("shows an Add-another-device link pointing at /billing/recover", () => {


### PR DESCRIPTION
## Summary

A paid user could click "Delete all data" → wipe their feeds → still have an active Stripe subscription billing them for an account they have nothing to use on. PR H closes that hole.

When `tier !== "free"`, the Danger Zone replaces the destructive delete button with:
- "You have an active subscription. Cancel it in the Stripe Customer Portal before deleting your data — otherwise the subscription stays active with nothing to use it on."
- A **Manage subscription** button routing to the Stripe Customer Portal.

Free / local-only users see the existing destructive flow unchanged.

## Also
- New `src/lib/open-portal.ts` — shared helper for the portal call. Two callers now use it (AccountTab and AccountSyncSection); AccountTab refactored from inline fetch.

## Test plan
- [x] `npm test` — 2278 pass / 0 fail
- [x] `npx tsc --noEmit` — clean
- [ ] As paid user: Settings → Account → see "cancel subscription first" message + Manage subscription button (no Delete button)
- [ ] Click Manage subscription → Stripe Customer Portal opens in same tab
- [ ] As free user: Settings → Account → see original "Delete all data" button (unchanged)

Follows arc PRs #91–96. PR E (OPML folders) still queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)