### PR TITLE
fix(layout): PR J — persist sidebar width in pixels, not percentage

### DIFF
--- a/src/hooks/use-shared-sidebar-size.ts
+++ b/src/hooks/use-shared-sidebar-size.ts
@@ -2,15 +2,27 @@ import { useCallback, useEffect, useRef } from "react";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 
 /**
- * localStorage key used to persist the sidebar's preferred width across
- * layout transitions and reloads. Stored as a percentage string (0..100).
+ * localStorage key for the sidebar's preferred width in absolute pixels.
+ *
+ * Stored as a bare integer string (e.g. "240"). The hook appends "px" when
+ * handing the value to react-resizable-panels so the library parses it
+ * unambiguously as pixels (see its bt() unit parser).
+ *
+ * Why pixels and not percentages: a percentage-based store re-evaluates the
+ * stored value against whatever viewport happens to be active on reload,
+ * which silently drifts the sidebar width whenever the user opens the app
+ * at a different window size than they dragged it at. Pixels are stable.
+ *
+ * Existing users had a percentage in the prior key `feedzero:sidebar-size`
+ * (deliberately a different key). Those values are not migrated; existing
+ * users get a one-time silent reset to the page's default.
  */
-export const SIDEBAR_SIZE_STORAGE_KEY = "feedzero:sidebar-size";
+export const SIDEBAR_WIDTH_STORAGE_KEY = "feedzero:sidebar-width-px";
 
 function readStored(): number | null {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.localStorage.getItem(SIDEBAR_SIZE_STORAGE_KEY);
+    const raw = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
     if (!raw) return null;
     const num = Number(raw);
     return Number.isFinite(num) && num > 0 ? num : null;
@@ -22,7 +34,7 @@ function readStored(): number | null {
 function writeStored(value: number) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(SIDEBAR_SIZE_STORAGE_KEY, String(value));
+    window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(value));
   } catch {
     // localStorage may be unavailable (private mode, quota exceeded).
     // The in-memory ref still serves the current session.
@@ -36,23 +48,22 @@ interface UseSharedSidebarSizeResult {
 }
 
 /**
- * Synchronizes the sidebar panel's width across distinct ResizablePanelGroup
- * ids (e.g. the 3-panel feeds layout and the 2-panel explore/stats layout).
+ * Persists the sidebar's user-dragged pixel width across reloads and across
+ * layout transitions that may remount the panel group (HMR, SidebarProvider
+ * remount).
  *
- * react-resizable-panels persists panel sizes per group id, so with separate
- * ids switching layouts resets the sidebar to its `defaultSize` even when the
- * user resized it in the other layout. This hook stores the user's preferred
- * width in localStorage so both layouts agree on it, and imperatively
- * re-applies the width whenever `layoutKey` changes — the library otherwise
- * rebalances proportions when conditionally-rendered panels appear or disappear.
+ * The imperative panelRef.resize() on layoutKey change is a safety net for
+ * remount paths; the outer panel group's child set is constant across
+ * routes (PR #103) so the library's own layout reconciliation no longer
+ * rebalances the sidebar on navigation.
  */
 export function useSharedSidebarSize(layoutKey: string): UseSharedSidebarSizeResult {
   const sizeRef = useRef<number | null>(readStored());
   const panelRef = useRef<PanelImperativeHandle | null>(null);
 
   const onResize = useCallback((panelSize: PanelSize) => {
-    sizeRef.current = panelSize.asPercentage;
-    writeStored(panelSize.asPercentage);
+    sizeRef.current = panelSize.inPixels;
+    writeStored(panelSize.inPixels);
   }, []);
 
   useEffect(() => {
@@ -60,13 +71,13 @@ export function useSharedSidebarSize(layoutKey: string): UseSharedSidebarSizeRes
     if (stored == null) return;
     const handle = panelRef.current;
     if (!handle) return;
-    handle.resize(stored);
+    handle.resize(`${stored}px`);
   }, [layoutKey]);
 
   const initial = sizeRef.current;
   return {
     panelRef,
     onResize,
-    defaultSize: initial != null ? `${initial}%` : undefined,
+    defaultSize: initial != null ? `${initial}px` : undefined,
   };
 }

--- a/src/pages/feeds-page.tsx
+++ b/src/pages/feeds-page.tsx
@@ -364,7 +364,7 @@ export function FeedsPage() {
       <ResizablePanelGroup id={layoutId} direction="horizontal" className="h-svh">
         <ResizablePanel
           id="sidebar"
-          defaultSize={sidebarSize.defaultSize ?? "17%"}
+          defaultSize={sidebarSize.defaultSize ?? "256px"}
           minSize="150px"
           maxSize="280px"
           className="overflow-hidden"

--- a/tests/components/layout/feeds-page-layout.test.tsx
+++ b/tests/components/layout/feeds-page-layout.test.tsx
@@ -320,17 +320,17 @@ describe("FeedsPage layout — desktop", () => {
     expect(useArticleStore.getState().selectedArticle?.id).toBe("a15");
   });
 
-  it("explore layout's sidebar starts at the user's stored width (preserved by single stable layout id)", async () => {
+  it("explore layout's sidebar starts at the user's stored width in pixels (preserved by single stable layout id)", async () => {
     // PR F: with one stable layout id across routes, the sidebar width is
     // naturally preserved by react-resizable-panels' per-id persistence.
-    // The useSharedSidebarSize hook still reads the localStorage migration
-    // value as the initial defaultSize, and is now called with the stable
-    // id regardless of route.
+    // PR J: the hook now stores pixels (not percentages) so the width
+    // survives viewport changes between drag and reload. The defaultSize
+    // returned by the hook is a px-suffixed string.
     const hookModule = await import("@/hooks/use-shared-sidebar-size.ts");
     const spy = vi.spyOn(hookModule, "useSharedSidebarSize");
 
-    const SIDEBAR_KEY = hookModule.SIDEBAR_SIZE_STORAGE_KEY;
-    window.localStorage.setItem(SIDEBAR_KEY, "27");
+    const SIDEBAR_KEY = hookModule.SIDEBAR_WIDTH_STORAGE_KEY;
+    window.localStorage.setItem(SIDEBAR_KEY, "240");
 
     renderPage("/explore");
 
@@ -340,7 +340,7 @@ describe("FeedsPage layout — desktop", () => {
 
     const lastResult = spy.mock.results.at(-1)?.value;
     expect(lastResult).toBeDefined();
-    expect(lastResult.defaultSize).toBe("27%");
+    expect(lastResult.defaultSize).toBe("240px");
 
     window.localStorage.removeItem(SIDEBAR_KEY);
     spy.mockRestore();

--- a/tests/hooks/use-shared-sidebar-size.test.tsx
+++ b/tests/hooks/use-shared-sidebar-size.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import {
   useSharedSidebarSize,
-  SIDEBAR_SIZE_STORAGE_KEY,
+  SIDEBAR_WIDTH_STORAGE_KEY,
 } from "@/hooks/use-shared-sidebar-size.ts";
 
 const localStorageMock = (() => {
@@ -36,40 +36,59 @@ describe("useSharedSidebarSize", () => {
     expect(result.current.defaultSize).toBeUndefined();
   });
 
-  it("reads the stored sidebar size on first mount and exposes it as defaultSize", () => {
-    window.localStorage.setItem(SIDEBAR_SIZE_STORAGE_KEY, "25");
+  it("reads the stored sidebar width in pixels and exposes it as a px-suffixed defaultSize", () => {
+    // The hook stores absolute pixels so the sidebar's width survives changes
+    // in viewport size (a percentage-based store would re-evaluate against
+    // the new viewport, producing a different pixel width than the user
+    // dragged). The returned defaultSize is a px-suffixed string so
+    // react-resizable-panels parses it as pixels (see its bt() unit parser).
+    window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "250");
     const { result } = renderHook(() => useSharedSidebarSize("feeds"));
-    expect(result.current.defaultSize).toBe("25%");
+    expect(result.current.defaultSize).toBe("250px");
   });
 
-  it("persists the new size to localStorage when onResize is called", () => {
+  it("ignores the legacy percentage storage key on read (silent reset for existing users)", () => {
+    // Pre-PR-J users had `feedzero:sidebar-size` populated with a percentage
+    // value. After the switch to pixel storage that value is meaningless;
+    // the hook must not try to migrate or coerce it. It just looks at the
+    // new key, which is empty, so defaultSize is undefined and the page's
+    // own fallback applies.
+    window.localStorage.setItem("feedzero:sidebar-size", "17");
+    const { result } = renderHook(() => useSharedSidebarSize("feeds"));
+    expect(result.current.defaultSize).toBeUndefined();
+  });
+
+  it("persists the new width as pixels (inPixels) when onResize is called", () => {
+    // PanelSize from react-resizable-panels carries both asPercentage and
+    // inPixels. We store inPixels so the next reload reproduces the exact
+    // pixel width the user dragged, independent of viewport.
     const { result } = renderHook(() => useSharedSidebarSize("feeds"));
     act(() => {
-      result.current.onResize({ asPercentage: 22, inPixels: 220 });
+      result.current.onResize({ asPercentage: 19.5, inPixels: 240 });
     });
-    expect(window.localStorage.getItem(SIDEBAR_SIZE_STORAGE_KEY)).toBe("22");
+    expect(window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("240");
   });
 
-  it("re-applies the remembered size to the panel when layoutKey changes", () => {
-    window.localStorage.setItem(SIDEBAR_SIZE_STORAGE_KEY, "25");
+  it("re-applies the remembered width as a px-suffixed string when layoutKey changes", () => {
+    // The library's imperative resize() accepts either a number (pixels) or
+    // a string with units. Passing "240px" makes the unit explicit so any
+    // future refactor of the library's number-default can't silently flip
+    // our intent.
+    window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "240");
     const resize = vi.fn();
     const { result, rerender } = renderHook(
       ({ key }: { key: string }) => useSharedSidebarSize(key),
       { initialProps: { key: "feeds" } },
     );
-    // Simulate the panel being mounted by attaching the imperative handle.
     result.current.panelRef.current = {
       resize,
       collapse: vi.fn(),
       expand: vi.fn(),
-      getSize: vi.fn(() => ({ asPercentage: 25, inPixels: 250 })),
+      getSize: vi.fn(() => ({ asPercentage: 19.5, inPixels: 240 })),
       isCollapsed: vi.fn(() => false),
     };
-    // Now switch layout. The sidebar's stored size must be re-applied so that
-    // the library's rebalancing on conditional-panel changes does not silently
-    // override the user's preference.
     rerender({ key: "explore" });
-    expect(resize).toHaveBeenCalledWith(25);
+    expect(resize).toHaveBeenCalledWith("240px");
   });
 
   it("does not call resize when nothing has been stored yet", () => {


### PR DESCRIPTION
## Summary

- On reload, the sidebar rendered narrower than the user had dragged it to — sometimes much narrower, sometimes clamped flat against the 150px minSize floor.
- Root cause: `useSharedSidebarSize` stored the dragged width as a **percentage** of the panel group's pixel width, then replayed that percentage against whatever viewport was active on reload. The user's mental model is pixels; the implementation's was proportions. The two drifted whenever the viewport changed between drag and reload.
- Fix: store the sidebar width as **absolute pixels** under a new localStorage key (`feedzero:sidebar-width-px`). New first-load fallback is `"256px"` (viewport-independent, sits comfortably inside the existing 150–280px minSize/maxSize range).

## Concrete failure mode

Drag sidebar to 250px at 1280px viewport → store ~19.5%. Reload at 900px viewport → 19.5% × 900 = 176px. Reload at ≤ ~770px viewport → 19.5% < 150px → clamped to the 150px minimum. The sidebar appears stuck narrow and the user can't understand why their dragged width didn't survive.

## What's in the diff

- `src/hooks/use-shared-sidebar-size.ts` — rename storage key, read `inPixels` from PanelSize on resize, return `"${n}px"` defaultSize, imperative `resize()` uses `"${n}px"`.
- `src/pages/feeds-page.tsx` — sidebar fallback `defaultSize` `"17%"` → `"256px"`.
- `tests/hooks/use-shared-sidebar-size.test.tsx` — full contract update (new key, pixel writes, px-suffixed defaultSize, legacy key ignored).
- `tests/components/layout/feeds-page-layout.test.tsx` — adjust the stored-width assertion to pixel units.

## Migration

The prior storage key (`feedzero:sidebar-size`, percentage-valued) is **not** migrated. Existing users get a one-time silent reset to the new 256px default. Same trade-off pattern as PR #103's article-list/reader split reset — cheaper than writing a unit-conversion heuristic.

## Test plan

- [x] `npm test` — 2285 pass, 0 fail, 30 skipped (smoke tests, opt-in via SMOKE_TESTS=1)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:e2e` — 74 pass, 0 fail, 1 skip
- [ ] **Manual cross-viewport reload** — at 1280px viewport, drag sidebar to ~220px. Resize browser to ~900px. Reload. Sidebar should still be 220px (not narrower; not clamped).
- [ ] **Manual fresh state** — clear `localStorage["feedzero:sidebar-width-px"]`, reload at common laptop widths (1024, 1280, 1440). Sidebar should land at 256px at every viewport (no `--sidebar-width: 18rem` mismatch is fixed here — pre-existing, out of scope).
- [ ] **Manual upgrade path** — set `localStorage["feedzero:sidebar-size"] = "17"` (legacy key, percentage value), reload. Sidebar should ignore the legacy value and land at 256px default.

## Relationship to PR #103

Independent of #103 (which fixed the route-change resize bug). Both PRs touch `use-shared-sidebar-size.ts` but address different root causes. Either can land first; both apply cleanly off `main`.

## Out of scope

- Reconciling `--sidebar-width: 18rem` CSS token (288px) with the 280px panel `maxSize` — pre-existing token/constraint mismatch, untouched here.
- Cleaning up orphaned `feedzero:sidebar-size` localStorage entries — cheap to ignore; not worth a migration script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)