### PR TITLE
feat(opml): PR E — preserve folder structure on import / export

### DIFF
--- a/src/components/settings/export-view.tsx
+++ b/src/components/settings/export-view.tsx
@@ -8,12 +8,16 @@ import { toast } from "sonner";
 
 export function ExportView() {
   const feeds = useFeedStore((s) => s.feeds);
+  const folders = useFeedStore((s) => s.folders);
   const [copied, setCopied] = useState(false);
 
   const urlList = generateUrlList(feeds);
 
   const handleDownloadOpml = useCallback(() => {
-    const opml = generateOpmlFile(feeds);
+    // Pass folders so the exported OPML preserves the user's organization
+    // (PR E round-trip fidelity). Older readers ignore the nested <outline>
+    // wrappers and read the inner feed entries flat.
+    const opml = generateOpmlFile(feeds, folders);
     const blob = new Blob([opml], { type: "application/xml" });
     const url = URL.createObjectURL(blob);
 
@@ -29,7 +33,7 @@ export function ExportView() {
     URL.revokeObjectURL(url);
 
     toast("OPML file downloaded");
-  }, [feeds]);
+  }, [feeds, folders]);
 
   const handleCopyUrls = useCallback(async () => {
     await navigator.clipboard.writeText(urlList);

--- a/src/components/settings/import-view.tsx
+++ b/src/components/settings/import-view.tsx
@@ -39,6 +39,8 @@ export function ImportView({ onClose }: ImportViewProps) {
   const reset = useImportStore((s) => s.reset);
 
   const addFeed = useFeedStore((s) => s.addFeed);
+  const createFolder = useFeedStore((s) => s.createFolder);
+  const moveFeedToFolder = useFeedStore((s) => s.moveFeedToFolder);
 
   const handleFileSelect = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -60,22 +62,26 @@ export function ImportView({ onClose }: ImportViewProps) {
     }
   }, []);
 
-  const extractUrls = useCallback(
-    async (content: string): Promise<string[]> => {
-      // Detect format and parse accordingly
+  /**
+   * Parse the import content into rich entries that carry folder context.
+   * URL-list imports always have folderName=undefined; OPML imports carry
+   * the parent group name when one exists (PR E).
+   */
+  const extractEntries = useCallback(
+    async (
+      content: string,
+    ): Promise<Array<{ xmlUrl: string; folderName?: string }>> => {
       if (isOpmlFormat(content)) {
         const result = parseOpmlFile(content);
-        if (!result.ok) {
-          throw new Error(result.error);
-        }
-        return result.value.map((entry) => entry.xmlUrl);
-      } else {
-        const result = parseUrlList(content);
-        if (!result.ok) {
-          throw new Error(result.error);
-        }
-        return result.value;
+        if (!result.ok) throw new Error(result.error);
+        return result.value.map((entry) => ({
+          xmlUrl: entry.xmlUrl,
+          folderName: entry.folderName,
+        }));
       }
+      const result = parseUrlList(content);
+      if (!result.ok) throw new Error(result.error);
+      return result.value.map((url) => ({ xmlUrl: url }));
     },
     [],
   );
@@ -99,11 +105,13 @@ export function ImportView({ onClose }: ImportViewProps) {
         content = textInput;
       }
 
-      const urls = await extractUrls(content);
-      if (urls.length === 0) {
+      const entries = await extractEntries(content);
+      if (entries.length === 0) {
         setParseError("No valid feed URLs found");
         return;
       }
+
+      const urls = entries.map((e) => e.xmlUrl);
 
       // Upfront quota check. The feed-store also gates per-URL, but doing
       // it once here lets us refuse cleanly before kicking off a loop that
@@ -120,16 +128,46 @@ export function ImportView({ onClose }: ImportViewProps) {
         return;
       }
 
+      // Pre-create one folder per unique folderName so per-feed assignment
+      // afterward is a cheap lookup, and we don't pay createFolder cost on
+      // every loop iteration. PR E.
+      const folderNames = Array.from(
+        new Set(
+          entries
+            .map((e) => e.folderName)
+            .filter((n): n is string => typeof n === "string" && n.length > 0),
+        ),
+      );
+      for (const name of folderNames) {
+        await createFolder(name);
+      }
+      const folderIdByName = new Map<string, string>();
+      for (const f of useFeedStore.getState().folders ?? []) {
+        if (folderNames.includes(f.name)) folderIdByName.set(f.name, f.id);
+      }
+
       // Start import process
       startImport(urls);
 
-      // Process each URL sequentially
-      for (const url of urls) {
-        const result = await addFeed(url);
+      // Process each entry sequentially. After a successful addFeed, look
+      // up the just-added feed by url in the store and move it into the
+      // matching folder (best-effort — a missing folder or feed leaves the
+      // subscription unfiled, which is the safe fallback).
+      for (const entry of entries) {
+        const result = await addFeed(entry.xmlUrl);
         if (result.ok) {
-          recordResult({ url, success: true });
+          if (entry.folderName) {
+            const folderId = folderIdByName.get(entry.folderName);
+            const addedFeed = useFeedStore
+              .getState()
+              .feeds.find((f) => f.url === entry.xmlUrl);
+            if (folderId && addedFeed) {
+              await moveFeedToFolder(addedFeed.id, folderId);
+            }
+          }
+          recordResult({ url: entry.xmlUrl, success: true });
         } else {
-          recordResult({ url, success: false, error: result.error });
+          recordResult({ url: entry.xmlUrl, success: false, error: result.error });
         }
       }
     } catch (err) {
@@ -141,9 +179,11 @@ export function ImportView({ onClose }: ImportViewProps) {
     inputMode,
     selectedFile,
     textInput,
-    extractUrls,
+    extractEntries,
     startImport,
     addFeed,
+    createFolder,
+    moveFeedToFolder,
     recordResult,
   ]);
 

--- a/src/core/opml/opml-service.ts
+++ b/src/core/opml/opml-service.ts
@@ -1,18 +1,26 @@
 import { parseOpml, generateOpml } from "feedsmith";
 import { ok, err } from "../../utils/result.ts";
 import type { Result } from "../../utils/result.ts";
-import type { Feed } from "../../types/index.ts";
+import type { Feed, Folder } from "../../types/index.ts";
 
 /** Represents a feed entry extracted from OPML. */
 export interface OpmlFeedEntry {
   title: string;
   xmlUrl: string;
   htmlUrl?: string;
+  /**
+   * Name of the immediate parent <outline> group, if any. PR E preserves
+   * the folder organization the user had in their previous reader.
+   * Deeply nested folders flatten to their closest named parent — most
+   * readers (Feedly, NetNewsWire, Inoreader) export one level deep, so
+   * this matches real-world OPML.
+   */
+  folderName?: string;
 }
 
 /**
  * Parse an OPML file and extract feed entries.
- * Flattens nested folder structures, returning only entries with xmlUrl.
+ * Preserves immediate-parent folder names (see OpmlFeedEntry.folderName).
  */
 export function parseOpmlFile(xml: string): Result<OpmlFeedEntry[]> {
   if (!xml || typeof xml !== "string" || !xml.trim()) {
@@ -21,25 +29,29 @@ export function parseOpmlFile(xml: string): Result<OpmlFeedEntry[]> {
 
   try {
     const doc = parseOpml(xml);
-    const feeds = extractFeeds(doc.body?.outlines || []);
+    const feeds = extractFeeds(doc.body?.outlines || [], undefined);
     return ok(feeds);
   } catch (e) {
     return err(`Failed to parse OPML: ${(e as Error).message}`);
   }
 }
 
+interface OpmlOutline {
+  text?: string;
+  title?: string;
+  xmlUrl?: string;
+  htmlUrl?: string;
+  outlines?: unknown[];
+}
+
 /**
- * Recursively extract feed entries from OPML outlines.
- * Flattens nested folders and only returns outlines with xmlUrl.
+ * Recursively extract feed entries from OPML outlines, threading the
+ * current folder context through the walk. An outline WITHOUT xmlUrl
+ * (i.e. a folder) becomes the new folderName for its children.
  */
 function extractFeeds(
-  outlines: Array<{
-    text?: string;
-    title?: string;
-    xmlUrl?: string;
-    htmlUrl?: string;
-    outlines?: unknown[];
-  }>,
+  outlines: OpmlOutline[],
+  folderName: string | undefined,
 ): OpmlFeedEntry[] {
   const feeds: OpmlFeedEntry[] = [];
 
@@ -49,12 +61,22 @@ function extractFeeds(
         title: outline.title || outline.text || "",
         xmlUrl: outline.xmlUrl,
         htmlUrl: outline.htmlUrl,
+        folderName,
       });
     }
 
-    // Recursively process nested outlines (folders)
     if (outline.outlines && Array.isArray(outline.outlines)) {
-      feeds.push(...extractFeeds(outline.outlines as typeof outlines));
+      // A parent outline without xmlUrl is a folder; its text/title
+      // becomes the folder name for its children. If we're already inside
+      // a folder, keep the outer one (most readers don't nest more than
+      // one level — flatten to closest named parent).
+      const childFolderName =
+        !outline.xmlUrl
+          ? folderName ?? outline.title ?? outline.text ?? undefined
+          : folderName;
+      feeds.push(
+        ...extractFeeds(outline.outlines as OpmlOutline[], childFolderName),
+      );
     }
   }
 
@@ -64,8 +86,13 @@ function extractFeeds(
 /**
  * Generate an OPML file from an array of Feed objects.
  * Returns a valid OPML document even for empty feeds array.
+ *
+ * When `folders` is provided, feeds with a matching `folderId` are
+ * grouped inside parent `<outline>` wrappers — preserves the user's
+ * organization for round-trip imports (PR E). Unfiled feeds (no
+ * folderId) remain at the top level.
  */
-export function generateOpmlFile(feeds: Feed[]): string {
+export function generateOpmlFile(feeds: Feed[], folders?: Folder[]): string {
   // feedsmith requires at least one outline, so handle empty case manually
   if (feeds.length === 0) {
     return `<?xml version="1.0" encoding="UTF-8"?>
@@ -78,18 +105,47 @@ export function generateOpmlFile(feeds: Feed[]): string {
 </opml>`;
   }
 
+  const feedToOutline = (feed: Feed) => ({
+    type: "rss",
+    text: feed.title,
+    title: feed.title,
+    xmlUrl: feed.url,
+    htmlUrl: feed.siteUrl || undefined,
+  });
+
+  if (!folders || folders.length === 0) {
+    // No folders → backwards-compatible flat output.
+    return generateOpml({
+      head: { title: "FeedZero Subscriptions" },
+      body: { outlines: feeds.map(feedToOutline) },
+    });
+  }
+
+  // Group feeds by folderId; unfiled feeds stay at top level.
+  const byFolder = new Map<string, Feed[]>();
+  const unfiled: Feed[] = [];
+  for (const feed of feeds) {
+    if (feed.folderId) {
+      const list = byFolder.get(feed.folderId) ?? [];
+      list.push(feed);
+      byFolder.set(feed.folderId, list);
+    } else {
+      unfiled.push(feed);
+    }
+  }
+
+  const folderOutlines = folders
+    .filter((f) => byFolder.has(f.id))
+    .map((folder) => ({
+      text: folder.name,
+      title: folder.name,
+      outlines: (byFolder.get(folder.id) ?? []).map(feedToOutline),
+    }));
+
   return generateOpml({
-    head: {
-      title: "FeedZero Subscriptions",
-    },
+    head: { title: "FeedZero Subscriptions" },
     body: {
-      outlines: feeds.map((feed) => ({
-        type: "rss",
-        text: feed.title,
-        title: feed.title,
-        xmlUrl: feed.url,
-        htmlUrl: feed.siteUrl || undefined,
-      })),
+      outlines: [...unfiled.map(feedToOutline), ...folderOutlines],
     },
   });
 }

--- a/tests/components/settings/export-view-folders.test.tsx
+++ b/tests/components/settings/export-view-folders.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * ExportView — passes folder data to generateOpmlFile (PR E round-trip).
+ *
+ * Contract test: verifies the wire-up. The generateOpmlFile contract for
+ * grouping by folders is exercised in opml-service.test.ts.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ExportView } from "@/components/settings/export-view";
+import { useFeedStore } from "@/stores/feed-store";
+
+const generateOpmlMock = vi.fn().mockReturnValue("<opml/>");
+vi.mock("@/core/opml/opml-service", () => ({
+  generateOpmlFile: (...args: unknown[]) =>
+    generateOpmlMock(...(args as Parameters<typeof generateOpmlMock>)),
+  generateUrlList: vi.fn().mockReturnValue(""),
+}));
+
+describe("<ExportView> — folder wire-up", () => {
+  beforeEach(() => {
+    generateOpmlMock.mockClear();
+    // Stub URL.createObjectURL / revokeObjectURL for the download flow.
+    Object.defineProperty(globalThis.URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn().mockReturnValue("blob:fake"),
+    });
+    Object.defineProperty(globalThis.URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("passes BOTH feeds AND folders to generateOpmlFile on download", async () => {
+    const now = Date.now();
+    const folders = [{ id: "fld-tech", name: "Tech", createdAt: now }];
+    const feeds = [
+      {
+        id: "f1",
+        url: "https://example.com/a.xml",
+        title: "A",
+        description: "",
+        siteUrl: "",
+        folderId: "fld-tech",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ];
+    useFeedStore.setState({ feeds, folders } as never);
+
+    const user = userEvent.setup();
+    render(<ExportView />);
+    await user.click(screen.getByRole("button", { name: /download opml/i }));
+
+    expect(generateOpmlMock).toHaveBeenCalledWith(feeds, folders);
+  });
+});

--- a/tests/components/settings/import-view-folders.test.tsx
+++ b/tests/components/settings/import-view-folders.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * ImportView — folder preservation on OPML import (PR E).
+ *
+ * Verifies the end-to-end wire-up: an OPML file with `<outline text="Tech">`
+ * parent groups results in folder creation and per-feed folder assignment.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImportView } from "@/components/settings/import-view";
+import { useFeedStore } from "@/stores/feed-store";
+import { useLicenseStore } from "@/stores/license-store";
+import { useImportStore } from "@/stores/import-store";
+
+vi.mock("@/core/features/self-hosted", () => ({
+  isSelfHosted: vi.fn(() => false),
+}));
+vi.mock("@/core/features/paid-tier-active", () => ({
+  isPaidTierActive: vi.fn(() => true),
+}));
+
+const FOLDERED_OPML = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Organized</title></head>
+  <body>
+    <outline text="Tech">
+      <outline type="rss" text="TechCrunch" xmlUrl="https://techcrunch.com/feed/"/>
+      <outline type="rss" text="Ars" xmlUrl="https://feeds.arstechnica.com/arstechnica/features"/>
+    </outline>
+    <outline text="News">
+      <outline type="rss" text="BBC" xmlUrl="https://feeds.bbci.co.uk/news/rss.xml"/>
+    </outline>
+    <outline type="rss" text="Unfiled" xmlUrl="https://example.com/unfiled.xml"/>
+  </body>
+</opml>`;
+
+describe("ImportView — preserves OPML folder structure (PR E)", () => {
+  let addFeedMock: ReturnType<typeof vi.fn>;
+  let createFolderMock: ReturnType<typeof vi.fn>;
+  let moveFeedToFolderMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    useLicenseStore.setState({ tier: "personal", verifying: false });
+    addFeedMock = vi.fn().mockImplementation(async (url: string) => {
+      // Simulate the post-add state: each addFeed appends a feed with the
+      // matching URL so the importer can look up its id afterward.
+      const newId = `feed-${useFeedStore.getState().feeds.length}`;
+      useFeedStore.setState((s) => ({
+        feeds: [
+          ...s.feeds,
+          {
+            id: newId,
+            url,
+            title: url,
+            description: "",
+            siteUrl: "",
+            createdAt: 0,
+            updatedAt: 0,
+          },
+        ] as never,
+      }));
+      return { ok: true };
+    });
+    createFolderMock = vi.fn().mockImplementation(async (name: string) => {
+      const id = `fld-${name.toLowerCase()}`;
+      useFeedStore.setState((s) => ({
+        folders: [...(s.folders ?? []), { id, name, createdAt: 0 }] as never,
+      }));
+    });
+    moveFeedToFolderMock = vi.fn().mockResolvedValue(undefined);
+    useFeedStore.setState({
+      feeds: [],
+      folders: [],
+      addFeed: addFeedMock,
+      createFolder: createFolderMock,
+      moveFeedToFolder: moveFeedToFolderMock,
+    } as never);
+    useImportStore.getState().reset();
+  });
+
+  it("creates one folder per unique folderName and assigns feeds into them", async () => {
+    const user = userEvent.setup();
+    render(<ImportView onClose={() => {}} />);
+
+    await user.click(screen.getByLabelText(/paste text/i));
+    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    await user.click(textarea);
+    await user.paste(FOLDERED_OPML);
+    await user.click(screen.getByRole("button", { name: /import feeds/i }));
+
+    // Three feeds inside folders + one unfiled
+    expect(addFeedMock).toHaveBeenCalledTimes(4);
+
+    // Two folders created (Tech, News) — exactly once each
+    const folderNames = createFolderMock.mock.calls.map((c) => c[0]);
+    expect(folderNames).toContain("Tech");
+    expect(folderNames).toContain("News");
+    expect(folderNames.length).toBe(2);
+
+    // Each foldered feed got moveFeedToFolder called with its folder id
+    const moveCalls = moveFeedToFolderMock.mock.calls.map((c) => ({
+      feedId: c[0],
+      folderId: c[1],
+    }));
+    expect(moveCalls.some((c) => c.folderId === "fld-tech")).toBe(true);
+    expect(moveCalls.some((c) => c.folderId === "fld-news")).toBe(true);
+    // The unfiled feed must NOT have been moved into any folder
+    expect(moveCalls.length).toBe(3);
+  });
+});

--- a/tests/core/opml/opml-service.test.ts
+++ b/tests/core/opml/opml-service.test.ts
@@ -83,19 +83,38 @@ describe("opml-service", () => {
       });
     });
 
-    it("should flatten nested folders and extract all feeds", () => {
+    it("should PRESERVE folder structure (PR E) — feeds carry their parent folder name", () => {
+      // Was: parser flattened nested folders, dropping the organization the
+      // user had spent years building in their previous reader. PR E
+      // captures the immediate parent <outline>'s text/title as folderName
+      // so the importer can recreate folders on the destination side.
       const result = parseOpmlFile(NESTED_OPML);
       expect(isOk(result)).toBe(true);
 
       const feeds = unwrap(result);
       expect(feeds).toHaveLength(3);
 
-      const urls = feeds.map((f) => f.xmlUrl);
-      expect(urls).toContain("https://techcrunch.com/feed/");
-      expect(urls).toContain(
-        "https://feeds.arstechnica.com/arstechnica/features",
+      const techcrunch = feeds.find(
+        (f) => f.xmlUrl === "https://techcrunch.com/feed/",
       );
-      expect(urls).toContain("https://feeds.bbci.co.uk/news/rss.xml");
+      const ars = feeds.find(
+        (f) => f.xmlUrl === "https://feeds.arstechnica.com/arstechnica/features",
+      );
+      const bbc = feeds.find(
+        (f) => f.xmlUrl === "https://feeds.bbci.co.uk/news/rss.xml",
+      );
+      expect(techcrunch?.folderName).toBe("Tech");
+      expect(ars?.folderName).toBe("Tech");
+      expect(bbc?.folderName).toBe("News");
+    });
+
+    it("top-level (unfiled) feeds get folderName=undefined", () => {
+      const result = parseOpmlFile(SAMPLE_OPML);
+      expect(isOk(result)).toBe(true);
+      const feeds = unwrap(result);
+      for (const f of feeds) {
+        expect(f.folderName).toBeUndefined();
+      }
     });
 
     it("should return error for non-OPML content", () => {
@@ -133,6 +152,96 @@ describe("opml-service", () => {
       const feeds = unwrap(result);
       expect(feeds).toHaveLength(1);
       expect(feeds[0].xmlUrl).toBe("https://example.com/feed");
+    });
+  });
+
+  describe("generateOpmlFile — folder grouping (PR E)", () => {
+    it("groups feeds inside <outline> parent groups when folders are provided", () => {
+      // PR E: round-trip fidelity. Export must mirror the import shape so
+      // a user can move feeds between readers without losing organization.
+      const now = Date.now();
+      const folders = [
+        { id: "fld-tech", name: "Tech", createdAt: now },
+        { id: "fld-news", name: "News", createdAt: now },
+      ];
+      const feeds: Feed[] = [
+        {
+          id: "f-tc",
+          url: "https://techcrunch.com/feed/",
+          title: "TechCrunch",
+          description: "",
+          siteUrl: "https://techcrunch.com/",
+          folderId: "fld-tech",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "f-bbc",
+          url: "https://feeds.bbci.co.uk/news/rss.xml",
+          title: "BBC",
+          description: "",
+          siteUrl: "https://www.bbc.com/",
+          folderId: "fld-news",
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "f-unfiled",
+          url: "https://example.com/feed",
+          title: "Unfiled Example",
+          description: "",
+          siteUrl: "",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ];
+
+      const opml = generateOpmlFile(feeds, folders);
+
+      // Folder outlines exist as wrappers (no xmlUrl, text=folder name)
+      expect(opml).toMatch(/<outline[^>]*text="Tech"[^>]*>[\s\S]*TechCrunch/);
+      expect(opml).toMatch(/<outline[^>]*text="News"[^>]*>[\s\S]*BBC/);
+      // Unfiled feeds stay at top level (not inside any folder)
+      expect(opml).toContain("Unfiled Example");
+    });
+
+    it("round-trip: parse → generate → parse preserves folder membership", () => {
+      const now = Date.now();
+      const folders = [{ id: "fld-tech", name: "Tech", createdAt: now }];
+      const feeds: Feed[] = [
+        {
+          id: "f-tc",
+          url: "https://techcrunch.com/feed/",
+          title: "TechCrunch",
+          description: "",
+          siteUrl: "",
+          folderId: "fld-tech",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ];
+
+      const opml = generateOpmlFile(feeds, folders);
+      const reparsed = parseOpmlFile(opml);
+      expect(isOk(reparsed)).toBe(true);
+      const entries = unwrap(reparsed);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].folderName).toBe("Tech");
+      expect(entries[0].xmlUrl).toBe("https://techcrunch.com/feed/");
+    });
+
+    it("called without folders arg keeps the old flat-list behavior", () => {
+      const feeds = [
+        createMockFeed(
+          "https://example.com/feed",
+          "Example",
+          "https://example.com/",
+        ),
+      ];
+      // Backwards compatible — older callers don't pass folders.
+      const opml = generateOpmlFile(feeds);
+      expect(opml).toContain("Example");
+      expect(opml).toContain("https://example.com/feed");
     });
   });
 


### PR DESCRIPTION
## Summary

Importing OPML from another reader (Feedly, NetNewsWire, Inoreader) used to drop every feed into the top level, losing the user's organization. PR E preserves it both ways.

**Import**: parser captures the immediate parent `<outline>` group as `folderName`. Importer pre-creates one folder per unique name, then assigns each feed to its folder after the addFeed call.

**Export**: `generateOpmlFile(feeds, folders)` groups feeds into nested `<outline>` wrappers by `folderId`. Unfiled feeds stay at the top level. Older readers ignore the wrappers and read the inner feeds flat — fully backwards-compatible.

**Round-trip fidelity**: parse → generate → parse preserves folder membership (new test).

## Design notes
- Deeply nested folders flatten to closest named parent. Most real-world readers export one level deep; this matches.
- Folder creation is best-effort: a missing folder or feed leaves the subscription unfiled. Safe fallback that never blocks the import.
- `generateOpmlFile(feeds)` (no second arg) still works — backwards-compatible.

## Test plan
- [x] `npm test` — 2282 pass / 30 skipped / 0 fail
- [x] `npx tsc --noEmit` — clean
- [ ] Import an OPML with nested `<outline text="Tech">` groups → folders appear in sidebar with feeds nested correctly
- [ ] Export → re-import the same OPML → folder set identical
- [ ] Import an OPML without folders → feeds land at top level (unchanged)
- [ ] Test with a real NetNewsWire / Feedly export

Follows arc PRs #91–96, #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)