### PR TITLE
feat(billing): add 30-day free trial via Stripe Checkout

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,8 +144,8 @@ Endpoints:
 - `/api/catalog` — `action=count`, `action=popular`, `?url=<...>` lookup. Storage: Upstash KV (`catalog:feed:*` + `catalog:ranking` sorted set).
 - `/api/stats-sync` — Vault count for the public stats page. Reads the same backend as `/api/sync`.
 - `POST /api/license/verify`, `POST /api/license/issue` — License Bearer-token verification and (admin-only) issuance. Storage: Upstash KV (`license:record:*`, `license:revoked:*`, `customer:*:keys`).
-- `POST /api/stripe/webhook` — Stripe webhook receiver with signature verification + event-id dedup. Dedup store: Upstash KV (`seen-event:<eventId>`).
-- `POST /api/checkout/create-session` — Stripe Checkout Session creation with priceId allowlist.
+- `POST /api/stripe/webhook` — Stripe webhook receiver with signature verification + event-id dedup. Dedup store: Upstash KV (`seen-event:<eventId>`). `customer.subscription.created` reads `current_period_end` (trial-end date for trialing subscriptions) and pins the issued license to it; `invoice.paid` extends the license on first charge.
+- `POST /api/checkout/create-session` — Stripe Checkout Session creation with priceId allowlist. Injects a server-controlled 30-day free trial via `subscription_data.trial_period_days` — see [ADR 015](decisions/015-stripe-side-trial.md).
 - `GET /api/health`, `GET /api/icon`, `POST /api/feedback`, `GET /api/favicon` — Operational endpoints.
 
 ### Production data layer: Upstash KV

