### PR TITLE
feat(feedback): surface GitHub Issues + email support, accept optional reply email (closes #102)

### DIFF
--- a/src/components/feedback/feedback-dialog.tsx
+++ b/src/components/feedback/feedback-dialog.tsx
@@ -1,5 +1,23 @@
+/**
+ * <FeedbackDialog> — three feedback channels, anonymous by default.
+ *
+ * Issue #102 asked for: link out to GitHub Issues first (where users can see
+ * the maintainer's responses and existing threads), link to email support,
+ * and an optional email field so a user who wants a reply can identify
+ * themselves. This dialog renders all three:
+ *
+ *   - Top: two outline buttons for the discoverable channels — `Browse on
+ *     GitHub` and `Email support`. Linking out is the fastest path when the
+ *     user wants to read existing issues or have a back-and-forth thread.
+ *   - Middle: the quick-note textarea. Anonymous by default. POSTs to
+ *     `/api/feedback` which creates a GitHub issue server-side.
+ *   - Bottom: optional email input. If provided, server appends a
+ *     `Reply to:` line to the issue body so the maintainer can email back.
+ *     A muted helper line below the input tells the user the email will be
+ *     visible on the public issue — that's the consent signal.
+ */
 import { useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, MessagesSquare, Mail, ExternalLink } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -9,9 +27,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { SUPPORT_EMAIL } from "@/components/settings/contact-support";
 import { toast } from "sonner";
 
 const MAX_LENGTH = 2000;
+const GITHUB_ISSUES_URL = "https://github.com/forcingfx/feedzero/issues";
 
 interface FeedbackDialogProps {
   open: boolean;
@@ -20,25 +40,33 @@ interface FeedbackDialogProps {
 
 export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   const [message, setMessage] = useState("");
+  const [email, setEmail] = useState("");
   const [isSending, setIsSending] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const trimmed = message.trim();
-    if (!trimmed) return;
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage) return;
+
+    const trimmedEmail = email.trim();
+    const payload: { message: string; email?: string } = {
+      message: trimmedMessage,
+    };
+    if (trimmedEmail) payload.email = trimmedEmail;
 
     setIsSending(true);
     try {
       const res = await fetch("/api/feedback", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: trimmed }),
+        body: JSON.stringify(payload),
       });
       const data = await res.json();
 
       if (data.ok) {
         toast.success("Thanks for your feedback!");
         setMessage("");
+        setEmail("");
         onOpenChange(false);
       } else {
         toast.error(data.error || "Could not send feedback");
@@ -64,42 +92,106 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Send Feedback</DialogTitle>
+          <DialogTitle>Send feedback</DialogTitle>
           <DialogDescription>
             Tell us what you think, report a bug, or suggest a feature.
-            No account needed — this is anonymous.
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit}>
-          <textarea
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            onKeyDown={handleTextareaKeyDown}
-            placeholder="What's on your mind?"
-            maxLength={MAX_LENGTH}
-            rows={5}
-            className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
-            disabled={isSending}
-            autoFocus
-          />
-          <div className="flex items-center justify-between mt-2">
-            <span className="text-xs text-muted-foreground">
-              {message.length}/{MAX_LENGTH}
-            </span>
-            <DialogFooter className="p-0">
-              <Button
-                type="submit"
-                size="sm"
-                disabled={!message.trim() || isSending}
+        <div className="rounded-md border border-border bg-muted/40 p-3 space-y-2">
+          <p className="text-xs text-muted-foreground">
+            For a threaded conversation or to see existing reports:
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild variant="outline" size="sm">
+              <a
+                href={GITHUB_ISSUES_URL}
+                target="_blank"
+                rel="noreferrer noopener"
               >
-                {isSending ? (
-                  <Loader2 className="size-3.5 animate-spin mr-1" />
-                ) : null}
-                Send
-              </Button>
-            </DialogFooter>
+                <MessagesSquare className="mr-2 size-3.5" />
+                Browse on GitHub
+                <ExternalLink className="ml-1 size-3" />
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <a href={`mailto:${SUPPORT_EMAIL}`}>
+                <Mail className="mr-2 size-3.5" />
+                Email support
+              </a>
+            </Button>
           </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1">
+            <label
+              htmlFor="feedback-message"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Or send a quick note here
+            </label>
+            <textarea
+              id="feedback-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={handleTextareaKeyDown}
+              placeholder="What's on your mind?"
+              maxLength={MAX_LENGTH}
+              rows={5}
+              className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
+              disabled={isSending}
+              autoFocus
+            />
+            <div className="text-right text-xs text-muted-foreground">
+              {message.length}/{MAX_LENGTH}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label
+              htmlFor="feedback-email"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Email{" "}
+              <span className="font-normal">(optional, for replies)</span>
+            </label>
+            <input
+              id="feedback-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              autoComplete="email"
+              maxLength={254}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              disabled={isSending}
+            />
+            <p className="text-xs text-muted-foreground">
+              We&apos;ll reply from{" "}
+              <a
+                href={`mailto:${SUPPORT_EMAIL}`}
+                className="underline hover:no-underline"
+              >
+                {SUPPORT_EMAIL}
+              </a>
+              . Your email will be visible on the public GitHub issue this
+              feedback creates.
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={!message.trim() || isSending}
+            >
+              {isSending ? (
+                <Loader2 className="size-3.5 animate-spin mr-1" />
+              ) : null}
+              Send
+            </Button>
+          </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>

