### PR TITLE
refactor(settings): frosted-glass sync gate overlay + adaptive card height

### DIFF
--- a/src/components/settings/data-sync-section.tsx
+++ b/src/components/settings/data-sync-section.tsx
@@ -199,7 +199,11 @@ export function DataSyncSection() {
 
   return (
     <div className="space-y-4">
-      <div className="relative overflow-hidden rounded-lg border border-border bg-card min-h-[160px]">
+      <div
+        className={`relative overflow-hidden rounded-lg border border-border bg-card ${
+          gated ? "min-h-[160px]" : ""
+        }`}
+      >
         <div
           className={`p-4 space-y-3 ${
             gated ? "pointer-events-none select-none opacity-60" : ""
@@ -305,22 +309,23 @@ interface GateOverlayProps {
  * Locked-state overlay for the Cloud sync card. Renders inside the parent's
  * `overflow-hidden` container with `absolute inset-0` so the blurred glass
  * is exactly the size of the card it covers — never overflows above (into
- * the tab strip) or below (into the Danger zone). Content is centred and
- * intentionally compact: lock icon + one-line message + one button. No
- * nested card frame, which is what caused the prior layout to overflow on
- * mobile when the parent card was shorter than the overlay's own content.
- */
-/**
- * Frosted-glass surface classes shared by both gate variants.
+ * the tab strip) or below (into the Danger zone).
  *
+ * Frosted-glass surface (`GLASS_CLASSES`):
  * - `bg-card/40` — light tint so the toggle behind reads through.
  * - `backdrop-blur-lg` — strong frosted blur on whatever sits behind.
- *   Falls back gracefully on browsers without `backdrop-filter` (Safari
- *   ≥9, Chrome ≥76, Firefox ≥103); the tint alone still dims the toggle.
+ *   Falls back gracefully on browsers without `backdrop-filter`
+ *   (Safari ≥9, Chrome ≥76, Firefox ≥103); the tint alone still dims
+ *   the toggle.
  * - `ring-1 ring-inset ring-foreground/10` — subtle inset edge that
  *   defines the glass surface against the card border.
  * - `supports-[backdrop-filter]:bg-card/30` — lighter tint when blur is
  *   actually doing the visual work, heavier tint when it isn't.
+ *
+ * Content is centred and intentionally compact: lock icon + one-line
+ * message + one button. No nested card frame, which is what caused the
+ * prior layout to overflow on mobile when the parent card was shorter
+ * than the overlay's own content.
  */
 const GLASS_CLASSES =
   "absolute inset-0 flex items-center justify-center px-4 " +

--- a/src/components/settings/data-sync-section.tsx
+++ b/src/components/settings/data-sync-section.tsx
@@ -199,10 +199,10 @@ export function DataSyncSection() {
 
   return (
     <div className="space-y-4">
-      <div className="relative overflow-hidden rounded-lg border border-border bg-card min-h-[140px]">
+      <div className="relative overflow-hidden rounded-lg border border-border bg-card min-h-[160px]">
         <div
           className={`p-4 space-y-3 ${
-            gated ? "pointer-events-none select-none blur-sm opacity-40" : ""
+            gated ? "pointer-events-none select-none opacity-60" : ""
           }`}
           aria-hidden={gated || undefined}
         >
@@ -310,12 +310,29 @@ interface GateOverlayProps {
  * nested card frame, which is what caused the prior layout to overflow on
  * mobile when the parent card was shorter than the overlay's own content.
  */
+/**
+ * Frosted-glass surface classes shared by both gate variants.
+ *
+ * - `bg-card/40` — light tint so the toggle behind reads through.
+ * - `backdrop-blur-lg` — strong frosted blur on whatever sits behind.
+ *   Falls back gracefully on browsers without `backdrop-filter` (Safari
+ *   ≥9, Chrome ≥76, Firefox ≥103); the tint alone still dims the toggle.
+ * - `ring-1 ring-inset ring-foreground/10` — subtle inset edge that
+ *   defines the glass surface against the card border.
+ * - `supports-[backdrop-filter]:bg-card/30` — lighter tint when blur is
+ *   actually doing the visual work, heavier tint when it isn't.
+ */
+const GLASS_CLASSES =
+  "absolute inset-0 flex items-center justify-center px-4 " +
+  "bg-card/40 supports-[backdrop-filter]:bg-card/30 " +
+  "backdrop-blur-lg ring-1 ring-inset ring-foreground/10";
+
 function GateOverlay({ variant, onUpgrade }: GateOverlayProps) {
   if (variant === "self-host") {
     return (
-      <div className="absolute inset-0 flex items-center justify-center bg-card/80 backdrop-blur-sm px-4">
+      <div className={GLASS_CLASSES}>
         <div className="text-center space-y-2 max-w-xs">
-          <Lock className="mx-auto size-5 text-muted-foreground" />
+          <Lock className="mx-auto size-5 text-foreground/70" />
           <p className="text-sm font-medium">Sync server not configured</p>
           <Button asChild size="sm" variant="outline">
             <a href={SELF_HOST_DOCS_URL} target="_blank" rel="noreferrer noopener">
@@ -329,9 +346,9 @@ function GateOverlay({ variant, onUpgrade }: GateOverlayProps) {
   }
 
   return (
-    <div className="absolute inset-0 flex items-center justify-center bg-card/80 backdrop-blur-sm px-4">
+    <div className={GLASS_CLASSES}>
       <div className="text-center space-y-2 max-w-xs">
-        <Lock className="mx-auto size-5 text-muted-foreground" />
+        <Lock className="mx-auto size-5 text-foreground/70" />
         <p className="text-sm font-medium">Cloud sync requires a subscription</p>
         <Button size="sm" onClick={onUpgrade}>
           Upgrade plan


### PR DESCRIPTION
Two visual fix-ups to the sync gate overlay that I'd pushed onto the original PR branch after #112 was already merged — they never made it onto main. Reopening on a fresh branch.

## Summary

- **Frosted-glass treatment for the sync gate overlay.** Previously `bg-card/80 + backdrop-blur-sm` rendered as a flat dim card sitting on top of a smeared, foreground-blurred toggle. Now: `bg-card/40` (drops to `/30` when `backdrop-filter` is supported), `backdrop-blur-lg`, `ring-1 ring-inset ring-foreground/10` for the glass edge. Foreground blur on the toggle is removed (only `opacity-60` dim) so the glass does the visual work and you can see what's locked behind.
- **`min-h-[160px]` is conditional on `gated`.** The fixed floor was added so the overlay had room for lock + button, but for users with sync unlocked and toggled off, the box sat half-empty. Now the floor only applies when the overlay is showing; unlocked state adapts to content.

## Files
- `src/components/settings/data-sync-section.tsx` — overlay classes + conditional min-h, JSDoc cleaned up

## Test plan
- [x] `npx tsc --noEmit` — green
- [x] `npm test` — 2,395 tests passing (pre-push hook reran)
- [x] Manual smoke on Vercel preview: free user lands on Sync & Data → frosted glass overlays the toggle cleanly; paid user toggles sync off → card collapses to header height (no empty space below)

https://claude.ai/code/session_01V85hetDYb1HKvuDDpvzz6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01V85hetDYb1HKvuDDpvzz6d)_