--- a/docs/decisions/015-stripe-side-trial.md
+++ b/docs/decisions/015-stripe-side-trial.md
@@ -1,0 +1,55 @@
+# ADR 015: Stripe-Side 30-Day Free Trial
+
+## Status
+Accepted (2026-05-17).
+
+## Context
+
+Pre-trial, every Personal-tier subscriber paid $5 (monthly) or $50 (yearly) upfront before seeing whether cloud sync, auto-organize, and unlimited feeds fit their workflow. The activation bar was the dollar charge: a free user who liked the product still had to commit money to try the Personal features end-to-end on their own data.
+
+We wanted to lower that activation bar with a 30-day free trial. The integration had to remain boring — FeedZero's billing surface area is already wide (Stripe Checkout, webhook, license issuance, vault sync, recovery) and a new tier or a new local trial clock would multiply edge cases (cross-device drift, clock tampering, expiry-vs-renewal races) without a matching revenue case.
+
+## Decision
+
+**Stripe owns the trial clock; FeedZero adds 13 lines of code and 4 lines of UI copy.**
+
+- **`subscription_data.trial_period_days: 30`** is injected by `src/core/stripe/checkout-handler.ts` on every Checkout Session it creates. The trial duration is a hardcoded `TRIAL_PERIOD_DAYS` constant, not env-flagged and not Dashboard-configured.
+- The webhook (`src/core/stripe/webhook-handler.ts`) reads `current_period_end` off `customer.subscription.created` and pins the issued license to it. Existing `invoice.paid → recordRenewal` extends the license to the next period when Stripe charges on day 31.
+- No new `LicenseTier`. A trialing customer carries `tier=personal` with `expirySec` set to the trial end. Feature gates need zero changes.
+- No new client-side state (`localStorage`, store, UI badge). The license-store already exposes `tier`; the trial is invisible to the app layer.
+- Cancellation during trial flows through the existing `customer.subscription.deleted → revoke` path.
+
+### Mode matrix (delta from ADR 012)
+
+| Mode | Trial behavior |
+|---|---|
+| **Hosted prod** (my.feedzero.app) | Every new Checkout Session opens with a 30-day trial. Customer card stored; auto-charged on day 31. |
+| **Self-hosted** | No effect — self-hosted bypasses tier gates entirely (ADR 014). |
+| **Dev / local** | No Stripe involvement; flag stays dormant. |
+
+## Rejected alternatives
+
+- **Env var (`STRIPE_TRIAL_PERIOD_DAYS=30`)** — Premature configurability. Monetary terms belong in code review history, not in a dashboard. Per CLAUDE.md "Principles → Design": flags-and-toggles are debt. Promote when there's a real reason to A/B.
+- **Stripe Dashboard `trial_period_days` on the Price object** — Moves a security-relevant business rule out of git. Risks silent staging-vs-live drift; risks a Dashboard click during an incident; risks the trial setting "expiring" after a Price-archive-and-recreate cycle. Source-of-truth must live in code.
+- **Client-supplied `trialPeriodDays` in the POST body** — An attacker would just pass `trial_period_days: 365`. The server must own monetary terms (same reason `allowedPrices` is server-side).
+- **New `LicenseTier = "free-trial"`** — A second pathway through `feature-gates.ts` for no functional gain. Trialing customers should see exactly what paying customers see; differentiating them in the type system invites accidental gating.
+- **Client-side trial flag (`feedzero:trial-started-at` in localStorage)** — Trivially reset (clear storage → fresh 30 days). Requires building expiry/renewal logic FeedZero would otherwise outsource to Stripe.
+- **Stripe coupon (100% off first month)** — Functionally identical from the customer's perspective, but Stripe couponing has a different metadata footprint (`discount.coupon.id` on invoices) that the recovery + admin scripts don't yet read. `trial_period_days` rides the existing webhook paths.
+
+## Consequences
+
+**Positive:**
+- Zero new state. Token shape, store shape, gate function signature all unchanged.
+- Cancellation, renewal, and revocation all reuse the production code paths that already had ~3 months of soak. The trial is just "a subscription that hasn't billed yet."
+- Sunset is `git revert` — one constant + one inject point.
+
+**Negative:**
+- **Abuse vector**: trivial to claim a trial twice with different emails or with email aliases (`user+1@gmail.com`, `user+2@…`). Stripe does not block this natively. Defer mitigation; revisit if smoke metrics show abuse.
+- **No app-side "trial: 5 days left" UI**. The license payload doesn't carry a trialing-vs-active flag. Users see Personal features unlocked from day 0 and have to look at their Stripe dashboard or email receipts for the trial-end date. Future ADR if we want to surface it.
+- **Yearly subscribers also get 30 days free**, not 30 days into a $50 commitment. This is the same trial as monthly — a 30-day try-out followed by a year of billing. Acceptable.
+
+## Cross-references
+
+- [ADR 012 — Open-core feature gating](012-open-core-feature-gating.md) — trialing customers carry `tier=personal`; gates work as-is.
+- [ADR 014 — Self-host first class](014-self-host-first-class.md) — self-hosted mode is unaffected; trial only applies to the hosted product.
+- [Feature 014 — Stripe trial](../features/014-stripe-trial.md) — operational details.

