### PR TITLE
fix(layout): PR I — stable [sidebar | stage] shell eliminates sidebar resize on route change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Full-text extraction (user-initiated): click "Extracted" → `/api/page` → `ex
 - **src/components/onboarding/** — `onboarding-modal.tsx` + step components under `steps/`.
 - **src/components/explore/**, **feedback/**, **settings/** — feature UIs.
 - **src/components/sync/** — `sync-setup-dialog.tsx` (enable/disable, data mgmt, vault deletion), `sync-status-chip.tsx` (amber local / green synced / red error).
-- **src/pages/feeds-page.tsx** — Desktop: 3-panel CSS grid. Mobile: single panel + back nav. Syncs URL params → Zustand.
+- **src/pages/feeds-page.tsx** — Desktop: two-tier `ResizablePanelGroup`. Outer = `[sidebar | stage]`, constant on every route — the only place sidebar width lives. The `stage` panel is a slot whose *content* varies per route: `<ExploreCatalog>` on `/explore` / empty feeds, `<StatsPage>` on `/stats`, or an inner `ResizablePanelGroup` `[article-list | reader]` on the default route. New feature areas mount inside the stage; they MUST NOT add siblings to the sidebar (that's what made the sidebar visibly resize on every navigation — see ADR 013). Mobile: single panel + back nav. Syncs URL params → Zustand.
 - **src/lib/content-modes.ts** — Pure view-mode logic for reader-panel.
 - **src/lib/decode-entities.ts** — HTML entity decoding for plain-text display.
 
@@ -112,7 +112,7 @@ URL is the source of truth for navigation state. `FeedsPage` syncs URL params �
 Single CSS entry: `src/index.css`. Tailwind CSS v4 via `@tailwindcss/vite` (zero runtime cost).
 
 - `@theme` — Design tokens (`--color-*`, `--font-*`).
-- `@layer base` — Resets, layout grid (`250px 300px 1fr`), base button/input styles.
+- `@layer base` — Resets, base button/input styles. (The desktop layout is a two-tier `ResizablePanelGroup` in `feeds-page.tsx`, not a CSS grid — see ADR 013.)
 - Use Tailwind utilities in JSX with `cn()` from `src/lib/utils.ts`.
 - **Spacing** — Use Tailwind v4's default numeric scale (`p-4`, `gap-2`). Do **not** define `--spacing-xs/sm/md/lg/xl` in `@theme` — these collide with `max-w-*` utilities (`max-w-lg` resolves to `--spacing-lg` instead of `--container-lg`). [Tailwind v4 gotcha](https://github.com/tailwindlabs/tailwindcss/discussions/17777).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,7 +171,7 @@ Every monetization handler (sync, license/verify, license/issue, stripe/webhook,
 Tailwind CSS v4 via `@tailwindcss/vite` (build-time only, zero runtime cost). Single CSS entry point: `src/index.css`.
 
 - **`@theme`** — Design tokens (colors, spacing, fonts, radius)
-- **`@layer base`** — Global resets, 3-panel grid layout, button/input base styles
+- **`@layer base`** — Global resets, button/input base styles (the desktop layout itself is a two-tier `ResizablePanelGroup` in `feeds-page.tsx`, not a CSS grid — see ADR 013)
 - **Tailwind utilities** — Used in JSX `className` props via `cn()` helper (clsx + tailwind-merge)
 
 See [ADR 004](decisions/004-tailwind-css.md) for Tailwind rationale.

--- a/docs/decisions/013-stable-outer-panel-topology.md
+++ b/docs/decisions/013-stable-outer-panel-topology.md
@@ -1,0 +1,76 @@
+# ADR 013: Stable Outer Panel Topology for Sidebar Width Preservation
+
+## Status
+Accepted (2026-05-17).
+
+## Context
+
+The desktop FeedsPage uses `react-resizable-panels` to give users an independently resizable sidebar, article list, and reader. Before this decision, all three lived in a single `ResizablePanelGroup` whose **child set varied by route**:
+
+- `/feeds/:feedId/...` → `[sidebar | article-list | reader]`
+- `/explore` (or empty feeds) → `[sidebar | explore]`
+- `/stats` → `[sidebar | stats]`
+
+PR F (2026-05-13) unified the group's id to `feedzero:layout:main` so it would persist sizes across routes. That fixed *some* of the sidebar-jump symptoms but not all: clicking **Explore** while sitting on `/feeds/:feedId` still visibly resized the sidebar — even though the user had only dragged it to a specific width.
+
+### Why a stable group id wasn't enough
+
+`react-resizable-panels` keys its saved layout by **group id + the shape of children at mount**. When the children shape changes, the library re-derives layout from each panel's `defaultSize` — even when individual panel ids are stable. So the sidebar's stored *percentage* was replayed as a proportion of a now-different total, producing a different *pixel* width. We were "remembering" the user's choice and then dividing it by the wrong number.
+
+A patch in `useSharedSidebarSize` (`useEffect([layoutKey]) → panelRef.resize(stored)`) papered over part of this by imperatively re-applying the stored width after a re-render. It still allowed a one-frame jump and fought the library's own layout pass. It also misidentified the failure mode: the issue isn't memory, it's topology.
+
+The user's stated rule was: **"the sidebar size only changes when the user drags the handle or resizes the window. Nothing else."** Any solution that depends on "the library got it right, *or* our effect corrects it fast enough" violates the spirit of that rule.
+
+## Decision
+
+Make the **outer panel topology constant** across every desktop route. The page now mounts:
+
+```
+ResizablePanelGroup id="feedzero:layout:main" direction="horizontal"
+├── ResizablePanel  id="sidebar"   ← width owned by useSharedSidebarSize
+└── ResizablePanel  id="stage"     ← always present; content swaps by route
+```
+
+The `stage` panel is a slot. Its *content* — not its existence as a sibling of the sidebar — varies by route:
+
+| Route | Stage content |
+|---|---|
+| `/stats` | `<StatsPage>` in a `ScrollArea` |
+| `/explore` or no feeds | `<ExploreCatalog>` in a `ScrollArea` |
+| Default (feed/article) | Inner `ResizablePanelGroup id="feedzero:layout:stage-inner"` → `[article-list | reader]` |
+
+The sidebar's neighbour is now always the same panel (`stage`). The library has nothing to recompute on route change. The rule **holds by construction** rather than by correction.
+
+### Why a separate inner group for list+reader
+
+Putting `article-list` + `reader` in their own group, keyed by `feedzero:layout:stage-inner`, keeps the list/reader split independently resizable and persistent across feed navigation. Its saved state is keyed by its own id, so it can mount/unmount as the user moves between Explore and feed routes without disturbing — or being disturbed by — the sidebar's saved width in the outer group.
+
+### Why we kept `useSharedSidebarSize`
+
+After this refactor, the hook's imperative `panelRef.resize()` effect is no longer load-bearing — the outer group's child set is constant, so the library preserves the sidebar width on its own. The hook remains as a safety net for HMR remounts and any future code path that re-mounts the SidebarProvider. Removing it is a follow-up; doing it in the same PR would conflate two concerns.
+
+## Consequences
+
+**Positive:**
+- Clicking **Explore**, **Stats**, opening a feed, or navigating between articles never changes the sidebar's pixel width. Two layers of regression defence:
+  - Unit test `STRUCTURAL INVARIANT: top-level panels are [sidebar, stage] on every desktop route` (in `tests/components/layout/feeds-page-layout.test.tsx`) — fails if anyone introduces a new top-level panel.
+  - E2E test `inner handle resizes article-list vs reader, leaves sidebar alone` — fails behaviourally if the topology ever lets inner drags affect the sidebar.
+- Future feature areas (Settings, future paid-tier surfaces) drop straight into the stage without changing the sidebar's neighbour relationship. The vocabulary of "the stage" makes that obvious.
+- `feeds-page.tsx` desktop branch is more readable: a single `stageContent` variable holds the per-route content, and the JSX shows the stable shell at a glance.
+
+**Negative:**
+- Existing users' previously-saved `article-list`/`reader` percentages (stored under the outer group's `feedzero:layout:main` id) are silently reset to the new inner group's defaults (40% / 60%) on next load. A one-time silent reset is acceptable; a migration would cost more than it buys.
+- One extra `ResizablePanelGroup` in the React tree on the default route. Negligible; the library is light and the inner group only mounts when needed.
+
+**Rejected alternative (Option 2 — imperative pin):**
+
+Leave the structure as-is and, on every navigation, call `panelRef.resize(savedPixels)` to snap the sidebar back. This was simpler to implement (no JSX restructuring) but violated the rule: the sidebar still gets resized by the library, we just undo it fast. It also fights the library's own layout pass — a recipe for subtle conflicts with future versions. Structural fix wins because it makes the bug impossible, not just unobservable.
+
+## References
+
+- `src/pages/feeds-page.tsx` — the two-tier shell.
+- `src/utils/constants.ts` — `PANEL_LAYOUT_ID.MAIN` / `STAGE_INNER`.
+- `src/hooks/use-shared-sidebar-size.ts` — kept as a safety net for remount paths.
+- `tests/components/layout/feeds-page-layout.test.tsx` — structural invariants.
+- `tests/e2e/layout-scroll.spec.ts` — behavioural invariants (outer vs inner handle).
+- PR F (2026-05-13) — earlier, incomplete fix that unified the group id but left topology variable.

--- a/src/pages/feeds-page.tsx
+++ b/src/pages/feeds-page.tsx
@@ -343,20 +343,72 @@ export function FeedsPage() {
     );
   }
 
-  // Desktop: all three columns in one ResizablePanelGroup so sidebar, article
-  // list, and reader are all independently user-resizable.
-  // AppSidebar uses collapsible="none" so it renders inline (not fixed-position)
-  // and participates naturally in the panel layout.
+  // Desktop: two-tier ResizablePanelGroup model.
+  //
+  //   OUTER group (id = MAIN): [sidebar | stage] — constant on every route.
+  //   STAGE content swaps:
+  //     /stats                  → <StatsPage>
+  //     /explore (or no feeds)  → <ExploreCatalog>
+  //     default                 → INNER group (id = STAGE_INNER) holding
+  //                                [article-list | reader]
+  //
+  // The outer group's child set never changes, so react-resizable-panels
+  // can't recompute layout when the route changes — that's what made the
+  // sidebar visibly resize on every navigation. The sidebar's neighbour
+  // (the stage) is always the same panel; its inner content is none of
+  // the library's business.
+  //
+  // AppSidebar uses collapsible="none" so it renders inline (not
+  // fixed-position) and participates naturally in the panel layout.
   const exploreOrEmpty = isExplorePage || feeds.length === 0;
   const showStats = isStatsPage;
-  // Single stable layout id across all routes — PR F. With the same group
-  // id everywhere, react-resizable-panels preserves the sidebar's user-
-  // dragged width naturally as routes change (the per-route ids of the
-  // prior model made the sidebar visibly resize on every navigation).
-  // Each child panel still has its own stable `id` so the library tracks
-  // their sizes independently.
   const layoutId = PANEL_LAYOUT_ID.MAIN;
   const sidebarSize = useSharedSidebarSize(layoutId);
+
+  let stageContent;
+  if (showStats) {
+    stageContent = (
+      <ScrollArea className="h-full">
+        <Suspense><StatsPage /></Suspense>
+      </ScrollArea>
+    );
+  } else if (exploreOrEmpty) {
+    stageContent = (
+      <ScrollArea className="h-full">
+        <Suspense><ExploreCatalog onFeedAdded={handleFeedAdded} /></Suspense>
+      </ScrollArea>
+    );
+  } else {
+    stageContent = (
+      <ResizablePanelGroup
+        id={PANEL_LAYOUT_ID.STAGE_INNER}
+        direction="horizontal"
+        className="h-full"
+      >
+        <ResizablePanel
+          id="article-list"
+          defaultSize="40%"
+          minSize="180px"
+          className="overflow-hidden"
+        >
+          <ArticleList onArticleSelect={handleArticleSelect} />
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel
+          id="reader"
+          defaultSize="60%"
+          minSize="200px"
+          className="overflow-hidden"
+        >
+          <ReaderPanel
+            nextArticle={nextArticle}
+            prevArticle={prevArticle}
+            onNavigate={handleArticleSelect}
+          />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    );
+  }
 
   return (
     <SidebarProvider className="h-svh overflow-hidden">
@@ -378,43 +430,9 @@ export function FeedsPage() {
           />
         </ResizablePanel>
         <ResizableHandle />
-        {showStats ? (
-          <ResizablePanel id="stats" className="overflow-hidden">
-            <ScrollArea className="h-full">
-              <Suspense><StatsPage /></Suspense>
-            </ScrollArea>
-          </ResizablePanel>
-        ) : exploreOrEmpty ? (
-          <ResizablePanel id="explore" className="overflow-hidden">
-            <ScrollArea className="h-full">
-              <Suspense><ExploreCatalog onFeedAdded={handleFeedAdded} /></Suspense>
-            </ScrollArea>
-          </ResizablePanel>
-        ) : (
-          <>
-            <ResizablePanel
-              id="article-list"
-              defaultSize="33%"
-              minSize="180px"
-              className="overflow-hidden"
-            >
-              <ArticleList onArticleSelect={handleArticleSelect} />
-            </ResizablePanel>
-            <ResizableHandle />
-            <ResizablePanel
-              id="reader"
-              defaultSize="50%"
-              minSize="200px"
-              className="overflow-hidden"
-            >
-              <ReaderPanel
-                nextArticle={nextArticle}
-                prevArticle={prevArticle}
-                onNavigate={handleArticleSelect}
-              />
-            </ResizablePanel>
-          </>
-        )}
+        <ResizablePanel id="stage" className="overflow-hidden">
+          {stageContent}
+        </ResizablePanel>
       </ResizablePanelGroup>
     </SidebarProvider>
   );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -88,27 +88,40 @@ export const ARTICLE_GROUPING = {
 } as const;
 
 /**
- * Group ids for the desktop ResizablePanelGroup. Each layout shape gets its own
- * id so react-resizable-panels persists widths independently — switching from
- * the 3-panel feeds layout to the 2-panel explore/stats layout must not
- * clobber the user's preferred sidebar/article-list/reader proportions.
+ * Group ids for the desktop ResizablePanelGroup tree.
+ *
+ * Two-tier model:
+ *
+ *   OUTER group (id = MAIN)          → constant topology on every route:
+ *     ├─ ResizablePanel "sidebar"      [the only place sidebar width lives]
+ *     └─ ResizablePanel "stage"        [a slot whose content swaps per route]
+ *
+ *   STAGE content (per route):
+ *     /explore | /stats | (empty feeds) → single feature component
+ *     default                            → INNER group (id = STAGE_INNER):
+ *                                            ├─ "article-list"
+ *                                            └─ "reader"
+ *
+ * Why a stable outer topology: react-resizable-panels keys saved layouts by
+ * group id PLUS the shape of children at mount. When the children shape
+ * changes, the library recomputes layout from each panel's `defaultSize` —
+ * which produced a visible sidebar resize whenever the user navigated
+ * between routes (Explore/Stats added/removed siblings of the sidebar).
+ * Keeping the outer group's children as always [sidebar, stage] makes the
+ * rule "sidebar size only changes by drag or window resize" hold by
+ * construction.
+ *
+ * Why a separate inner group: the article-list/reader split should stay
+ * independently resizable across feed navigation, and its own saved state
+ * is keyed by STAGE_INNER, so it's untouched by the outer group's state.
+ *
+ * Historical note: PR F unified the outer group id to MAIN. That fixed the
+ * id, but not the topology — children still varied per route. This refactor
+ * (the "stage" model) completes that fix.
  */
 export const PANEL_LAYOUT_ID = {
-  /**
-   * Single stable layout id used across every route.
-   *
-   * react-resizable-panels persists panel sizes per group id, so a single
-   * stable id means the sidebar width is preserved naturally as the user
-   * navigates between /feeds, /explore, /stats. Conditionally-rendered
-   * child panels (reader on /feeds, single content on /explore) don't
-   * affect the sidebar's stored size because each panel has its own
-   * `id` within the group.
-   *
-   * Prior model used distinct ids per layout shape (`:feeds`, `:single`),
-   * which made the sidebar visibly resize on every navigation — that's
-   * the bug PR F fixed.
-   */
   MAIN: "feedzero:layout:main",
+  STAGE_INNER: "feedzero:layout:stage-inner",
 } as const;
 
 const textEncoder = new TextEncoder();

--- a/tests/components/layout/feeds-page-layout.test.tsx
+++ b/tests/components/layout/feeds-page-layout.test.tsx
@@ -65,6 +65,7 @@ function renderPage(route = "/feeds") {
           element={<FeedsPage />}
         />
         <Route path="/explore" element={<FeedsPage />} />
+        <Route path="/stats" element={<FeedsPage />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -98,13 +99,22 @@ describe("FeedsPage layout — desktop", () => {
     });
   });
 
-  it("shows only 2 panels (sidebar + explore) when there are no feeds", () => {
-    // When no feeds exist, the layout shows sidebar + explore, not sidebar +
-    // article list + reader. The panel group is still present for resizability.
+  it("shows only 2 top-level panels (sidebar + stage) when there are no feeds", () => {
+    // When no feeds exist, the empty-state Explore renders *inside* the stage
+    // panel. The outer panel group always exposes exactly two children:
+    // sidebar and stage. Whatever the route shows lives inside the stage.
     useFeedStore.setState({ feeds: [] });
     const { container } = renderPage();
-    const panels = container.querySelectorAll("[data-panel]");
-    expect(panels).toHaveLength(2);
+    const outerGroup = container.querySelector(
+      "[data-slot='resizable-panel-group']",
+    );
+    expect(outerGroup).not.toBeNull();
+    const topLevelPanels = outerGroup!.querySelectorAll(
+      ":scope > [data-panel]",
+    );
+    expect(topLevelPanels).toHaveLength(2);
+    const ids = Array.from(topLevelPanels).map((p) => p.getAttribute("id"));
+    expect(ids).toEqual(["sidebar", "stage"]);
   });
 
   it("shows panels when feeds exist", () => {
@@ -152,13 +162,14 @@ describe("FeedsPage layout — desktop", () => {
 
   it("each ResizablePanel has overflow-hidden via className", () => {
     const { container } = renderPage();
-    // The library renders data-panel on the outer div with inline overflow:hidden.
-    // Our className prop goes to an inner child div. We assert the inner div
-    // (data-slot="resizable-panel") carries overflow-hidden.
+    // Two-tier model: outer group has [sidebar, stage] (2 panels). On the
+    // default route, the stage contains an inner group with [article-list,
+    // reader] (2 more panels). All four ResizablePanels carry overflow-hidden
+    // so neither layer accidentally introduces a scrollbar at the panel edge.
     const panelSlots = container.querySelectorAll(
       "[data-slot='resizable-panel']",
     );
-    expect(panelSlots).toHaveLength(3);
+    expect(panelSlots).toHaveLength(4);
     for (const slot of panelSlots) {
       // The className is on the inner div (child of data-panel)
       const inner = slot.querySelector("div");
@@ -167,20 +178,23 @@ describe("FeedsPage layout — desktop", () => {
     }
   });
 
-  it("each panel has its own scrollable region", () => {
-    // Both panels use native overflow-y-auto scroll containers.
-    // ArticleList needs a native scroller for the virtualizer to measure.
-    // The reader panel also uses native overflow to avoid Radix ScrollArea's
-    // display:table wrapper, which prevents text from wrapping at panel width.
+  it("each leaf panel has its own scrollable region", () => {
+    // Sidebar, article-list, and reader are the *leaf* panels that hold
+    // scrollable content. The `stage` panel is a relay — its scrollable
+    // children live inside the inner group (or inside a single feature
+    // component on /explore /stats). We assert the three leaves carry
+    // scrollers; double-counting `stage` would falsely require it to scroll.
     const { container } = renderPage();
-    const panels = container.querySelectorAll("[data-panel]");
-    for (const panel of panels) {
-      const scrollArea = panel.querySelector(
+    const leafIds = ["sidebar", "article-list", "reader"];
+    for (const id of leafIds) {
+      const panel = container.querySelector(`[data-panel][id="${id}"]`);
+      expect(panel, `leaf panel ${id} not found`).not.toBeNull();
+      const scrollArea = panel!.querySelector(
         "[data-radix-scroll-area-viewport]",
       );
       const nativeScroller =
-        panel.querySelector(".overflow-y-auto") ??
-        panel.querySelector(".overflow-auto");
+        panel!.querySelector(".overflow-y-auto") ??
+        panel!.querySelector(".overflow-auto");
       expect(scrollArea ?? nativeScroller).not.toBeNull();
     }
   });
@@ -189,12 +203,17 @@ describe("FeedsPage layout — desktop", () => {
     // Radix ScrollArea wraps content in display:table which prevents text from
     // wrapping to the panel width — text clips at the panel edge instead.
     // The reader panel must use a plain overflow-y-auto div.
+    // The reader now lives in the inner group inside `stage`; find it by id
+    // rather than by index, since the outer group also contains panels.
     const { container } = renderPage();
-    const panels = container.querySelectorAll("[data-panel]");
-    const readerPanel = panels[2]; // sidebar=0, article-list=1, reader=2
-    expect(readerPanel.querySelector("[data-radix-scroll-area-viewport]")).toBeNull();
-    const nativeScroller = readerPanel.querySelector(".overflow-y-auto") ??
-      readerPanel.querySelector(".overflow-auto");
+    const readerPanel = container.querySelector('[data-panel][id="reader"]');
+    expect(readerPanel).not.toBeNull();
+    expect(
+      readerPanel!.querySelector("[data-radix-scroll-area-viewport]"),
+    ).toBeNull();
+    const nativeScroller =
+      readerPanel!.querySelector(".overflow-y-auto") ??
+      readerPanel!.querySelector(".overflow-auto");
     expect(nativeScroller).not.toBeNull();
   });
 
@@ -204,12 +223,13 @@ describe("FeedsPage layout — desktop", () => {
     expect(handle).not.toBeNull();
   });
 
-  it("renders 3 ResizablePanels on desktop (sidebar + article list + reader)", () => {
-    // All three columns must be independently resizable. Two handles required:
-    // sidebar|article-list and article-list|reader.
+  it("renders 2 outer + 2 inner ResizablePanels on the default desktop route", () => {
+    // Two-tier model. Outer group: [sidebar | stage]. Stage on the default
+    // route holds an inner group: [article-list | reader]. Total 4 panels,
+    // 2 handles (one per group). Each tier is independently resizable.
     const { container } = renderPage();
     const panels = container.querySelectorAll("[data-panel]");
-    expect(panels).toHaveLength(3);
+    expect(panels).toHaveLength(4);
     const handles = container.querySelectorAll("[data-slot='resizable-handle']");
     expect(handles).toHaveLength(2);
   });
@@ -217,19 +237,63 @@ describe("FeedsPage layout — desktop", () => {
   it("each ResizablePanel has a stable id so the layout library can persist sizes across re-renders", () => {
     // Without stable ids, react-resizable-panels falls back to useId() and
     // generates fresh keys on every mount/route change — which breaks
-    // persistence and causes a visible re-balance when the panel count
-    // changes (e.g. switching to /explore drops the reader panel).
+    // persistence and re-balances proportions on remount.
     const { container } = renderPage();
     const panels = container.querySelectorAll("[data-panel]");
-    expect(panels).toHaveLength(3);
+    expect(panels).toHaveLength(4);
     const ids = Array.from(panels).map((p) => p.getAttribute("id"));
     expect(ids).toEqual(
-      expect.arrayContaining(["sidebar", "article-list", "reader"]),
+      expect.arrayContaining(["sidebar", "stage", "article-list", "reader"]),
     );
     // No id should be auto-generated (react useId values start with ":r")
     for (const id of ids) {
       expect(id).not.toMatch(/^:/);
     }
+  });
+
+  it("STRUCTURAL INVARIANT: top-level panels are [sidebar, stage] on every desktop route", () => {
+    // The sidebar's neighbors must never change across routes. This is the
+    // structural counterpart of the user-facing rule "the sidebar size only
+    // changes when you drag the handle or resize the window."
+    //
+    // react-resizable-panels recomputes layout when a group's child set
+    // changes — even when individual panel ids stay stable. The fix is not
+    // to remember harder, but to never present a different child set in the
+    // first place. The stage is a constant slot whose *content* swaps.
+    for (const route of ["/feeds/f1", "/explore", "/stats"]) {
+      const { container, unmount } = renderPage(route);
+      const outerGroup = container.querySelector(
+        "[data-slot='resizable-panel-group']",
+      );
+      expect(outerGroup, `outer group missing on ${route}`).not.toBeNull();
+      const topLevelPanels = outerGroup!.querySelectorAll(
+        ":scope > [data-panel]",
+      );
+      const ids = Array.from(topLevelPanels).map((p) => p.getAttribute("id"));
+      expect(ids, `top-level ids on ${route}`).toEqual(["sidebar", "stage"]);
+      unmount();
+    }
+  });
+
+  it("inner group exists ONLY on the default route (article list + reader)", () => {
+    // Explore and Stats render a single feature inside the stage with no
+    // inner ResizablePanelGroup. The default route adds a second group for
+    // the list/reader split. This keeps the topology of the *outer* group
+    // constant while letting list/reader stay independently resizable.
+    const { container: cDefault } = renderPage("/feeds/f1");
+    expect(
+      cDefault.querySelectorAll("[data-slot='resizable-panel-group']"),
+    ).toHaveLength(2);
+
+    const { container: cExplore } = renderPage("/explore");
+    expect(
+      cExplore.querySelectorAll("[data-slot='resizable-panel-group']"),
+    ).toHaveLength(1);
+
+    const { container: cStats } = renderPage("/stats");
+    expect(
+      cStats.querySelectorAll("[data-slot='resizable-panel-group']"),
+    ).toHaveLength(1);
   });
 
   it("uses a STABLE layout id across all routes so the sidebar width survives navigation", () => {
@@ -249,12 +313,18 @@ describe("FeedsPage layout — desktop", () => {
     expect(id1).toBe("feedzero:layout:main");
   });
 
-  it("explore layout exposes stable ids for sidebar and explore panels", () => {
+  it("explore route renders [sidebar, stage] at the top level with explore inside the stage", () => {
+    // Explore is a feature area mounted *inside* the stage panel, not a
+    // sibling of sidebar. Total panel count is 2 (no inner group).
     const { container } = renderPage("/explore");
     const panels = container.querySelectorAll("[data-panel]");
     expect(panels).toHaveLength(2);
     const ids = Array.from(panels).map((p) => p.getAttribute("id"));
-    expect(ids).toEqual(expect.arrayContaining(["sidebar", "explore"]));
+    expect(ids).toEqual(["sidebar", "stage"]);
+    const stage = container.querySelector('[data-panel][id="stage"]');
+    expect(stage).not.toBeNull();
+    // ExploreCatalog content lives inside the stage.
+    expect(stage!.textContent ?? "").not.toBe("");
   });
 
   it("does not clobber selectedArticle to the previous URL article when articles mutates faster than React Router (PR #34 follow-up)", async () => {

--- a/tests/e2e/layout-scroll.spec.ts
+++ b/tests/e2e/layout-scroll.spec.ts
@@ -167,20 +167,23 @@ test.describe("Layout and scroll", () => {
     expect(leftAfter).toBe(leftBefore);
   });
 
-  test("panels are resizable via drag handle", async ({ feedPage: page }) => {
+  test("outer handle resizes sidebar vs stage", async ({ feedPage: page }) => {
+    // Two-tier model: the outer ResizablePanelGroup has [sidebar, stage] —
+    // the only place sidebar width changes. Drag the *first* (outer) handle
+    // and assert the sidebar panel's width changed. .first() is required
+    // because the default route also renders an inner group (article-list +
+    // reader) with its own handle.
     await setupFeed(page);
 
-    // Get the resize handle
-    const handle = page.locator('[data-slot="resizable-handle"]');
-    await expect(handle).toBeVisible();
+    const outerHandle = page.locator('[data-slot="resizable-handle"]').first();
+    await expect(outerHandle).toBeVisible();
 
-    // Get initial panel widths
-    const panelsBefore = await page
-      .locator('[data-slot="resizable-panel"]')
-      .evaluateAll((els) => els.map((el) => el.getBoundingClientRect().width));
+    const sidebar = page.locator('[data-panel][id="sidebar"]');
+    const widthBefore = await sidebar.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
 
-    // Drag the handle 100px to the right
-    const handleBox = await handle.boundingBox();
+    const handleBox = await outerHandle.boundingBox();
     if (handleBox) {
       await page.mouse.move(
         handleBox.x + handleBox.width / 2,
@@ -188,23 +191,64 @@ test.describe("Layout and scroll", () => {
       );
       await page.mouse.down();
       await page.mouse.move(
-        handleBox.x + handleBox.width / 2 + 100,
+        handleBox.x + handleBox.width / 2 + 80,
         handleBox.y + handleBox.height / 2,
         { steps: 10 },
       );
       await page.mouse.up();
     }
 
-    // Panel widths should have changed
-    const panelsAfter = await page
-      .locator('[data-slot="resizable-panel"]')
-      .evaluateAll((els) => els.map((el) => el.getBoundingClientRect().width));
+    const widthAfter = await sidebar.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+    expect(Math.abs(widthAfter - widthBefore)).toBeGreaterThan(10);
+  });
 
-    // At least one panel width should have changed after drag
-    const widthChanged =
-      Math.abs(panelsAfter[0] - panelsBefore[0]) > 10 ||
-      Math.abs(panelsAfter[1] - panelsBefore[1]) > 10;
-    expect(widthChanged).toBe(true);
+  test("inner handle resizes article-list vs reader, leaves sidebar alone", async ({
+    feedPage: page,
+  }) => {
+    // The inner ResizablePanelGroup persists the article-list/reader split
+    // independently of the sidebar. Dragging its handle must NOT change the
+    // sidebar's width — that's the structural promise of the two-tier model.
+    await setupFeed(page);
+
+    const handles = page.locator('[data-slot="resizable-handle"]');
+    await expect(handles).toHaveCount(2);
+    const innerHandle = handles.nth(1);
+
+    const sidebar = page.locator('[data-panel][id="sidebar"]');
+    const articleList = page.locator('[data-panel][id="article-list"]');
+    const sidebarWidthBefore = await sidebar.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+    const listWidthBefore = await articleList.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+
+    const handleBox = await innerHandle.boundingBox();
+    if (handleBox) {
+      await page.mouse.move(
+        handleBox.x + handleBox.width / 2,
+        handleBox.y + handleBox.height / 2,
+      );
+      await page.mouse.down();
+      await page.mouse.move(
+        handleBox.x + handleBox.width / 2 + 80,
+        handleBox.y + handleBox.height / 2,
+        { steps: 10 },
+      );
+      await page.mouse.up();
+    }
+
+    const sidebarWidthAfter = await sidebar.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+    const listWidthAfter = await articleList.evaluate(
+      (el) => el.getBoundingClientRect().width,
+    );
+
+    expect(Math.abs(listWidthAfter - listWidthBefore)).toBeGreaterThan(10);
+    expect(Math.abs(sidebarWidthAfter - sidebarWidthBefore)).toBeLessThan(2);
   });
 
   test("sidebar collapse/expand via trigger", async ({ feedPage: page }) => {

--- a/tests/e2e/viewport-resize.spec.ts
+++ b/tests/e2e/viewport-resize.spec.ts
@@ -54,8 +54,12 @@ test.describe("Viewport resize", () => {
       { timeout: 10000 },
     );
 
-    // Desktop layout: resizable panel group should be present
-    const panels = page.locator('[data-slot="resizable-panel-group"]');
+    // Desktop layout: outer resizable panel group should be present.
+    // .first() because the default route also renders an inner group
+    // (article-list + reader) nested inside the stage panel.
+    const panels = page
+      .locator('[data-slot="resizable-panel-group"]')
+      .first();
     await expect(panels).toBeVisible({ timeout: 5000 });
 
     // Persistent sidebar should be visible (no trigger needed to open it)


### PR DESCRIPTION
## Summary

- The desktop sidebar visibly resized when navigating to Explore/Stats, even though the user had only ever dragged the sidebar handle. PR F unified the panel group's id; this PR finishes the job by also stabilising the **child set** of that group across every route.
- Outer panel topology is now constant on every desktop route: always `[sidebar | stage]`. The `stage` panel is a slot whose *content* swaps by route (StatsPage / ExploreCatalog / inner `[article-list | reader]` group on the default route). The sidebar's neighbour never changes, so `react-resizable-panels` has nothing to recompute on route change.
- Naming choice: **"stage"** rather than "main" so the slot's intent is communicable — a Settings consolidation will mount inside the same stage in a follow-up PR.
- The rule "the sidebar's siblings never change" is now enforced by **two layers of regression defence** (structural unit invariant + behavioural e2e) and documented in ADR 013.

## Why this matters

The user-facing rule is *"sidebar size only changes when you drag the handle or resize the window."* Before this PR, opening Explore violated that rule by ~10–20px every time. The fix is structural — make the rule hold *by construction* rather than by imperative correction (the prior `useSharedSidebarSize.useEffect` was a corrective patch that left a one-frame flicker and competed with the library's own layout pass).

## What's in the diff

- `src/utils/constants.ts` — `PANEL_LAYOUT_ID` gains `STAGE_INNER` for the inner article-list/reader group; updated JSDoc describing the two-tier model.
- `src/pages/feeds-page.tsx` — outer group is permanently `[sidebar | stage]`; `stage` holds route-varying content; default route nests an inner `ResizablePanelGroup` for list+reader.
- `tests/components/layout/feeds-page-layout.test.tsx` — 6 existing topology tests updated + 2 new tests (\`STRUCTURAL INVARIANT…\`, \`inner group exists ONLY on the default route\`).
- `tests/e2e/layout-scroll.spec.ts` — old single-handle drag test replaced by two scoped tests: outer handle resizes sidebar vs stage / inner handle leaves sidebar alone.
- `tests/e2e/viewport-resize.spec.ts` — `.first()` on the panel-group locator (there are now two on the default route).
- `docs/decisions/013-stable-outer-panel-topology.md` — new ADR.
- `CLAUDE.md`, `docs/architecture.md` — describe the new two-tier model; stale "3-panel grid" references corrected.

## Test plan

- [x] `npm test` — 2286 pass, 0 fail, 30 skipped (smoke tests, opt-in via SMOKE_TESTS=1).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run test:e2e` — 76 pass, 0 fail, 1 skip.
- [x] **Manual desktop walk** — drag sidebar to ~250px, click Explore → no resize, click Stats → no resize, navigate to a feed → no resize. Reload at each route → sidebar returns to dragged width.
- [x] **Manual inner handle** — on `/feeds/:feedId`, drag the article-list/reader handle → sidebar pixel-width unchanged. Navigate away and back → inner ratio persists.
- [x] **Mobile (375px)** — no `ResizablePanelGroup` rendered; behaviour unchanged.

## One-time user-visible effect

Existing users' previously-saved `article-list` / `reader` percentages (stored under the outer group's id) will silently reset to the inner group's defaults (40% / 60%) on next load. Sidebar width is preserved. A migration would cost more than it buys; the reset is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)