--- a/src/core/feedback/feedback-handler.ts
+++ b/src/core/feedback/feedback-handler.ts
@@ -5,14 +5,19 @@
  * token with `repo` scope, scoped to the issues repo) and GITHUB_REPO env var
  * in the form "owner/repo" (e.g. "forcingfx/feedzero").
  *
- * No user identity is collected. The message is the only content posted.
+ * Anonymous by default. If the user supplies an email, it is appended to the
+ * issue body as a "Reply to:" line so the maintainer can email them back. The
+ * UI surfaces a warning that the email becomes part of the public issue
+ * before the user types it — see <FeedbackDialog>.
  */
 
 interface FeedbackBody {
   message?: string;
+  email?: string;
 }
 
 const MAX_MESSAGE_LENGTH = 2000;
+const MAX_EMAIL_LENGTH = 254;
 
 /**
  * HTTP methods this handler accepts. Used by the routing contract test in
@@ -56,6 +61,21 @@ export async function handleFeedbackRequest(
     );
   }
 
+  // Email is optional. Reject obviously malformed values so a stray copy-paste
+  // doesn't end up in the public issue body, but keep validation permissive —
+  // the maintainer is the one who'll actually try replying.
+  const email = body.email?.trim();
+  if (email) {
+    if (email.length > MAX_EMAIL_LENGTH || !email.includes("@")) {
+      return jsonResponse(
+        { ok: false, error: "Email looks invalid" },
+        400,
+      );
+    }
+  }
+
+  const issueBody = email ? `${message}\n\n— Reply to: ${email}` : message;
+
   try {
     const response = await fetch(
       `https://api.github.com/repos/${repo}/issues`,
@@ -70,7 +90,7 @@ export async function handleFeedbackRequest(
         },
         body: JSON.stringify({
           title: `Feedback: ${message.slice(0, 80)}${message.length > 80 ? "…" : ""}`,
-          body: message,
+          body: issueBody,
           labels: ["feedback"],
         }),
       },

--- a/tests/components/feedback/feedback-dialog.test.tsx
+++ b/tests/components/feedback/feedback-dialog.test.tsx
@@ -29,31 +29,140 @@ describe("FeedbackDialog", () => {
     vi.unstubAllGlobals();
   });
 
-  it("submits the message to /api/feedback as JSON POST", async () => {
-    mockFetch.mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
+  describe("channel surfaces (issue #102)", () => {
+    it("links out to the public GitHub issues page", () => {
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+      const link = screen.getByRole("link", { name: /browse on github/i });
+      expect(link.getAttribute("href")).toBe(
+        "https://github.com/forcingfx/feedzero/issues",
+      );
+      expect(link.getAttribute("target")).toBe("_blank");
+    });
 
-    const onOpenChange = vi.fn();
-    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />);
+    it("exposes a mailto link to support", () => {
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+      const link = screen.getByRole("link", { name: /email support/i });
+      expect(link.getAttribute("href")).toBe("mailto:support@feedzero.app");
+    });
 
-    const textarea = screen.getByPlaceholderText("What's on your mind?");
-    await userEvent.type(textarea, "I love this app");
-    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+    it("warns that a provided email becomes visible on the public GitHub issue", () => {
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+      expect(
+        screen.getByText(/email will be visible on the public github issue/i),
+      ).toBeInTheDocument();
+    });
+  });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      "/api/feedback",
-      expect.objectContaining({
-        method: "POST",
-        headers: expect.objectContaining({
-          "Content-Type": "application/json",
+  describe("submission payload", () => {
+    it("submits message-only when no email is provided", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
         }),
-        body: JSON.stringify({ message: "I love this app" }),
-      }),
-    );
+      );
+
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+      await userEvent.type(
+        screen.getByPlaceholderText("What's on your mind?"),
+        "I love this app",
+      );
+      await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ message: "I love this app" }),
+        }),
+      );
+    });
+
+    it("includes the email in the payload when the user provides one", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+      await userEvent.type(
+        screen.getByPlaceholderText("What's on your mind?"),
+        "Found a bug",
+      );
+      await userEvent.type(
+        screen.getByLabelText(/email/i),
+        "alice@example.com",
+      );
+      await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            message: "Found a bug",
+            email: "alice@example.com",
+          }),
+        }),
+      );
+    });
+
+    it("trims whitespace from the email before sending", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+      await userEvent.type(
+        screen.getByPlaceholderText("What's on your mind?"),
+        "hello",
+      );
+      await userEvent.type(
+        screen.getByLabelText(/email/i),
+        "  bob@example.com  ",
+      );
+      await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({
+          body: JSON.stringify({
+            message: "hello",
+            email: "bob@example.com",
+          }),
+        }),
+      );
+    });
+
+    it("omits the email key entirely when only whitespace is entered", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+      await userEvent.type(
+        screen.getByPlaceholderText("What's on your mind?"),
+        "hello",
+      );
+      await userEvent.type(screen.getByLabelText(/email/i), "   ");
+      await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+      // No email field in the body — server should treat as anonymous.
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({
+          body: JSON.stringify({ message: "hello" }),
+        }),
+      );
+    });
   });
 
   it("shows success toast and closes the dialog when submission succeeds", async () => {

--- a/tests/core/feedback/feedback-handler.test.ts
+++ b/tests/core/feedback/feedback-handler.test.ts
@@ -124,6 +124,62 @@ describe("handleFeedbackRequest", () => {
     expect(sent.labels).toEqual(["feedback"]);
   });
 
+  it("appends a 'Reply to:' line to the issue body when an email is provided (issue #102)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleFeedbackRequest(
+      postJson({
+        message: "Could not subscribe to https://example.com/feed",
+        email: "alice@example.com",
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent.body).toBe(
+      "Could not subscribe to https://example.com/feed\n\n— Reply to: alice@example.com",
+    );
+    // The title is built from the raw message, not the augmented body — the
+    // user's email should not leak into the issue title.
+    expect(sent.title).not.toContain("alice@example.com");
+  });
+
+  it("rejects an email missing the '@' separator with 400", async () => {
+    const res = await handleFeedbackRequest(
+      postJson({ message: "hi", email: "not-an-email" }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/email/i);
+  });
+
+  it("rejects an email longer than 254 characters with 400", async () => {
+    const longEmail = "a".repeat(250) + "@x.io";
+    const res = await handleFeedbackRequest(
+      postJson({ message: "hi", email: longEmail }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("treats whitespace-only email as absent (no Reply-to line, no validation failure)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleFeedbackRequest(
+      postJson({ message: "hi", email: "   " }),
+    );
+    expect(res.status).toBe(200);
+
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent.body).toBe("hi");
+    expect(sent.body).not.toContain("Reply to");
+  });
+
   it("truncates the issue title at 80 characters with an ellipsis", async () => {
     const longMessage = "a".repeat(150);
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));


### PR DESCRIPTION
Closes #102.

## Summary

The feedback dialog was a single anonymous textarea that quietly posted to GitHub server-side. Users had no signal that (a) their feedback became a tracked GitHub issue, (b) they could read the maintainer's replies on the existing public issues, or (c) email support was an option. And there was no way to identify themselves to get a direct reply.

Three changes:

### 1. Channel block at the top of the dialog
Two outline buttons before the textarea:
- **Browse on GitHub** → `https://github.com/forcingfx/feedzero/issues` (opens in new tab).
- **Email support** → `mailto:support@feedzero.app`.

Copy frames these as the path for a threaded conversation or to see existing reports; the textarea below stays the quick-note path.

### 2. Optional email field
`<input type="email">` with `autocomplete="email"` and `maxLength=254`. Helper text spells out:

> We'll reply from support@feedzero.app. Your email will be visible on the public GitHub issue this feedback creates.

That's the consent signal — a privacy-first product shouldn't quietly publish user emails.

### 3. Server-side handling
`handleFeedbackRequest` now accepts an optional `email` in the body and, when present, appends `\n\n— Reply to: {email}` to the issue body. The issue **title** is still built from the message only, so an email can't leak into titles even if the user pastes their address into the message text. Validation is permissive (must contain `@`, ≤254 chars); whitespace-only is treated as absent.

## Files

- `src/components/feedback/feedback-dialog.tsx` — channel block, optional email input, payload now `{message, email?}`.
- `src/core/feedback/feedback-handler.ts` — accept optional email, validate, append "Reply to:" to body.
- `tests/components/feedback/feedback-dialog.test.tsx` — link hrefs, payload shape (with and without email), consent-warning copy.
- `tests/core/feedback/feedback-handler.test.ts` — email appended to body, never to title; rejects malformed/over-long emails; whitespace-only treated as absent.

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `npm test` — 2,405 tests passing (10 new feedback tests; pre-push hook reran)
- [ ] Manual smoke on Vercel preview: open Send feedback from Help tab → verify both link affordances → submit with email → check the created issue contains `— Reply to:` footer

## Re: other open issues

#111 and #113 form a pair — #111 reports a TLS-cert warning from the self-host preflight when the user fronts the server with a Caddy `tls internal` reverse proxy; #113 is the user retracting it as their own configuration mistake. No code change in this PR; suggest closing both as resolved.

https://claude.ai/code/session_01V85hetDYb1HKvuDDpvzz6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01V85hetDYb1HKvuDDpvzz6d)_