--- a/docs/features/014-stripe-trial.md
+++ b/docs/features/014-stripe-trial.md
@@ -1,0 +1,99 @@
+# Feature 014: 30-Day Free Trial via Stripe Checkout
+
+## Status
+Implemented
+
+## Summary
+
+Every new Personal-tier subscriber opens with a 30-day free trial. Stripe owns the clock, FeedZero issues a license pinned to the trial end date, and the existing `invoice.paid → recordRenewal` path extends the license when the first charge lands on day 31. No new tier, no client-side trial state, no new endpoint — the trial is invisible to the app's data model. See [ADR 015](../decisions/015-stripe-side-trial.md) for the rationale.
+
+## Behaviour
+
+```gherkin
+Feature: 30-day free trial
+
+  Scenario: New subscriber opens a Personal monthly Checkout Session
+    Given a user lands on /?subscribe=personal-monthly
+    When the deeplink fires /api/checkout/create-session
+    Then the Stripe Checkout Session is created with subscription_data.trial_period_days=30
+    And the customer enters a card but is not charged
+    And consent_collection.terms_of_service="required" still gates the EU 14-day-waiver
+
+  Scenario: Stripe fires customer.subscription.created on a trialing subscription
+    Given the webhook handler receives a signed event with status="trialing"
+    And the subscription carries current_period_end = trial_end_sec
+    When handleSubscriptionCreated dispatches to issuer.issue
+    Then issuer.issue is called with expirySec=trial_end_sec
+    And a license token is minted that expires at the trial end (not at issuer default of 31 days)
+
+  Scenario: Trial ends, first invoice paid
+    Given day 30 passes and Stripe charges the stored card
+    When the webhook receives invoice.paid with period.end = next_billing_sec
+    Then issuer.recordRenewal extends the existing license to next_billing_sec
+    And the customer experiences no functional change
+
+  Scenario: Customer cancels during trial
+    Given a trialing subscription
+    When the customer cancels via Stripe Customer Portal
+    And Stripe fires customer.subscription.deleted
+    Then issuer.revoke marks every license for that customer as revoked
+    And subsequent /api/sync requests with the old token return 401
+```
+
+## Architecture
+
+### Flow
+
+1. Customer clicks "Start 30-day free trial" on `/settings/subscription` (or lands on `?subscribe=personal-monthly` from the landing page).
+2. `subscribe-deeplink.tsx` POSTs to `/api/checkout/create-session` with `{priceId, successUrl, cancelUrl}` — body unchanged from the pre-trial flow.
+3. `handleCreateCheckoutSession` (`src/core/stripe/checkout-handler.ts`) injects `subscription_data: { trial_period_days: 30 }` server-side and calls Stripe.
+4. Customer completes Checkout on Stripe's hosted page; card stored, no immediate charge.
+5. Stripe fires `customer.subscription.created` with `status: "trialing"` and `current_period_end` = trial end.
+6. `handleSubscriptionCreated` (`src/core/stripe/webhook-handler.ts`) calls `extractSubscriptionCurrentPeriodEnd(obj)` and passes the result as `expirySec` to `issuer.issue`. License is minted with that exact expiry.
+7. License token is delivered to the customer via the success-page handoff (`pages/billing-success.tsx` reads the Stripe session and fetches the matching license).
+8. On day 31 Stripe charges the card and fires `invoice.paid`. `handleInvoicePaid → issuer.recordRenewal` updates the same license record's `expirySec` to `period.end` (≈ day 61).
+
+### Files
+
+| File | Role |
+|------|------|
+| `src/core/stripe/checkout-handler.ts` | Injects `subscription_data.trial_period_days` into every Checkout Session create call. Houses `TRIAL_PERIOD_DAYS = 30` constant — the single source of truth. |
+| `src/core/stripe/webhook-handler.ts` | `handleSubscriptionCreated` now reads `current_period_end` and passes it as `expirySec` to `issuer.issue`. Falls back to issuer default if missing (back-compat / non-trial subscriptions). |
+| `src/core/license/issuer.ts` | Unchanged — `mintAndPersist` already honored `expirySec` overrides. Only the public `LicenseIssuer.issue` interface was widened. |
+| `src/components/settings/subscription-upgrade.tsx` | Personal tier card surfaces "30 days free" in blurb and CTA. |
+| `src/core/stripe/test-fixtures.ts` | `subscriptionCreatedEvent` accepts optional `current_period_end`; new `subscriptionCreatedEventDahlia` mirrors the 2026-04-22 API-version shape. |
+
+### Tests
+
+| File | Coverage |
+|------|----------|
+| `tests/core/stripe/checkout-handler.test.ts` | Asserts `subscription_data: { trial_period_days: 30 }` is passed on every call; EU consent + idempotency key unchanged. |
+| `tests/core/stripe/webhook-handler.test.ts` | Two new cases: trialing subscription.created with top-level `current_period_end`, and dahlia variant with `current_period_end` on items[0]. |
+| `tests/core/license/issuer.test.ts` | New case: `issue({expirySec: T})` persists a record whose `expirySec === T`. |
+| `tests/components/settings/subscription-upgrade.test.tsx` | Asserts the trial CTA + "30 days free" copy render. |
+| `tests/smoke/checkout.test.ts` | Pre-existing — endpoint reachable, allowlist enforced. Does NOT exercise the trial-create path (would create real Stripe data); manual verification covers it. |
+
+## Design Decisions
+
+- **Trial duration is a code constant, not an env var or Dashboard setting.** Monetary terms must live in git. See ADR 015.
+- **Pin license expiry to `current_period_end`, not to the issuer's 31-day default.** A 30-day trial expiring on day 31 mostly works, but is brittle if Stripe changes trial semantics or we shorten the trial. Reading the subscription's own clock is more correct.
+- **No new `LicenseTier`.** Trialing customers carry `tier=personal`. Feature gates need zero changes; the trial is invisible to `feature-gates.ts`.
+- **No app-side trial state.** `localStorage` and stores don't know about trials. The Stripe-side `current_period_end` is the only source of truth.
+- **Yearly subscribers also get the trial.** Same 30-day try-out, then a year of billing instead of a month. Equal treatment of monthly/yearly.
+
+## Manual verification
+
+Unit tests prove the handler emits `subscription_data.trial_period_days`. They cannot prove Stripe's hosted page actually shows "Start your 30-day free trial" — that's a Stripe-rendered surface. Once per deploy:
+
+1. On staging (`SMOKE_BASE_URL=https://staging.feedzero.app`), POST a valid `personal-monthly` checkout body and copy the returned `body.url`.
+2. Open the URL in a browser. Expect:
+   - "Try free for 30 days" or equivalent trial banner beneath the price line.
+   - The EU Terms-of-Service consent checkbox still present.
+   - No immediate charge to the test card (use `4242 4242 4242 4242`).
+3. Advance Stripe's test clock to 31 days. Expect `invoice.paid` fires and `recordRenewal` extends the license.
+
+## Limitations
+
+- **Abuse vector**: a determined user can claim a trial twice via different emails or email aliases (`user+1@gmail.com`). Stripe does not natively block this. Out of scope; revisit if smoke metrics show real abuse.
+- **No "X days left" UI in the app.** License payload doesn't carry a trialing-vs-active flag. Surfacing it would require either a payload-format change or an extra `/api/license/status` call. Future work if customer confusion becomes a support driver.
+- **`sync-migration-dialog.tsx`** still uses pre-trial CTA copy ("Subscribe to Personal — $5/mo"). That dialog targets users whose subscription has lapsed and whose vault is in 90-day retention; offering them a fresh trial may or may not be appropriate. Decision deferred.

