### PR TITLE
fix(e2e): stop waiting on aria-hidden Cloud sync heading in sync.spec.ts

### DIFF
--- a/tests/e2e/sync.spec.ts
+++ b/tests/e2e/sync.spec.ts
@@ -9,6 +9,16 @@ import type { Page } from "@playwright/test";
  * "Sync & Data", and the primary sync affordance is a <Switch> toggle (not
  * the prior "Enable sync" / "Use existing cloud account" buttons).
  *
+ * IMPORTANT: in e2e the default tier is `free` and the build is hosted, so
+ * the Cloud sync card mounts with the frosted-glass gate overlay. The
+ * gate wraps its content in `aria-hidden=true` so screen readers focus on
+ * the upgrade CTA rather than the blurred toggle. That means the
+ * "Cloud sync" <h3> is unreachable via Playwright's `getByRole`
+ * (which filters out aria-hidden) when this helper runs. We wait on the
+ * Danger zone heading instead — it's a sibling card, always rendered,
+ * never aria-hidden, so it's a reliable signal that the Sync & Data tab
+ * has actually mounted.
+ *
  * On mobile, the sidebar Settings button is inside the bottom drawer which
  * we open first.
  */
@@ -36,9 +46,11 @@ async function goToSyncSection(page: Page) {
   // Switch to the Sync & Data tab if the page didn't open straight onto it.
   await page.getByRole("radio", { name: /sync and data/i }).click();
   await page.waitForURL(/\/settings\?tab=sync-and-data/, { timeout: 5000 });
-  await expect(page.getByRole("heading", { name: /cloud sync/i })).toBeVisible({
-    timeout: 5000,
-  });
+  // Always-visible anchor — see the helper docstring on why this is NOT
+  // the Cloud sync heading.
+  await expect(
+    page.getByRole("heading", { name: /danger zone/i }),
+  ).toBeVisible({ timeout: 5000 });
 }
 
 async function addFeedForSync(page: Page) {
@@ -51,18 +63,20 @@ async function addFeedForSync(page: Page) {
 }
 
 test.describe("Sync", () => {
-  test("Sync & Data tab shows the Cloud sync section + local-only status", async ({
+  test("Sync & Data tab gates the cloud sync toggle for free-tier hosted users", async ({
     feedPage: page,
   }) => {
     await addFeedForSync(page);
     await goToSyncSection(page);
-    await expect(
-      page.getByRole("heading", { name: /cloud sync/i }),
-    ).toBeVisible();
-    // Free-tier hosted users see the upgrade overlay rather than the
-    // local-only status — assert the gate is present.
+    // The Cloud sync card content is aria-hidden behind the frosted-glass
+    // gate; the user-visible state is the overlay's headline. Asserting on
+    // the overlay text (not the hidden heading) matches what the user
+    // actually sees and what they can interact with.
     await expect(
       page.getByText(/cloud sync requires a subscription/i),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /upgrade plan/i }),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Why this is failing

E2E has been failing on every push to main since #112 merged. Likely root cause is `aria-hidden` filtering in `goToSyncSection`:

`data-sync-section.tsx` line 211 wraps the Cloud sync card's content with `aria-hidden={gated || undefined}`. That's the correct a11y treatment for the frosted-glass gate — sighted users see the overlay, screen readers should focus on the **Upgrade plan** CTA, not the unreachable toggle behind the glass.

But in e2e, the build is hosted and the default tier is `free`, so the gate is always on. Playwright's `getByRole` filters out `aria-hidden="true"` elements, so:

```ts
await expect(page.getByRole("heading", { name: /cloud sync/i })).toBeVisible({ timeout: 5000 });
```

…times out after 5 seconds in `goToSyncSection`. Every test in `sync.spec.ts` that calls that helper has been failing — 2 of the 3 tests in the file (`"Sync & Data tab shows..."` and `"delete all data..."`). The 3rd test (sidebar nav, no helper call) was passing.

## What this PR changes

`tests/e2e/sync.spec.ts` only — no production change, no a11y regression.

- `goToSyncSection` waits on the **Danger zone** heading instead. That heading is a sibling card, always rendered, never `aria-hidden`, so it's a reliable mount-completed signal.
- The first test is renamed to honestly describe what it asserts: `"Sync & Data tab gates the cloud sync toggle for free-tier hosted users"`. It now asserts on the `GateOverlay`'s `"Cloud sync requires a subscription"` text and the `Upgrade plan` button — i.e. what the user actually sees and can interact with.
- Inline comments on both call sites explain the `aria-hidden` rationale so a future reader doesn't "fix" it by switching back to the heading.

## Why this couldn't be reproduced in PRs

The E2E workflow runs `on: push: branches: [main]` (not on PRs — see the comment at the top of `.github/workflows/e2e.yml`). So PRs merge green, then post-merge E2E fails. #112 introduced the regression; #114 and #116 inherited it.

## Test plan

- [x] `npx tsc --noEmit` — green
- [ ] Playwright browsers don't install in this sandbox, so I couldn't run the e2e locally. The fix is mechanical (aria-hidden filtering is a documented Playwright behavior) and the new anchor (the Danger zone heading) is plainly always-rendered.
- [ ] Post-merge: the next E2E run on main should turn shards 1, 3, 4, 5, 6 green (whichever shard `sync.spec.ts` lands in, plus the cascading shards if my hypothesis about cascading timeouts holds — if not, only the `sync.spec.ts` shard turns green and the rest need a follow-up).

If E2E still has red shards after this merges, please send the names of the failing tests from the first failing shard — happy to chase the next layer.

https://claude.ai/code/session_01V85hetDYb1HKvuDDpvzz6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01V85hetDYb1HKvuDDpvzz6d)_