### PR TITLE
PR M — Finish the self-host workstream (Retry-After, preflight UI, sidebar E2E)

### DIFF
--- a/src/components/settings/preflight-panel.tsx
+++ b/src/components/settings/preflight-panel.tsx
@@ -1,0 +1,101 @@
+/**
+ * Self-host preflight panel — Settings → Help.
+ *
+ * A self-hoster clicks "Run preflight" to verify the deployment is wired
+ * correctly. The panel runs `runSelfHostPreflight()` (pure helper in
+ * `@/core/diagnostics/self-host-preflight`) and renders each check's
+ * result with a clear pass/fail and per-check detail string.
+ *
+ * Component takes `runPreflight` as a prop rather than calling the
+ * helper directly — tests inject a mock; production wiring lives in
+ * the parent (HelpTab) that closes over the real env.
+ */
+import { useState } from "react";
+import { CheckCircle2, XCircle, Loader2, Stethoscope } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { PreflightReport } from "@/core/diagnostics/self-host-preflight";
+
+const CHECK_LABELS: Record<string, string> = {
+  "secure-context": "Secure context (HTTPS or localhost)",
+  "crypto-subtle": "Web Crypto API exposed",
+  "api-feed": "/api/feed reachable",
+  "api-sync": "/api/sync reachable",
+};
+
+interface Props {
+  runPreflight: () => Promise<PreflightReport>;
+}
+
+export function PreflightPanel({ runPreflight }: Props) {
+  const [state, setState] = useState<
+    | { kind: "idle" }
+    | { kind: "running" }
+    | { kind: "done"; report: PreflightReport }
+  >({ kind: "idle" });
+
+  async function handleRun() {
+    setState({ kind: "running" });
+    const report = await runPreflight();
+    setState({ kind: "done", report });
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <Stethoscope className="size-4 text-muted-foreground" />
+        <p className="text-sm font-medium">Self-host preflight</p>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Run a quick diagnostic against your deployment. Useful when feeds
+        won't load or sync misbehaves — the preflight tells you which
+        layer is wrong.
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleRun}
+        disabled={state.kind === "running"}
+      >
+        {state.kind === "running" ? (
+          <>
+            <Loader2 className="mr-2 size-4 animate-spin" />
+            Running…
+          </>
+        ) : (
+          "Run preflight"
+        )}
+      </Button>
+      {state.kind === "done" ? (
+        <div className="space-y-2 pt-2">
+          {state.report.allPassed ? (
+            <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
+              All checks passed ✓
+            </p>
+          ) : (
+            <p className="text-sm font-medium text-destructive">
+              Some checks failed.
+            </p>
+          )}
+          <ul className="space-y-1.5">
+            {state.report.checks.map((c) => (
+              <li key={c.id} className="flex items-start gap-2 text-xs">
+                {c.passed ? (
+                  <CheckCircle2 className="size-4 shrink-0 text-emerald-600 dark:text-emerald-400 mt-0.5" />
+                ) : (
+                  <XCircle className="size-4 shrink-0 text-destructive mt-0.5" />
+                )}
+                <div className="min-w-0">
+                  <p className="font-medium text-foreground">
+                    {CHECK_LABELS[c.id] ?? c.id}
+                  </p>
+                  <p className="text-muted-foreground break-words">{c.detail}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/settings/tabs/help-tab.tsx
+++ b/src/components/settings/tabs/help-tab.tsx
@@ -14,7 +14,10 @@ import { Button } from "@/components/ui/button";
 import { Kbd } from "@/components/ui/kbd";
 import { FeedbackDialog } from "@/components/feedback/feedback-dialog";
 import { ContactSupport } from "@/components/settings/contact-support";
+import { PreflightPanel } from "@/components/settings/preflight-panel";
 import { getLicenseToken } from "@/core/license/license-token-store";
+import { isSelfHosted } from "@/core/features/self-hosted";
+import { runSelfHostPreflight } from "@/core/diagnostics/self-host-preflight";
 
 const isMac =
   typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
@@ -127,6 +130,19 @@ export function HelpTab({ onWhatsNew }: HelpTabProps) {
         token={token}
         diagnosticContext={{ Source: "settings-help" }}
       />
+
+      {isSelfHosted() ? (
+        <PreflightPanel
+          runPreflight={() =>
+            runSelfHostPreflight({
+              isSecureContext: globalThis.isSecureContext ?? false,
+              crypto: globalThis.crypto as Pick<Crypto, "subtle"> | undefined,
+              fetch: globalThis.fetch.bind(globalThis),
+              origin: window.location.origin,
+            })
+          }
+        />
+      ) : null}
 
       <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
     </div>

--- a/src/core/feeds/feed-service.ts
+++ b/src/core/feeds/feed-service.ts
@@ -16,6 +16,7 @@ import {
 import type { Feed, Article } from "../../types/index.ts";
 import { proxyFetch } from "../proxy/proxy-fetch.ts";
 import { groupByHostForRefresh } from "./group-by-host.ts";
+import { parseRetryAfter } from "./parse-retry-after.ts";
 
 interface AddFeedResult {
   feed: Feed;
@@ -228,6 +229,21 @@ export async function refreshFeed(feed: Feed): Promise<Result<RefreshResult>> {
   try {
     const response = await proxyFetch("/api/feed", feed.url);
     if (!response.ok) {
+      // Surface Retry-After when the upstream rate-limits us so the user
+      // sees an actionable hint instead of a generic HTTP code. Per
+      // feedback #97 — self-host bulk refresh against fresh IPs trips
+      // upstream WAFs and the user needs to know when to retry.
+      if (response.status === 429) {
+        const retryAt = parseRetryAfter(
+          response.headers?.get?.("retry-after"),
+          Date.now(),
+        );
+        if (retryAt !== null) {
+          const seconds = Math.ceil((retryAt - Date.now()) / 1000);
+          return err(`Upstream rate-limited (429). Retry in ${seconds}s.`);
+        }
+        return err("Upstream rate-limited (429). Retry later.");
+      }
       return err(`Failed to fetch feed (HTTP ${response.status})`);
     }
     const text = await response.text();

--- a/src/core/feeds/parse-retry-after.ts
+++ b/src/core/feeds/parse-retry-after.ts
@@ -1,0 +1,47 @@
+/**
+ * Parse an HTTP `Retry-After` header value into an absolute resume
+ * timestamp (ms since epoch).
+ *
+ * Two RFC 7231 §7.1.3 forms:
+ *   - delta-seconds: an integer count of seconds (e.g. "60")
+ *   - HTTP-date:     an RFC 7231 date string (e.g. "Wed, 21 Oct 2026 07:28:00 GMT")
+ *
+ * Returns null on malformed input — caller's contract is "no pause was
+ * specified," distinct from a 0 pause ("retry immediately").
+ *
+ * Two safety clamps:
+ *   - Past / negative values → NOW (don't create permanent "paused since
+ *     1970" state from clock skew or an upstream typo).
+ *   - Cap at 24h. A misconfigured upstream sending 30-day Retry-After
+ *     would otherwise silently disappear feeds for a month.
+ *
+ * Pure: `now` is injected so tests are deterministic and time-zone-free.
+ */
+const MAX_PAUSE_MS = 24 * 3600 * 1000;
+
+export function parseRetryAfter(
+  value: string | null | undefined,
+  now: number,
+): number | null {
+  if (!value) return null;
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+
+  // Form 1: delta-seconds (allow negatives so we can clamp them).
+  if (/^-?\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    return clamp(now + seconds * 1000, now);
+  }
+
+  // Form 2: HTTP-date.
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) return null;
+  return clamp(dateMs, now);
+}
+
+function clamp(target: number, now: number): number {
+  if (target < now) return now;
+  if (target - now > MAX_PAUSE_MS) return now + MAX_PAUSE_MS;
+  return target;
+}

--- a/tests/components/settings/preflight-panel.test.tsx
+++ b/tests/components/settings/preflight-panel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PreflightPanel } from "@/components/settings/preflight-panel";
+
+function makeReport(allPassed: boolean) {
+  return {
+    allPassed,
+    checks: [
+      { id: "secure-context", passed: allPassed, detail: "ok" },
+      { id: "crypto-subtle", passed: allPassed, detail: "ok" },
+      { id: "api-feed", passed: allPassed, detail: "ok" },
+      { id: "api-sync", passed: allPassed, detail: "ok" },
+    ],
+  };
+}
+
+describe("PreflightPanel", () => {
+  it("shows the Run preflight button before any run", () => {
+    render(<PreflightPanel runPreflight={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /run preflight|run diagnostic/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an all-passed summary after a successful run", async () => {
+    // Self-hoster opens Help, clicks Run preflight, sees "all checks
+    // passed" — the happy-path confirmation that the deployment is wired.
+    const user = userEvent.setup();
+    const runPreflight = vi
+      .fn()
+      .mockResolvedValue(makeReport(true));
+
+    render(<PreflightPanel runPreflight={runPreflight} />);
+    await user.click(
+      screen.getByRole("button", { name: /run preflight|run diagnostic/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/all checks passed/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders per-check failure details after a failed run", async () => {
+    // Failure case must show *which* check failed, not a generic
+    // "something's wrong." That's the whole point of a preflight.
+    const user = userEvent.setup();
+    const runPreflight = vi.fn().mockResolvedValue({
+      allPassed: false,
+      checks: [
+        { id: "secure-context", passed: false, detail: "Insecure context (http://...)" },
+        { id: "crypto-subtle", passed: true, detail: "ok" },
+        { id: "api-feed", passed: true, detail: "ok" },
+        { id: "api-sync", passed: true, detail: "ok" },
+      ],
+    });
+
+    render(<PreflightPanel runPreflight={runPreflight} />);
+    await user.click(
+      screen.getByRole("button", { name: /run preflight|run diagnostic/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/insecure context/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/core/feeds/feed-service.test.js
+++ b/tests/core/feeds/feed-service.test.js
@@ -491,6 +491,38 @@ describe("refreshFeed", () => {
     expect(result.error).toMatch(/Failed to fetch/);
   });
 
+  it("surfaces Retry-After when the upstream returns 429", async () => {
+    // Self-host scenario from feedback #97: a feed hit by upstream
+    // rate-limiting should tell the user when to retry, not a generic
+    // "Failed to fetch feed (HTTP 429)". The refresh worker doesn't
+    // know how to retry automatically yet (separate piece of work),
+    // but the error message must surface the upstream's hint.
+    const feed = await addTestFeed();
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map([["retry-after", "120"]]),
+    });
+
+    const result = await refreshFeed(feed);
+    expect(isErr(result)).toBe(true);
+    expect(result.error).toMatch(/rate.?limit|429/i);
+    expect(result.error).toMatch(/120s|2 ?min/i);
+  });
+
+  it("falls back to a plain 429 message when no Retry-After is present", async () => {
+    const feed = await addTestFeed();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Map(),
+    });
+    const result = await refreshFeed(feed);
+    expect(isErr(result)).toBe(true);
+    expect(result.error).toMatch(/rate.?limit|429/i);
+  });
+
   it("should return 'Refresh failed: ...' when fetch throws (outer catch)", async () => {
     const feed = await addTestFeed();
 

--- a/tests/core/feeds/parse-retry-after.test.ts
+++ b/tests/core/feeds/parse-retry-after.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { parseRetryAfter } from "@/core/feeds/parse-retry-after";
+
+describe("parseRetryAfter", () => {
+  const NOW = new Date("2026-05-17T12:00:00Z").getTime();
+
+  it("parses a delta-seconds integer", () => {
+    // RFC 7231 §7.1.3 form 1: delta-seconds.
+    expect(parseRetryAfter("60", NOW)).toBe(NOW + 60_000);
+  });
+
+  it("parses an HTTP-date string", () => {
+    // RFC 7231 §7.1.3 form 2: HTTP-date. Some upstreams (notably nginx
+    // and Apache mod_evasive) prefer this form.
+    const future = new Date("2026-05-17T12:05:00Z").toUTCString();
+    expect(parseRetryAfter(future, NOW)).toBe(NOW + 5 * 60_000);
+  });
+
+  it("clamps negative values to 0 (no time travel)", () => {
+    // An HTTP-date in the past or a negative delta means "retry now."
+    // Clamp to NOW so the pause window resolves immediately rather than
+    // creating a permanent "paused since 1970" state.
+    expect(parseRetryAfter("-30", NOW)).toBe(NOW);
+    const past = new Date("2026-05-16T12:00:00Z").toUTCString();
+    expect(parseRetryAfter(past, NOW)).toBe(NOW);
+  });
+
+  it("returns null for malformed input", () => {
+    // Don't guess. If we can't parse it, the refresh worker treats this
+    // as "no pause specified" and uses its default backoff instead.
+    expect(parseRetryAfter("forever", NOW)).toBeNull();
+    expect(parseRetryAfter("", NOW)).toBeNull();
+    expect(parseRetryAfter(null, NOW)).toBeNull();
+  });
+
+  it("caps the pause at 24 hours (don't lose feeds to upstream typos)", () => {
+    // A misconfigured upstream sending "Retry-After: 2592000" (30 days)
+    // would otherwise silently disappear the feed for a month. Cap at
+    // a day so the feed surfaces back in the rotation tomorrow.
+    expect(parseRetryAfter("999999999", NOW)).toBe(NOW + 24 * 3600 * 1000);
+  });
+});

--- a/tests/e2e/sidebar-width-stability.spec.ts
+++ b/tests/e2e/sidebar-width-stability.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression guard for ADR 013 (stable outer panel topology).
+ *
+ * Feedback issue #97 reported: "The panel listing all of the feeds &
+ * folders [resets] after I extend it to its max width & click on the
+ * Explore tab after reading an article. This also happens vice-versa."
+ *
+ * PR I + ADR 013 made the outer ResizablePanelGroup constant across all
+ * routes so the persisted size survives navigation. This spec exercises
+ * the exact route sequence from the report: a feed route → Explore →
+ * a feed route, capturing the sidebar width at each step. If a future
+ * refactor breaks the topology, this fails loudly.
+ *
+ * Desktop-only — mobile collapses the sidebar entirely so the invariant
+ * doesn't apply.
+ */
+import { test, expect, addFeedViaUI, selectFeedInSidebar } from "./fixtures";
+import { SAMPLE_RSS, mockFeedEndpoint } from "./feed-fixtures";
+
+async function sidebarWidth(page: import("@playwright/test").Page) {
+  // The first panel inside the outer group is the sidebar (left of the
+  // stage). data-panel-id values come from react-resizable-panels' own
+  // attribute conventions — they're stable across versions.
+  const sidebar = page.locator("[data-panel-group-id='feedzero:layout:main'] [data-panel]").first();
+  await expect(sidebar).toBeVisible();
+  const box = await sidebar.boundingBox();
+  if (!box) throw new Error("sidebar panel had no bounding box");
+  return Math.round(box.width);
+}
+
+test.describe("Sidebar width stability across routes (ADR 013)", () => {
+  test.skip(({ viewport }) => (viewport?.width ?? 1280) < 1024, "Desktop only");
+
+  test("sidebar width survives Feed → Explore → Feed navigation", async ({ page }) => {
+    await mockFeedEndpoint(page, SAMPLE_RSS);
+    await addFeedViaUI(page, "https://example.com/feed");
+    await selectFeedInSidebar(page, "Test Feed");
+
+    const startingWidth = await sidebarWidth(page);
+    // Make the sidebar a different size than the default so we can detect
+    // a "reset to default" regression. Drag is preferable to a synthetic
+    // setSize because it exercises the real persistence path.
+    const handle = page
+      .locator("[data-panel-group-id='feedzero:layout:main'] [data-resize-handle]")
+      .first();
+    const handleBox = await handle.boundingBox();
+    if (!handleBox) throw new Error("resize handle had no bounding box");
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(handleBox.x + 120, handleBox.y + handleBox.height / 2, { steps: 8 });
+    await page.mouse.up();
+
+    const widened = await sidebarWidth(page);
+    expect(widened, "drag should actually change the sidebar width").not.toBe(startingWidth);
+
+    await page.getByRole("link", { name: /explore/i }).first().click();
+    await page.waitForURL(/\/explore/);
+    const afterExplore = await sidebarWidth(page);
+    expect(afterExplore, "navigating to /explore must not reset sidebar width").toBe(widened);
+
+    await selectFeedInSidebar(page, "Test Feed");
+    const afterReturn = await sidebarWidth(page);
+    expect(afterReturn, "navigating back to a feed must not reset sidebar width").toBe(widened);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the three deferred items from PR L (#107) so the self-host workstream has no remaining "out of scope" notes.

1. **Retry-After surfacing on feed refresh** — `parseRetryAfter` pure helper + `refreshFeed` integration. A 429 from upstream now produces "Upstream rate-limited (429). Retry in 120s." instead of a generic HTTP code.
2. **In-app preflight panel** — `PreflightPanel` component wired into Settings → Help, gated behind `isSelfHosted()`. Renders the four checks from the existing `runSelfHostPreflight` helper with pass/fail icons and detail strings.
3. **Sidebar width stability E2E** — Playwright regression guard for ADR 013 that reproduces the exact sequence from feedback #97 (Feed → drag-resize → Explore → Feed) and asserts the width survives.

## Test plan

- [x] `npm test` — 2375 unit tests pass (up from 2365), zero failures
- [x] `npx tsc --noEmit` — clean
- [x] New tests:
  - `tests/core/feeds/parse-retry-after.test.ts` (5 cases including 24h cap and clock-skew guard)
  - `tests/core/feeds/feed-service.test.js` (+2 for Retry-After surfacing)
  - `tests/components/settings/preflight-panel.test.tsx` (3 cases: idle, all-pass, failure-detail)
- [ ] E2E runs in CI (sidebar-width-stability spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)