--- a/docs/operations/license-support.md
+++ b/docs/operations/license-support.md
@@ -76,6 +76,7 @@ License records: (none) — customer has no licenses in storage.
 |---|---|
 | Active record exists, recent expiry | Just reissue (Step 3). You don't need the original token's text — reissuing mints a brand-new token signed with the same key. |
 | Active record exists, expiry far in the future, customer just needs the token text | Same: reissue. The CLI prints a fresh token. The old one remains valid until expiry but it's not exposed by the CLI. |
+| Active record, expiry ≈ 30 days out, Stripe shows `status=trialing` | Customer is in their 30-day free trial. The license is pinned to the trial-end date (not the issuer's 31-day default) — see [ADR 015](../decisions/015-stripe-side-trial.md). Reissue if they need the token text; the trial clock is owned by Stripe and unaffected. Auto-renewal happens on day 31 via `invoice.paid` → `recordRenewal`. |
 | No records, but Stripe shows an active subscription | The webhook likely failed. Reissue still works — the issuer mints from the customer + subscription state. |
 | Stripe customer not found | Customer used a different email. Go to [Procedure 2](#procedure-2--multiple-lookups). |
 | Subscription is cancelled in Stripe | Go to [Procedure 3](#procedure-3--cancelled-subscription). |

--- a/src/components/settings/subscription-upgrade.tsx
+++ b/src/components/settings/subscription-upgrade.tsx
@@ -45,7 +45,7 @@ export function SubscriptionUpgrade() {
         name="Personal"
         price="$5/mo"
         priceSub="or $50/yr — save 17%"
-        blurb="Sync across every device. Unlimited feeds."
+        blurb="Sync across every device. Unlimited feeds. 30 days free, cancel anytime."
         featured
         features={[
           "Everything in Free",
@@ -53,9 +53,9 @@ export function SubscriptionUpgrade() {
           "Auto-organize folders",
           "Unlimited feeds",
         ]}
-        cta="Subscribe to Personal — $5/mo"
+        cta="Start 30-day free trial — then $5/mo"
         ctaHref="/?subscribe=personal-monthly"
-        secondaryCta="or $50/yr — save 17%"
+        secondaryCta="or 30 days free, then $50/yr — save 17%"
         secondaryCtaHref="/?subscribe=personal-yearly"
       />
 

--- a/src/core/stripe/checkout-handler.ts
+++ b/src/core/stripe/checkout-handler.ts
@@ -35,6 +35,24 @@ export const SUPPORTED_METHODS: readonly string[] = ["POST"];
 const ROUTE = "/api/checkout/create-session";
 
 /**
+ * Free-trial duration applied to every Checkout Session this handler creates.
+ *
+ * Why a server-controlled constant (not env var, not Dashboard config, not a
+ * client-supplied flag):
+ *  - Monetary terms must live in code review history, not in dashboards that
+ *    silently drift between staging and live mode.
+ *  - The client cannot be trusted to choose a trial length — an env var
+ *    would just push the same trust problem one layer down.
+ *  - Flags-and-toggles are debt (CLAUDE.md "Principles → Design").
+ *
+ * To shorten or extend the trial: edit this constant. To sunset the trial:
+ * remove the `subscription_data` field from the create call entirely —
+ * Stripe rejects `trial_period_days: 0`, so a zero value is not a valid
+ * off-switch.
+ */
+const TRIAL_PERIOD_DAYS = 30;
+
+/**
  * Minimal subset of `stripe.checkout.sessions.create` we depend on. Defining
  * it here means tests pass a fake without pulling in the Stripe SDK.
  */
@@ -55,6 +73,12 @@ export interface CheckoutClient {
        * without this checkbox the waiver is unenforceable.
        */
       consent_collection?: { terms_of_service: "required" | "none" };
+      /**
+       * Trial-period configuration. Stripe lets the Checkout Session inject
+       * a trial directly on the underlying Subscription. Stripe docs:
+       * https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-subscription_data
+       */
+      subscription_data?: { trial_period_days: number };
     },
     opts?: { idempotencyKey?: string },
   ): Promise<{ url: string | null; id: string }>;
@@ -224,6 +248,7 @@ export async function handleCreateCheckoutSession(
         // CheckoutClient.create JSDoc for the why; without this, the waiver
         // text in our Terms is unenforceable against an EU consumer.
         consent_collection: { terms_of_service: "required" },
+        subscription_data: { trial_period_days: TRIAL_PERIOD_DAYS },
         ...(parsed.args.customerEmail
           ? { customer_email: parsed.args.customerEmail }
           : {}),

--- a/src/core/stripe/test-fixtures.ts
+++ b/src/core/stripe/test-fixtures.ts
@@ -37,6 +37,13 @@ interface SubscriptionCreatedArgs {
   customerId: string;
   subscriptionId: string;
   tier: "personal" | "pro";
+  /**
+   * Trial-aware subscriptions expose the trial-end date here (Stripe sets it
+   * when `subscription_data.trial_period_days` is on the Checkout Session).
+   * Omit to model a legacy non-trial subscription where the webhook had to
+   * fall back to the issuer's 31-day default.
+   */
+  current_period_end?: number;
 }
 
 export function subscriptionCreatedEvent(
@@ -49,9 +56,46 @@ export function subscriptionCreatedEvent(
       object: {
         id: args.subscriptionId,
         customer: args.customerId,
+        ...(args.current_period_end !== undefined
+          ? { current_period_end: args.current_period_end }
+          : {}),
         items: {
           data: [
             {
+              price: {
+                metadata: { tier: args.tier },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  return {
+    event,
+    signature: (secret, ts) => buildSignature(event, secret, ts),
+  };
+}
+
+/**
+ * Dahlia-shaped subscription.created event — `current_period_end` rides on
+ * `items.data[0]` instead of the top level. See subscriptionUpdatedEventDahlia
+ * for the same shape change on update events.
+ */
+export function subscriptionCreatedEventDahlia(
+  args: SubscriptionCreatedArgs & { current_period_end: number },
+): StripeFixture {
+  const event = {
+    id: `evt_${args.subscriptionId}_created_dahlia`,
+    type: "customer.subscription.created",
+    data: {
+      object: {
+        id: args.subscriptionId,
+        customer: args.customerId,
+        items: {
+          data: [
+            {
+              current_period_end: args.current_period_end,
               price: {
                 metadata: { tier: args.tier },
               },

--- a/src/core/stripe/webhook-handler.ts
+++ b/src/core/stripe/webhook-handler.ts
@@ -26,6 +26,13 @@ export interface LicenseIssuer {
     customerId: string;
     tier: "personal" | "pro";
     subscriptionId: string;
+    /**
+     * Optional override. Trial-aware `customer.subscription.created` events
+     * arrive with `current_period_end` already set to the trial-end date;
+     * we pass it through here so the issued license expires when the trial
+     * does instead of falling back to the issuer's 31-day default.
+     */
+    expirySec?: number;
   }): Promise<Result<void>>;
   revoke(args: {
     customerId: string;
@@ -278,8 +285,18 @@ async function handleSubscriptionCreated(
     // the issue for our own observability.
     return acceptedWithIssue("Missing tier metadata on price");
   }
+  // When the subscription is trialing (or just newly created) Stripe sets
+  // current_period_end to the trial-end / first-billing date. Pin the
+  // license expiry to it so the trial license expires when Stripe says it
+  // should, not at the issuer's 31-day default.
+  const expirySec = extractSubscriptionCurrentPeriodEnd(obj);
   return outcomeFromIssuerResult(
-    await issuer.issue({ customerId, subscriptionId, tier }),
+    await issuer.issue({
+      customerId,
+      subscriptionId,
+      tier,
+      ...(expirySec !== null ? { expirySec } : {}),
+    }),
   );
 }
 

--- a/tests/components/settings/subscription-upgrade.test.tsx
+++ b/tests/components/settings/subscription-upgrade.test.tsx
@@ -16,10 +16,21 @@ describe("<SubscriptionUpgrade>", () => {
     expect(screen.getByRole("heading", { name: /Self-host/i })).toBeInTheDocument();
   });
 
-  it("Personal Subscribe CTA links to the personal-monthly deeplink", () => {
+  it("Personal CTA links to the personal-monthly deeplink and surfaces the 30-day free trial", () => {
+    // Stripe-managed trial: the checkout handler injects
+    // subscription_data.trial_period_days=30. The CTA copy must match so a
+    // user reading the card understands why no charge appears immediately.
     render(<SubscriptionUpgrade />);
-    const cta = screen.getByRole("link", { name: /subscribe.*personal/i });
+    const cta = screen.getByRole("link", { name: /30-day free trial/i });
     expect(cta.getAttribute("href")).toMatch(/\?subscribe=personal-monthly/);
+  });
+
+  it("calls out '30 days free' in the Personal card blurb so the trial is visible above the fold", () => {
+    render(<SubscriptionUpgrade />);
+    // Multiple matches expected (blurb + secondary yearly CTA). Both surfaces
+    // intentionally repeat the trial framing — make sure at least the blurb
+    // line is present.
+    expect(screen.getAllByText(/30 days free/i).length).toBeGreaterThan(0);
   });
 
   it("Pro tier shows Coming Soon with no subscribe link", () => {

--- a/tests/core/license/issuer.test.ts
+++ b/tests/core/license/issuer.test.ts
@@ -141,6 +141,29 @@ describe("LicenseIssuerImpl — issue (interface method)", () => {
     const fetched = await storage.get("interface_method_key_id_xxxxxxxx");
     expect(isOk(fetched) && fetched.value?.customerId).toBe("cus_006");
   });
+
+  // When the Stripe webhook receives `customer.subscription.created` for a
+  // trialing subscription, the subscription's `current_period_end` is the
+  // trial-end date (not 31 days as the issuer's hardcoded default would
+  // assume). The interface must let the caller pin expiry to that value so
+  // the license expires when the trial does, not a day later.
+  it("honors a caller-supplied expirySec via the public interface", async () => {
+    const customExpiry = NOW + 7 * 24 * 3600;
+    const { issuer, storage } = makeIssuer({
+      generateKeyId: () => "interface_expiry_key_id_yyyyyyyy",
+    });
+
+    const result = await issuer.issue({
+      customerId: "cus_007",
+      tier: "personal",
+      subscriptionId: "sub_007",
+      expirySec: customExpiry,
+    });
+    expect(isOk(result)).toBe(true);
+
+    const fetched = await storage.get("interface_expiry_key_id_yyyyyyyy");
+    expect(isOk(fetched) && fetched.value?.expirySec).toBe(customExpiry);
+  });
 });
 
 describe("LicenseIssuerImpl — revoke", () => {

--- a/tests/core/stripe/checkout-handler.test.ts
+++ b/tests/core/stripe/checkout-handler.test.ts
@@ -161,6 +161,28 @@ describe("checkout handler — success path", () => {
     );
   });
 
+  it("injects subscription_data.trial_period_days=30 so every Personal subscription opens with a 30-day free trial", async () => {
+    // The 30-day trial is server-controlled (constant in the handler, not an
+    // env var or client field) so attackers can't extend it and operators
+    // don't risk staging vs live drift. Sunset by removing the field; setting
+    // it to 0 is invalid per Stripe.
+    const create = vi.fn(async () => ({ url: "https://x", id: "y" }));
+    await handleCreateCheckoutSession(
+      postBody({
+        priceId: "price_personal_monthly_test",
+        successUrl: "https://feedzero.app/s",
+        cancelUrl: "https://feedzero.app/c",
+      }),
+      { client: { create }, allowedPrices: ALLOWED_PRICES },
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscription_data: { trial_period_days: 30 },
+      }),
+      expect.anything(),
+    );
+  });
+
   it("passes consent_collection.terms_of_service='required' so EU customers explicitly accept Terms (which embed the Art. 16(m) withdrawal-right waiver)", async () => {
     // Stripe docs (https://docs.stripe.com/api/checkout/sessions/create):
     //   "If set to `required`, it requires customers to check a terms of

--- a/tests/core/stripe/webhook-handler.test.ts
+++ b/tests/core/stripe/webhook-handler.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/core/stripe/webhook-handler";
 import {
   subscriptionCreatedEvent,
+  subscriptionCreatedEventDahlia,
   subscriptionDeletedEvent,
   subscriptionUpdatedEvent,
   subscriptionUpdatedEventDahlia,
@@ -146,6 +147,53 @@ describe("handleStripeWebhook", () => {
       customerId: CUSTOMER_ID,
       subscriptionId: SUBSCRIPTION_ID,
       tier: "pro",
+    });
+  });
+
+  // Trialing subscriptions arrive with `current_period_end` already set to the
+  // trial-end date. We MUST pass that through as expirySec — otherwise the
+  // issuer falls back to its 31-day default, which is fine for a 30-day trial
+  // (off by ~1 day) but wrong for any other trial length and brittle if the
+  // trial period changes. Pin the license to the subscription's own clock.
+  it("passes current_period_end (top-level) to issuer.issue for trialing subscription.created", async () => {
+    const trialEndSec = nowSec() + 30 * 24 * 60 * 60;
+    const fixture = subscriptionCreatedEvent({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "personal",
+      current_period_end: trialEndSec,
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(200);
+    expect(issuer.issue).toHaveBeenCalledWith({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "personal",
+      expirySec: trialEndSec,
+    });
+  });
+
+  it("reads current_period_end from items.data[0] when top-level is missing (dahlia subscription.created)", async () => {
+    const trialEndSec = nowSec() + 30 * 24 * 60 * 60;
+    const fixture = subscriptionCreatedEventDahlia({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "personal",
+      current_period_end: trialEndSec,
+    });
+    const res = await handleStripeWebhook(
+      postFixture(fixture, nowSec()),
+      makeConfig(issuer),
+    );
+    expect(res.status).toBe(200);
+    expect(issuer.issue).toHaveBeenCalledWith({
+      customerId: CUSTOMER_ID,
+      subscriptionId: SUBSCRIPTION_ID,
+      tier: "personal",
+      expirySec: trialEndSec,
     });
   });
 


### PR DESCRIPTION
Every new Personal-tier subscriber opens with a 30-day free trial.
Stripe owns the trial clock; FeedZero adds 13 lines of handler code,
4 lines of UI copy, and zero new state.

What changes:
- `checkout-handler.ts` injects `subscription_data.trial_period_days=30`
  on every Checkout Session create call. Trial duration is a server-side
  `TRIAL_PERIOD_DAYS` constant — not an env var, not Dashboard config.
- `webhook-handler.ts` `handleSubscriptionCreated` reads
  `current_period_end` (top-level or dahlia `items.data[0]`) off the
  subscription object and passes it through as `expirySec` so the
  license pins to the trial end instead of the issuer's 31-day default.
- `LicenseIssuer.issue` interface widened with optional `expirySec`.
  The impl already supported it; only the public surface changed.
- `subscription-upgrade.tsx` Personal card copy: "30 days free" in the
  blurb + "Start 30-day free trial — then $5/mo" CTA. Yearly secondary
  CTA mirrors the framing.

What does NOT change:
- No new `LicenseTier`. Trialing customers carry `tier=personal`.
- No license payload format change — `expirySec` already encoded trial
  end semantically.
- No new endpoint, no request body change, no client-side state.
- No abuse prevention beyond Stripe Radar (acknowledged in ADR 015).

Tests added (RGR):
- `tests/core/license/issuer.test.ts` — public-interface expirySec honored.
- `tests/core/stripe/webhook-handler.test.ts` — two cases: trialing
  subscription.created with top-level `current_period_end`, and dahlia
  variant on `items.data[0]`.
- `tests/core/stripe/checkout-handler.test.ts` — `subscription_data.
  trial_period_days=30` injected on every call; consent + idempotency
  key unchanged.
- `tests/components/settings/subscription-upgrade.test.tsx` — CTA copy
  and "30 days free" framing render.
- `src/core/stripe/test-fixtures.ts` — `subscriptionCreatedEvent` now
  accepts optional `current_period_end`; new `subscriptionCreatedEventDahlia`
  mirrors the 2026-04-22 API shape.

Documentation:
- `docs/architecture.md` — note trial injection + webhook pinning.
- `docs/decisions/015-stripe-side-trial.md` (new ADR) — decision +
  rejected alternatives (env var, Dashboard config, client flag,
  free-trial tier, client-only trial flag).
- `docs/features/014-stripe-trial.md` (new) — flow, files, manual
  verification, limitations.
- `docs/operations/license-support.md` — runbook row for trialing
  customers.

https://claude.ai/code/session_01TQzUjiPpprgHyNRnEabk16