### PR TITLE
feat: reader polish — strategy + retry-after + PWA shortcuts + sort modes + stale indicator + Pocket import + migration landing copy

### DIFF
--- a/.claude/commands/research-competitors.md
+++ b/.claude/commands/research-competitors.md
@@ -1,0 +1,127 @@
+---
+description: Scan the RSS reader landscape and refresh FeedZero's Playing-to-Win strategy in docs/strategy/.
+argument-hint: "[focus] — optional. A competitor name (e.g. readwise-reader) or theme (e.g. pricing) to deep-dive instead of running the full scan."
+---
+
+# /research-competitors
+
+You are running FeedZero's competitor + strategy refresh. Output goes to `docs/strategy/`. **Do not touch `src/`, `tests/`, or any other tree.** Match the voice of `docs/features/` (prose headings, tables, opinionated).
+
+Focus argument (optional): `$ARGUMENTS`
+
+- If empty → full landscape scan (default).
+- If a competitor slug (e.g. `feedly`, `readwise-reader`) → deep-dive on that one competitor only. Update the relevant row in `001-competitor-scan.md`, append observations to the latest run log, do **not** rewrite `002` or `003`.
+- If a theme (e.g. `pricing`, `ai-summarization`, `self-hosting`) → scan all competitors through that lens, update relevant sections of `002` and `003`, leave the rest alone.
+
+## Step 1 — Read prior state
+
+Before scanning anything external:
+
+1. `ls docs/strategy/runs/` — find the most recent dated run log. Read it.
+2. Read `docs/strategy/001-competitor-scan.md`, `002-user-pain-points.md`, `003-playing-to-win.md`. The new run **revises** these, marking changed sections with `<!-- changed YYYY-MM-DD -->`. It does not replace them.
+3. Read `README.md`, `package.json` version, and `CLAUDE.md`'s **Principles** section. These anchor the "Winning Aspiration" — do not invent a new one.
+
+## Step 2 — Scan
+
+Use `WebFetch` + `WebSearch`. Sources, in order:
+
+### Direct competitors (cloud)
+Feedly, Inoreader, NewsBlur, Feedbin, The Old Reader, BazQux, Feeder, Readwise Reader (RSS surface).
+
+### Direct competitors (native / local-first)
+NetNewsWire (macOS/iOS), Reeder 5, lire, ReadKit, Unread, Fluent Reader.
+
+### Self-hosted
+Miniflux, FreshRSS, Tiny Tiny RSS, CommaFeed, Stringer, FreshRSS, Yarr.
+
+### Adjacent (read-later / aggregators)
+Pocket, Matter, Readwise Reader (broader), Instapaper. Note Omnivore + Artifact as shutdown reference points — survivorship in this category matters.
+
+### Community signal
+- `reddit.com/r/rss` — top + hot posts last 90 days. Cluster complaints.
+- `reddit.com/r/RSS_Readers` — same.
+- `reddit.com/r/selfhosted` filtered for "rss" — self-hoster pain.
+
+### New entrants
+- `alternativeto.net/category/internet/rss/` — new arrivals.
+- Product Hunt search "RSS" — last 90 days.
+
+### For each competitor, capture
+| Field | Notes |
+|------|------|
+| Positioning headline | Their own words, from homepage hero. |
+| Pricing | Free tier limits + paid tiers in USD. |
+| Distinctive feature | What they're known for that others don't have. |
+| Hosting model | Cloud / native / self-hosted / hybrid. |
+| Last meaningful release | Date + what shipped. Stale projects are signal. |
+| Privacy posture | Telemetry? Account required? Encrypted at rest? Open source? |
+| What FeedZero learns | One sentence — feature, anti-pattern, or positioning insight. |
+
+Pricing changes monthly — always verify against the live page, never quote from prior run logs.
+
+## Step 3 — Synthesize
+
+### Update `001-competitor-scan.md`
+One sorted table (by hosting model: cloud → native → self-hosted → adjacent). Below it, a "Movement since last run" subsection listing diffs (new entrants, dead products, price changes, notable releases). If a competitor is gone or stale >12 months, mark `_stale_` rather than removing — survivorship data is itself a signal.
+
+### Update `002-user-pain-points.md`
+Cluster complaints by theme. Existing buckets to extend, not replace:
+- **Privacy + data ownership** — telemetry, accounts, where my reading lives.
+- **Sync friction** — losing reads across devices, conflicts, paywalled sync.
+- **Mobile UX** — what mobile readers do badly.
+- **AI / summarization** — demand for it, fear of telemetry from it.
+- **Full-text extraction** — paywalled article handling, parser quality.
+- **Pricing fatigue** — subscription resentment, lifetime-license demand.
+- **Server-died-on-me** — abandonware risk, "where's my OPML?" exits.
+
+Each theme: 2–5 representative quotes (paraphrased, with source link), then one sentence on **what this means for FeedZero's roadmap**.
+
+### Update `003-playing-to-win.md`
+Lafley + Martin's 5 cascading questions. Revise, mark changes with `<!-- changed YYYY-MM-DD -->`. Each section must be **opinionated and falsifiable**, not a generic mission statement. If a section can't be sharpened with this run's data, leave it and note that in the run log.
+
+1. **Winning Aspiration** — what does winning look like for FeedZero? Anchor on CLAUDE.md Principles ("FeedZero protects people"). Measurable success criteria.
+2. **Where to Play** — segments (privacy-paranoid pros? journalists/activists per CLAUDE.md? self-hosters? mainstream privacy-curious?), surfaces (web/PWA/native/extension), geographies, acquisition channels. Be explicit about who we are **not** for.
+3. **How to Win** — the wedge. The "crushing" part. What can FeedZero do that no incumbent can or will? Why is that durable? Why won't Feedly copy it in a quarter?
+4. **Capabilities** — what must FeedZero be exceptional at to win this way? (E2E crypto, full-text extraction, sync UX without lock-in, AI without telemetry, OPML round-trip, etc.) For each: are we there? gap to close?
+5. **Management Systems** — measurement, cadence, feedback loops. Vault count from `/api/stats-sync`, GitHub stars, release cadence (the `new-release` skill), issue volume by category, this very strategy doc's refresh cadence.
+
+## Step 4 — Persist the run log
+
+Write `docs/strategy/runs/YYYY-MM-DD.md` (UTC date). Structure:
+
+```
+# Run YYYY-MM-DD
+
+## Focus
+Full landscape | <competitor> | <theme>
+
+## Sources scanned
+- competitor URLs hit
+- subreddit threads referenced
+- new entrants discovered
+
+## Key new findings
+- bulleted, terse
+
+## Cascade changes
+One paragraph: what moved in 003-playing-to-win.md and why.
+
+## Open questions
+Things to chase next run.
+```
+
+## Step 5 — Self-check before finishing
+
+- `git status` shows only `docs/strategy/**` modified. If anything else is touched, revert it.
+- Spot-check 3 competitor pricing pages directly — do not trust your synthesis blindly. Hallucinated pricing is the #1 failure mode.
+- The cascade in `003` reads as something FeedZero would actually do, not a generic strategy template. If you can't tell from reading it whether FeedZero or NetNewsWire wrote it, sharpen it.
+- Do **not** commit. Leave the working tree dirty for the user to review.
+
+## Invocation patterns
+
+```
+/research-competitors                       # full landscape
+/research-competitors readwise-reader       # one competitor
+/research-competitors pricing               # one theme
+/loop 7d /research-competitors              # weekly while session is open
+```

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,13 @@ coverage/
 test-results/
 playwright-report/
 # Personal Claude Code config + permissions, not for the public repo.
-# Skills and hooks ARE tracked because they describe shared workflows
-# (e.g. /new-release) and contributor automation (RGR pre-edit hook).
+# Skills, hooks, and commands ARE tracked because they describe shared
+# workflows (e.g. /new-release, /research-competitors) and contributor
+# automation (RGR pre-edit hook).
 .claude/*
 !.claude/skills/
 !.claude/hooks/
+!.claude/commands/
 
 .vercel
 .env*.local

--- a/README.md
+++ b/README.md
@@ -165,6 +165,20 @@ bundles them.
 - **Extraction**: Defuddle
 - **Testing**: Vitest, Playwright, React Testing Library
 
+## Sustainability commitment
+
+FeedZero is built as a sustainable business, not a venture-funded runway. The category around us has gotten brutal — Pocket shut down November 2025, Omnivore November 2024, Tiny Tiny RSS's original maintainer retired the project the same month, Artifact closed January 2024. Each of those services took user data with them.
+
+The structural commitments that keep FeedZero around:
+
+- **No external runway to outrun.** No VC, no board demanding hockey-stick growth. We grow at the pace the work supports.
+- **No data we cannot lose.** The server holds opaque encrypted blobs. There is nothing here to sell, sublicense, or accidentally leak — see [docs/vault-format.md](docs/vault-format.md) for the format.
+- **Lossless exit at all times.** OPML import/export round-trips, the [vault format](docs/vault-format.md) is publicly documented, and the entire server runs as a single Hono binary you can self-host. If FeedZero ever shuts down, your data leaves with you.
+- **Open source.** The privacy claims and the code that delivers them are auditable today.
+- **Focused.** We are great at one thing: fetching feeds reliably and presenting them in a reader that's a pleasure to use. We decline features that would distract from that, even when the market is asking for them — see [docs/strategy/003-playing-to-win.md](docs/strategy/003-playing-to-win.md).
+
+If you're migrating from a product that just shut down, you're welcome here. We'll still be here when the next one does.
+
 ## Security
 
 Found a vulnerability? See [SECURITY.md](SECURITY.md) for reporting guidelines.

--- a/docs/marketing/README.md
+++ b/docs/marketing/README.md
@@ -1,0 +1,17 @@
+# Marketing copy
+
+Migration landing pages and product positioning copy live here as markdown. The actual public site at [feedzero.app](https://feedzero.app) is in a separate repo (see CLAUDE.md). These files are the source of truth for the copy; deploying them is tracked in [TODO.md](./TODO.md).
+
+## Why these are versioned in this repo
+
+- The copy makes claims about FeedZero's architecture (E2E sync, OPML round-trip, self-host story). Those claims must stay in lockstep with the code. Co-locating the copy with the code makes drift a code-review concern, not an oversight.
+- The strategy doc ([../strategy/003-playing-to-win.md](../strategy/003-playing-to-win.md) §2) calls out per-shutdown migration pages as the highest-leverage acquisition channel currently available. Tracking the copy here makes the pipeline auditable.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `pocket-migration.md` | Landing copy for users displaced by Pocket's 2025-11-12 shutdown. |
+| `omnivore-migration.md` | Landing copy for users displaced by Omnivore's 2024-11-15 shutdown. |
+| `tt-rss-migration.md` | Landing copy for users whose Tiny Tiny RSS instance is now community-fork-only after the original maintainer retired the project 2025-11-01. |
+| `TODO.md` | Deployment + campaign checklist — what hasn't happened yet. |

--- a/docs/marketing/TODO.md
+++ b/docs/marketing/TODO.md
@@ -1,0 +1,59 @@
+# Marketing TODO
+
+Status: copy drafted, deployment + campaigns not yet executed. This file tracks the work that has to happen *outside* this repo before the migration story actually lands.
+
+## Per-page deployment
+
+The landing pages live as markdown here. The actual landing site (`feedzero.app`) is a separate repo. Each page below needs:
+
+- [ ] **Pocket migration page** — deploy `pocket-migration.md` content to `https://feedzero.app/pocket`.
+- [ ] **Omnivore migration page** — deploy `omnivore-migration.md` content to `https://feedzero.app/omnivore`.
+- [ ] **TT-RSS migration page** — deploy `tt-rss-migration.md` content to `https://feedzero.app/tt-rss`.
+
+Each deployed page should:
+- Render the markdown body (front-matter strips into the page title + meta description).
+- Include the standard FeedZero header / footer / cookie-free analytics (we don't have analytics — nothing to add).
+- Add Open Graph + Twitter Card metadata using the front-matter `title` + `description`.
+- Link the migration page from the homepage in a small "Coming from…" section.
+
+## Campaign distribution
+
+Once the pages are live, push to channels in this order. Time-sensitive — the migration window narrows as users settle on whichever alternative they tried first.
+
+### Channels — Pocket
+
+- [ ] **r/rss** — short post linking to the migration page. Include a one-line description of FeedZero. Mod-tag if applicable.
+- [ ] **r/RSS_Readers** — same.
+- [ ] **r/privacy** — emphasize the E2E sync angle, not the import.
+- [ ] **r/selfhosted** — emphasize the self-host story; the audience here will pick FreshRSS otherwise.
+- [ ] **Hacker News Show HN** — title: "Show HN: FeedZero — RSS reader for Pocket refugees who care about privacy."
+- [ ] **lobste.rs** — link under the `web` tag with a one-paragraph context comment.
+- [ ] **Privacy Guides community** — comment on the existing RSS-recommendation thread (don't post a new one).
+- [ ] **Direct outreach** — Pocket-power-user newsletter writers; Daring Fireball / Macstories / TechCrunch (Pocket shutdown coverage is still indexing).
+
+### Channels — Omnivore
+
+- [ ] **r/rss / r/RSS_Readers / r/privacy** — short post per sub.
+- [ ] **Hacker News** — combined "Two RSS readers built differently than the ones that shut down" post. Show HN restrictions: confirm timing rules.
+- [ ] **omnivore.work community fork README** — open a PR adding FeedZero to a "alternatives if you don't want to self-host" line.
+- [ ] **Existing Omnivore migration round-ups** — comment on the top 5 (Readless, Gleamr, Notes by ghed.in) with the migration page link.
+
+### Channels — TT-RSS
+
+- [ ] **r/selfhosted** — the only sub that matters for this audience.
+- [ ] **awesome-selfhosted** — PR to add FeedZero with the right tags.
+- [ ] **selfh.st** — submit FeedZero as an alternative to TT-RSS.
+- [ ] **Don't post on r/rss** — TT-RSS users overlap less with that audience; signal-to-noise low.
+
+## Hygiene
+
+- [ ] **No paid acquisition.** Per [strategy §2](../strategy/003-playing-to-win.md), paid channels contradict the privacy stance.
+- [ ] **No SEO content farms.** Same reason.
+- [ ] **One round of campaign distribution.** Repeating the same post across subs in a 7-day window will get us shadow-banned and is bad form.
+- [ ] **Track effect via vault count.** `/api/stats-sync` is the only legitimate metric the architecture allows. Snapshot before each campaign push, snapshot 7 days after, log the delta in the next `docs/strategy/runs/` entry.
+
+## Open questions
+
+- Which one to ship first? Pocket has the largest audience but coldest trail (7 months stale by now). TT-RSS is the freshest (just 6 months out) but smallest audience. Omnivore is in between. **Recommendation: Pocket first because of audience size — even a cold-trail conversion adds compounding word-of-mouth.**
+- Should the homepage carry a permanent "Coming from a shutdown?" panel, or is that a sign we're over-indexing on a transient acquisition channel? Discuss before deploying.
+- Per-shutdown migration pages SEO well in the short term but rot once the audience has resettled. Add a `created_at` to front-matter, and revisit each page 12 months after publishing — delete or rewrite as "in memoriam" archival pages.

--- a/docs/marketing/omnivore-migration.md
+++ b/docs/marketing/omnivore-migration.md
@@ -1,0 +1,55 @@
+---
+slug: omnivore
+title: "Moving from Omnivore? Here's where to land."
+description: "Omnivore shut down on November 15, 2024 after the team was acquihired by ElevenLabs. FeedZero is a privacy-first RSS reader for the audience Omnivore served — built to outlive the next acquisition."
+intended_url: https://feedzero.app/omnivore
+---
+
+# Moving from Omnivore? Here's where to land.
+
+Omnivore shut down on **November 15, 2024**. The team joined ElevenLabs, the service went dark, user data was deleted. The open-source code is still on GitHub — unmaintained — and a small community fork lives at `omnivore.work` for anyone willing to self-host.
+
+You probably picked Omnivore because the alternatives (Pocket, Instapaper) felt like surveillance products. Then Pocket shut down too. We notice this.
+
+## What FeedZero is, and isn't
+
+FeedZero is an **RSS reader**, not a read-it-later app. That's a real difference:
+
+- **Omnivore** saved articles. You opened it to clear a queue.
+- **FeedZero** subscribes to the *sources* that publish those articles. You open it to see what's new.
+
+Where Omnivore's draw was privacy + highlighting + AI summarization, FeedZero's draw is privacy + the trunk: fetching feeds reliably and presenting them in a reader that's a pleasure to use. We don't ship AI summarization yet — every implementation in the category sends your reading content to a centralized LLM, and we're not willing to do that.
+
+## Importing Omnivore data
+
+If you exported your Omnivore library before the shutdown, you have a JSON or HTML file of saved articles. Drop it into Settings → Import. FeedZero extracts the source domains and tries to discover an RSS feed for each one, leaving you with subscriptions to the publishers you cared about. (The article queue itself doesn't import — RSS readers don't have queues.)
+
+If you didn't export in time, you can still rebuild from memory. Most Omnivore users had 5–30 publishers in active rotation; the long tail rarely makes the move.
+
+## Why we expect to be here in 2030
+
+The structural commitments that keep FeedZero around:
+
+- **The server holds opaque encrypted blobs.** We can't sell your data, can't sublicense it, can't accidentally leak it. ([Format documented.](../vault-format.md))
+- **Lossless exit.** OPML round-trips. Vault format public. Self-hostable as a single binary.
+- **Open source.** Audit the claims. Fork it if we ever go quiet.
+- **No VC runway.** No board demanding hockey-stick growth. See our [sustainability commitment](../../README.md#sustainability-commitment).
+- **Acquihires don't work the same way.** Our value isn't a team — it's the architecture and the audience trust. There's no equivalent of "ElevenLabs acquires the FeedZero team and shuts down the service" because the service is the architecture, not the team.
+
+## Where we differ from Omnivore
+
+We don't have:
+
+- Article highlighting with per-paragraph notes. The PKM workflow Readwise Reader is great for — go there if that's your pattern.
+- Cloud AI summarization or Q&A over saved articles. Every cloud implementation we've seen leaks reading content; we won't.
+- A native mobile app (PWA only).
+- A queue. Subscribe to sources, not articles.
+
+## Get started
+
+1. Visit [feedzero.app](https://feedzero.app).
+2. Pick a passphrase. Choose sync if you want subscriptions across devices.
+3. Settings → Import → drop your Omnivore export.
+4. Prune the discovered feed list. Close the tab.
+
+We'll still be here when the next product shuts down.

--- a/docs/marketing/pocket-migration.md
+++ b/docs/marketing/pocket-migration.md
@@ -1,0 +1,65 @@
+---
+slug: pocket
+title: "Moving from Pocket? Here's where to land."
+description: "Pocket shut down on November 12, 2025. FeedZero is a privacy-first RSS reader that can absorb your old reading habit without selling you out to the next acquirer."
+intended_url: https://feedzero.app/pocket
+---
+
+# Moving from Pocket? Here's where to land.
+
+Pocket shut down on **November 12, 2025**. Mozilla pulled the apps, disabled the API, and queued every saved article for deletion. If you exported your data before the deadline, you have an HTML file full of links — and nowhere good to put them.
+
+FeedZero might be that nowhere good. Here's the honest pitch.
+
+## What FeedZero is
+
+FeedZero is an RSS reader, not a read-it-later app. The mental model is different:
+
+- **Pocket** saved individual articles. You opened it to clear a queue.
+- **FeedZero** subscribes to the *sources* that publish those articles. You open it to catch up on what's new, then close it.
+
+For most Pocket users that turns out to be the better model. The reason you saved 200 NYT articles wasn't because you loved 200 articles — it was because you wanted to know what NYT published. Subscribing to the source, once, replaces saving the article 200 times.
+
+## What we'll do with your Pocket export
+
+Drop your `pocket-export.html` into the Import dialog. FeedZero:
+
+1. Parses every saved link in the file.
+2. Groups them by site (so 30 NYT articles become "you read NYT").
+3. Tries to discover an RSS feed for each site automatically.
+4. Subscribes you to the feeds it found.
+
+You'll usually end up with somewhere between 5 and 50 feed subscriptions, depending on how varied your Pocket library was. You can prune from there.
+
+The original article URLs are not imported — RSS readers don't have a queue. If you want a queue, FeedZero is not for you, and we'd rather you know that now.
+
+## Why this won't happen to you again
+
+The list of read-later / RSS shutdowns in the last 19 months: **Pocket (2025-11), Tiny Tiny RSS original (2025-11), Omnivore (2024-11), Artifact (2024-01).** Four products that took user data with them when they left.
+
+The structural reasons FeedZero is built differently:
+
+- **Nothing to sell, sublicense, or accidentally leak.** Our server holds opaque encrypted blobs. Your reading list, your saves, your read state — we genuinely cannot see them. ([Vault format documented.](../vault-format.md))
+- **Lossless exit.** OPML import/export round-trips. The vault format is publicly specified. The server runs as a single Hono binary you can self-host. If we shut down, your data leaves with you.
+- **No VC runway.** No board demanding hockey-stick growth. We grow at the pace the work supports — see our [sustainability commitment](../../README.md#sustainability-commitment).
+- **Open source.** Audit the claims. Fork the code. Send patches.
+
+## What you trade away
+
+We don't have:
+
+- A read-later queue (RSS, not Pocket).
+- Server-side AI summarization. Every product in the category that does this sends your reading content to a third-party LLM. We won't.
+- A native iOS or Android app. The web app installs as a PWA (Add to Home Screen).
+- A social graph or "popular among your contacts" feature. Incompatible with end-to-end encryption.
+
+If those gaps are dealbreakers, fair. We'd rather lose you to NetNewsWire (free, native, Apple-only) or Readwise Reader (great PKM workflow, cloud AI) than over-promise.
+
+## Get started
+
+1. Visit [feedzero.app](https://feedzero.app).
+2. Choose "Sync across devices" if you want your subscriptions to follow you. Save your four-word passphrase — it's the only way back in.
+3. Settings → Import → drop your `pocket-export.html`.
+4. Wait 30–60 seconds while FeedZero discovers feeds. Prune what you don't want. Close the tab. Come back tomorrow.
+
+You're welcome here.

--- a/docs/marketing/tt-rss-migration.md
+++ b/docs/marketing/tt-rss-migration.md
@@ -1,0 +1,49 @@
+---
+slug: tt-rss
+title: "Tiny Tiny RSS's maintainer walked away. Yours doesn't have to."
+description: "Andrew Dolgov retired the original Tiny Tiny RSS project on 2025-11-01. The community fork lives — but if you'd rather not babysit a server, FeedZero is a privacy-first RSS reader with optional E2E sync."
+intended_url: https://feedzero.app/tt-rss
+---
+
+# Tiny Tiny RSS's maintainer walked away. Yours doesn't have to.
+
+On **2025-11-01**, Andrew Dolgov (Fox) retired Tiny Tiny RSS, dismantling the public infrastructure and the official repo. Long-time contributor `supahgreg` forked the codebase the same week to [github.com/tt-rss/tt-rss](https://github.com/tt-rss/tt-rss) and the project lives on under community maintenance. The tt-rss.org domain redirects there now.
+
+If you're happy maintaining your tt-rss instance against the community fork, fantastic — that's exactly the model we want to see survive. This page is for the contingent who, after years of running a TT-RSS server, are reconsidering whether they really want to keep running a TT-RSS server.
+
+## What FeedZero offers that TT-RSS doesn't
+
+- **No server to maintain.** FeedZero is browser-first. The hosted version at [feedzero.app](https://feedzero.app) gives you the reader and a CORS proxy; everything else runs in your browser.
+- **End-to-end encrypted sync** across devices, by default. No PHP, no MySQL, no nightly cron, no upgrade-day. ([Format documented.](../vault-format.md))
+- **A reader pane that's actually a pleasure to use.** TT-RSS optimizes for the power-user backend; FeedZero optimizes for reading.
+
+## What you keep from TT-RSS
+
+- **The trust model.** TT-RSS's appeal was "my data lives on my server, not someone else's." FeedZero's E2E architecture preserves that: the operator (us) cannot read your feed list, your reads, your saved articles. Period. We can't subpoena what we don't have.
+- **Self-hostable.** If the hosted service goes away, FeedZero's [Hono server](../../README.md#self-hosting) runs as a single binary on whatever you used to run TT-RSS on. Same threat model, less maintenance.
+- **Open source.** Audit, fork, contribute.
+
+## Importing your TT-RSS subscriptions
+
+TT-RSS exports OPML cleanly. Settings → Preferences → Feeds → OPML → Export. Drop the resulting `tt-rss-feeds.xml` into FeedZero's Settings → Import. Sub-second import for hundreds of feeds, no API token shuffle.
+
+Read state doesn't import — TT-RSS's API doesn't expose it in OPML and we don't have the article corpus locally yet. You'll start with everything unread; mark-all-as-read on day one is a clean way to begin.
+
+## What we differ on
+
+- **Power-user filtering.** TT-RSS has rules. FeedZero doesn't yet. (We're building toward it; not there.)
+- **Plugin ecosystem.** TT-RSS's strength. FeedZero is opinionated — fewer hooks, less to break.
+- **AI summarization.** Neither of us ships it well today. Every cloud AI integration in the category leaks reading content; we won't until we have an architecture that doesn't.
+
+## Why we built this
+
+FeedZero exists to protect its users — journalists, activists, people whose reading habits matter. The privacy moat is also a sustainability moat: nothing to sell, no platform liability, [no VC runway to outrun](../../README.md#sustainability-commitment). We expect to be here in 2030. Most readers in this category won't.
+
+## Get started
+
+1. Visit [feedzero.app](https://feedzero.app).
+2. Pick a passphrase. Enable sync.
+3. Settings → Import → upload your TT-RSS OPML export.
+4. Done.
+
+You're welcome here.

--- a/docs/strategy/001-competitor-scan.md
+++ b/docs/strategy/001-competitor-scan.md
@@ -1,0 +1,33 @@
+# 001 — Competitor Scan
+
+## Status
+Seeded. Awaiting first `/research-competitors` run.
+
+## Summary
+
+Living table of every RSS reader and adjacent product worth tracking. Sorted by hosting model so the trade-space is visible at a glance: cloud convenience vs. native polish vs. self-hosted control vs. read-later adjacency. The "What FeedZero learns" column is the operative one — every row should produce a feature insight, an anti-pattern to avoid, or a positioning move to mirror or counter.
+
+## Scope
+
+Direct: Feedly, Inoreader, NewsBlur, Feedbin, The Old Reader, BazQux, Feeder, NetNewsWire, Reeder 5, lire, ReadKit, Unread, Fluent Reader, Miniflux, FreshRSS, Tiny Tiny RSS, CommaFeed, Stringer, Yarr.
+
+Adjacent: Pocket, Matter, Readwise Reader, Instapaper. Omnivore and Artifact tracked as shutdown reference points.
+
+## Table
+
+| Competitor | Hosting | Positioning | Pricing (USD) | Distinctive feature | Privacy posture | Last meaningful release | What FeedZero learns |
+|------------|---------|-------------|---------------|---------------------|-----------------|-------------------------|----------------------|
+| _populated by `/research-competitors`_ | | | | | | | |
+
+## Movement since last run
+
+_No prior run. First population will list every entrant as new._
+
+## Stale / dead products tracked
+
+| Product | Status | Date | Why it matters |
+|---------|--------|------|----------------|
+| Omnivore | Shut down | 2024-11 | Open-source read-later that died — survivorship lesson. |
+| Artifact | Shut down | 2024-01 | News aggregator with AI summarization, by Instagram founders — well-funded shutdowns happen too. |
+
+_Run logs in `runs/` capture per-refresh diffs and the reasoning behind table changes._

--- a/docs/strategy/001-competitor-scan.md
+++ b/docs/strategy/001-competitor-scan.md
@@ -1,7 +1,7 @@
 # 001 — Competitor Scan
 
 ## Status
-Seeded. Awaiting first `/research-competitors` run.
+First population — 2026-05-16. <!-- changed 2026-05-16 -->
 
 ## Summary
 
@@ -9,25 +9,68 @@ Living table of every RSS reader and adjacent product worth tracking. Sorted by 
 
 ## Scope
 
-Direct: Feedly, Inoreader, NewsBlur, Feedbin, The Old Reader, BazQux, Feeder, NetNewsWire, Reeder 5, lire, ReadKit, Unread, Fluent Reader, Miniflux, FreshRSS, Tiny Tiny RSS, CommaFeed, Stringer, Yarr.
+Direct: Feedly, Inoreader, NewsBlur, Feedbin, The Old Reader, BazQux, Feeder, NetNewsWire, Reeder, lire, Fluent Reader, Miniflux, FreshRSS, Tiny Tiny RSS (community fork), CommaFeed, Yarr.
 
-Adjacent: Pocket, Matter, Readwise Reader, Instapaper. Omnivore and Artifact tracked as shutdown reference points.
+Adjacent: Matter, Readwise Reader, Instapaper, Readless. Omnivore + Artifact + Pocket tracked as shutdown reference points.
 
 ## Table
 
-| Competitor | Hosting | Positioning | Pricing (USD) | Distinctive feature | Privacy posture | Last meaningful release | What FeedZero learns |
-|------------|---------|-------------|---------------|---------------------|-----------------|-------------------------|----------------------|
-| _populated by `/research-competitors`_ | | | | | | | |
+<!-- changed 2026-05-16: first population -->
+
+| Competitor | Hosting | Positioning | Pricing (USD, 2026-05) | Distinctive feature | Privacy posture | Last meaningful release | What FeedZero learns |
+|------------|---------|-------------|------------------------|---------------------|-----------------|-------------------------|----------------------|
+| **Feedly** | Cloud | Market intelligence + RSS for teams. Consumer side has drifted into upsell theatre. | Free (100 sources) / Pro $6/mo annual / Pro+ $8.25/mo annual (adds Leo AI, 2,500 sources) / Enterprise $1,600+/mo | Leo AI assistant (priorities, mutes, summaries) | Account required. AI summarization sends content to third-party LLM provider. Free tier shows promoted content. | Continuous; Leo AI is the active surface. | The AI-on-Pro+ play is the obvious next demand. We can't match it without crossing our privacy line — make that **the** wedge, not a gap. |
+| **Inoreader** | Cloud | Power-user filtering, rules, monitoring. Where Feedly used to be before enterprise pivot. | Free (150 feeds) / Pro $7.50/mo annual or $9.99/mo / Teams + Enterprise on quote | Rules engine + Inoreader Intelligence (article summaries via GPT-4o-mini) | Account required. Public-only article metadata sent to OpenAI per their own docs ("no personal information"). Better disclosure than Feedly. | 2026-03 Intelligence reports automation. | Power-user filtering is sticky. We don't need rules parity — we need rules **with E2E** so even the rules themselves stay private. Anti-pattern: their disclosure is honest but still requires trust. |
+| **NewsBlur** | Cloud | Trainable feed intelligence (per-author, per-tag scoring) by solo dev since 2009. | Free (64 sites) / Premium $36/yr / Premium Archive $99/yr / Premium Pro $29/mo | Per-author/tag/title training; blurblogs (social sharing) | Account required. Solo-dev — key-person risk material. Open source (samuelclay/NewsBlur). | Active; AGPL on GitHub. | Solo-dev shipping at this price proves the indie privacy reader is viable. Reminder that competitor exits are slower than they feel. |
+| **Feedbin** | Cloud | Clean, opinionated, newsletter + podcast + YouTube + Mastodon in one inbox. | Supporter $2.50/mo / Pro $5/mo / Enterprise $12.50/mo (no free reading tier; 30-day trial) | Newsletter routing via dedicated email address; works with Reeder Classic. | Account required. Indie, no ads. | Active. | Newsletter-via-email is the single feature Pocket refugees most want. Either build it or partner. |
+| **The Old Reader** | Cloud | Spiritual Google Reader successor; social. | Free (100 feeds) / Premium $5/mo (500 subs, full-text search, 1yr archive) | Social: follow users, see what friends read. | Account required. Long-tail indie. | Active but slow. | Social-reading died as a category — Artifact's shutdown is the proof. Don't chase. |
+| **BazQux** | Cloud | Fast, full-text, indie. | $30/yr or $50/yr or $249 lifetime | Aggressive full-text fetching even from partial feeds | Account required. Indie, single operator. | Active, slow cadence. | Lifetime pricing is a strong signal for the "I'm sick of subscriptions" segment. Worth considering as a vault-only one-time SKU later. |
+| **Feeder (Android, nononsenseapps)** | Native / local | Open-source Android RSS, no account, no sync. | Free (Play Store + F-Droid) | True local-only Android client. | Open source, no account, no telemetry per Play listing. | Active. | The closest spiritual sibling on Android. Confirms there's an audience for "no cloud at all." We extend with opt-in E2E cloud. |
+| **Feeder.co** | Cloud | Web/extension RSS reader. | Free / Pro / Business (tiers not directly verified — homepage 403) | — | Account required. | Active, regular updates. | _Stale_ for our purposes — name collision with the OSS Android app obscures both. |
+| **NetNewsWire** | Native (Apple) | The best free RSS reader for Mac/iOS in 2026. | Free, MIT. | iCloud sync that actually works; native everywhere on Apple. v7.0 with full Liquid Glass support (Jan 2026); 7.0.4 (Apr 2026) added iCloud storage stats + selective sync. | Open source, optional iCloud, optional third-party sync (Feedbin/Feedly/Inoreader). No telemetry. | 2026-04 (7.0.4). | The reference for "privacy-respecting native RSS." Why does someone choose FeedZero over NNW? Answer: cross-platform + zero-knowledge cloud. NNW ties you to Apple + ties your data to iCloud. |
+| **Reeder (new)** | Native (Apple) | Unified timeline: RSS + YouTube + Reddit + Mastodon + Bluesky. | Free (10 feeds) / Reeder+ $1/mo or $10/yr (unlimited + shared feeds + social timelines) | Unified timeline; iCloud-only sync. | iCloud only — meaning Apple holds the key, no end-to-end. Account required for shared feeds. | Active (2024+ rewrite). | Reeder's iCloud sync is reported broken in 2026 (drift, slow background sync). Reliability gap we can exploit. |
+| **Reeder Classic** | Native (Apple) | Traditional RSS reader, third-party sync. | $4.99 one-time | Works with Feedbin, NewsBlur, FreshRSS, Inoreader, BazQux, FeedHQ, etc. | Same as the backend you pair it with. | Maintained alongside new Reeder. | The "one-time purchase reader that talks to your backend" pattern is a real demand. Could we be that backend for Reeder Classic users? Adds a distribution lever. |
+| **lire** | Native (Apple) | Best for offline; auto-fetches full text of every article. | $4.99 one-time | Background full-text fetch for every item; works on a plane. | Local + sync via Feedbin/etc. | Active. | Aggressive full-text fetching matters for offline. We already have extraction — make it batchable + scheduled. |
+| **Unread** | Native (Apple) | Gesture-driven minimal reader. | Subscription (pricing not directly verified — App Store gated) | Beautiful single-pane reading. | Local + third-party sync. | Active. | _Stale verification_ — pricing needs direct App Store check next run. |
+| **Fluent Reader** | Native (cross-platform) | Local desktop reader, Fluent Design. | Free, open source (BSD-3) | Local-only OR sync to Inoreader/Feedbin/BazQux/Old Reader/Fever/Google Reader API. | Local-first; account optional. | Active. | Electron memory cost (264MB / 7 processes) is the trade. We win on browser-native = no install. |
+| **Miniflux** | Self-hosted | Minimalist, opinionated, single Go binary. | Self-host free (AGPL) / hosted at reader.miniflux.app $15/yr | ~50ms render; 20MB RAM idle; strips tracking pixels; proxies media. | Open source, no telemetry, by design. Solo maintainer (Frédéric Guillot). | Active, regular tagged releases. | $15/yr hosted is the floor for the entire RSS-as-a-service market. Anyone above that is paying for trust or polish, not infrastructure. |
+| **FreshRSS** | Self-hosted | Community-maintained PHP aggregator, extensible. | Free (AGPL) | Extensions (incl. Pocket-replacement button), themes, multi-DB, multi-user. v1.27 added PHP 8.5, sudo mode, stricter CSP. v1.29 current. | Open source, no telemetry. | 2026 — actively shipping. | The Pocket-button extension shows how the OSS community absorbs shutdowns. Could FeedZero ship a "Pocket export → FeedZero import" path in the next quarter? It's the cheapest acquisition channel we'll ever have. |
+| **Tiny Tiny RSS (community fork)** | Self-hosted | Original maintainer Andrew Dolgov retired the project 2025-11-01; long-time contributor supahgreg forked to github.com/tt-rss/tt-rss, GPLv3, ownership of tt-rss.org transferred. | Free | Plugin ecosystem. | Open source. | 2025-11+ active fork. | A live, well-publicised abandonware-to-fork transition. The OSS contingency works only because the code was open. Validates our self-host story; reinforces section 3 wedge. |
+| **CommaFeed** | Self-hosted | Google Reader-inspired, Quarkus + React. | Self-host free (Apache-2.0) / commafeed.com free (donation-funded) / PikaPods $1/mo | Free public instance funded by donations — rare survivor model. | Open source, no ads, no tracking. | Active. | Donation-funded public instance is the "purest" privacy story. We can't match without compromising sync infra cost, but worth understanding the audience. |
+| **Yarr** | Self-hosted | Single Go binary, embedded SQLite, ~5 deps. | Free | Smallest viable self-host; Vue.js frontend. | Open source. Local only. | Active, low cadence. | Reinforces "minimal beats featured" for self-host. Our self-host story is the Hono server — keep it small. |
+| **Readwise Reader** | Cloud (adjacent) | Highlighting + AI Ghostreader + Obsidian/Notion/Roam export. | $9.99/mo annual / $12.99/mo monthly / Lite $5.59/mo (no Reader) | Highlights → PKM workflow; cited AI answers grounded in source text. | Account required. AI usage well-disclosed. | Continuous. | The PKM-export angle is a real moat. We don't need to chase highlighting — but we should make sure OPML + JSON export are loss-free so users can pipe into PKM externally. |
+| **Matter** | Cloud (adjacent) | iOS-first read-later with AI Co-Reader. | Free / Premium $60/yr | HD TTS, AI Q&A about articles. | Account required. AI is cloud. | Continuous; absorbed Pocket refugees. | TTS is a feature gap we have. On-device TTS via Web Speech API is cheap to add and stays private. |
+| **Instapaper** | Cloud (adjacent) | OG read-later, independent again under Instant Paper, Inc. | Free / Premium $6/mo or $60/yr (first price change in 9 years, 2023) | TTS with 17 AI voices, full-text search, permanent archive. | Account required. Independent + sustainable-business-funded. | Active. | The "independent again, funded by Premium not VC" pitch is exactly the model we want to be seen in. Their public language is good template material. |
+| **Readless** | Cloud (adjacent / new) | AI-first RSS + newsletter digest delivered by email. | Pricing not directly verified | GPT-5-class summarizer of feeds → daily digest email. | Account required; ships content through cloud LLM. | 2025 launch, active. | Confirms the AI-first new-entrant wave. They've ceded privacy entirely — that's our opening. |
 
 ## Movement since last run
 
-_No prior run. First population will list every entrant as new._
+This is the first run.
+
+### New entrants observed
+- **Readless** (2025) — AI-first RSS + newsletter digest via email. Aggressively SEO'd.
+- **Brief Digest** (2025) — AI-first reader, less established.
+- **Reeder (new, 2024+)** — Silvio Rizzi's ground-up rewrite as a unified timeline app. Reeder Classic continues for the traditional crowd.
+- **NetNewsWire 7** (2026-01) with Liquid Glass support — the strongest free native Apple option got stronger.
+
+### Notable category shifts
+- **Pocket shut down 2025-11-12** (Mozilla); API + apps offline. Data deletion queue active.
+- **TT-RSS original abandoned 2025-11-01**; community fork on GitHub picked it up same week.
+- **Omnivore shut down 2024-11-15** (team acquihired by ElevenLabs); open-source code remains, community fork at omnivore.work.
+- **Artifact shut down 2024-01** (Instagram founders' news aggregator).
+
+Four shutdowns in 19 months across the broader category. The abandonware-risk theme in `002` is not theoretical.
+
+### Price changes since baseline
+- N/A (first run). Track from next run.
 
 ## Stale / dead products tracked
 
 | Product | Status | Date | Why it matters |
 |---------|--------|------|----------------|
-| Omnivore | Shut down | 2024-11 | Open-source read-later that died — survivorship lesson. |
+| Pocket | Shut down | 2025-11-12 (data deleted; API + apps offline) | Largest read-later shutdown in years. Millions of users redistributed across Matter, Readwise, Instapaper, FreshRSS. The exact migration FeedZero should be on. |
+| Tiny Tiny RSS (original) | Retired by maintainer | 2025-11-01 | Live abandonware case. Code being kept alive by community fork — proof OSS contingency works. |
+| Omnivore | Shut down | 2024-11-15 (team acquihired by ElevenLabs) | Open-source read-later that died — survivorship lesson. Code remains; community fork exists but slow. |
 | Artifact | Shut down | 2024-01 | News aggregator with AI summarization, by Instagram founders — well-funded shutdowns happen too. |
 
 _Run logs in `runs/` capture per-refresh diffs and the reasoning behind table changes._

--- a/docs/strategy/002-user-pain-points.md
+++ b/docs/strategy/002-user-pain-points.md
@@ -1,60 +1,85 @@
 # 002 — User Pain Points
 
 ## Status
-Seeded. Awaiting first `/research-competitors` run.
+First population — 2026-05-16. <!-- changed 2026-05-16 -->
 
 ## Summary
 
-Themed clusters of recurring complaints + feature requests from r/rss, r/RSS_Readers, r/selfhosted (filtered "rss"), and competitor reviews. Each theme produces a one-sentence implication for FeedZero's roadmap — that's the bridge from "users complain about X" to "we should ship Y."
+Themed clusters of recurring complaints + feature requests from r/rss, r/RSS_Readers, r/selfhosted (filtered "rss"), the Privacy Guides community, lobste.rs, MacRumors forums, and competitor reviews. Each theme produces a one-sentence implication for FeedZero's roadmap — that's the bridge from "users complain about X" to "we should ship Y."
 
 Quotes are paraphrased to avoid lifting verbatim. Source links preserved for verification.
 
+**Sourcing caveat (2026-05-16):** Reddit and several competitor sites return 403 to `WebFetch` (anti-bot). This run synthesizes from secondary aggregators (Readless, BeeMind, SereneReader, OSSAlt, Zapier, XDA-Developers, lobste.rs, MacRumors, Privacy Guides) plus competitor blogs. Direct r/rss thread scraping is a known gap — see the run log. Future runs should retry via authenticated GitHub/Reddit MCP if available.
+
 ## Themes
 
-### Privacy + data ownership
+### Privacy + data ownership <!-- changed 2026-05-16 -->
 
-_Empty — awaiting first run._
+- Norwegian Consumer Council 2023 audit cited repeatedly: **7 of 8** popular AI news digest services were transmitting unencrypted article content to third-party LLM providers, with no opt-out for data processing. ([source via Alibaba Insights](https://www.alibaba.com/product-insights/how-to-build-a-private-ai-assistant-that-summarizes-news-without-feeding-data-to-corporate-servers.html))
+- Feedly's free tier shows "promoted content"; search is locked behind paid plans. The consumer experience has degraded under the enterprise pivot. ([readless](https://www.readless.app/blog/best-rss-readers-2026), [SereneReader](https://serenereader.com/blog/best-rss-readers-2026))
+- Inoreader Intelligence transparently sends article title/date/source/author to OpenAI for summarization. Better disclosure than Feedly, but still requires trust in the operator. ([Inoreader blog](https://www.inoreader.com/blog/2025/03/inoreader-intelligence-and-article-summaries-are-here.html))
+- Privacy Guides community thread on RSS readers (active discussion, but body 403'd this run): consistent recommendation pattern in the broader web is NetNewsWire (Apple-only), Miniflux (self-host), Feeder/Android (no account). ([thread URL](https://discuss.privacyguides.net/t/rss-reader-recomendation/10989))
+- "For privacy and control, self-hosted options like FreshRSS or Miniflux put your data on your own server." — the implicit consensus in self-hosted communities is that there are **no** trustworthy hosted privacy options at scale today. ([readless / selfh.st](https://selfh.st/alternatives/rss-readers/))
 
-**Roadmap implication:** _TBD._
+**Roadmap implication:** FeedZero is the only entrant that can credibly claim "hosted RSS with end-to-end encryption" — every cloud competitor sees plaintext, every privacy-first option ships only as self-host. That's the wedge; the marketing has to make this concrete (animated threat model, "what your server operator sees", architecture diagram on the landing page).
 
-### Sync friction
+### Sync friction <!-- changed 2026-05-16 -->
 
-_Empty — awaiting first run._
+- Reeder (new) iCloud sync reported broken in 2026: "unread counts starting to drift over time," "feeds from the previous day that they had marked as read already," "background sync option was practically not working." ([Jose Munoz Matos blog](https://www.josemunozmatos.com/blog/from-reeder-s-icloud-feeds-to-feedbin-finding-the-perfect-rss-service))
+- NetNewsWire 7.0.4 (2026-04) shipped specifically to fix iCloud sync friction: new option to **not** sync unread article content, new iCloud Storage Stats window with a Clean Up button to trim sync DB. ([Michael Tsai](https://mjtsai.com/blog/2026/04/23/netnewswire-7-0-4/), [netnewswire.blog](https://netnewswire.blog/2026/04/03/netnewswire-for-mac-new-icloud.html))
+- Users repeatedly switch from iCloud to Feedbin specifically to get reliable cross-device sync. ([MacRumors thread](https://forums.macrumors.com/threads/rss-reader-with-icloud-sync.2225209/))
+- Apple-ecosystem sync ties data to Apple's threat model — incompatible with FeedZero's user base (cross-platform + adversarial environments).
 
-**Roadmap implication:** _TBD._
+**Roadmap implication:** Sync reliability is the loudest live pain in the category right now. FeedZero's zero-knowledge sync (`src/core/sync/`) needs (a) telemetry-free reliability proof — smoke tests catching drift — and (b) marketing that explicitly contrasts with broken iCloud sync without naming names. Conflict resolution and offline-merge are the gaps to close (already flagged in `003` Section 4).
 
-### Mobile UX
+### Mobile UX <!-- changed 2026-05-16 -->
 
-_Empty — awaiting first run._
+- "Lire is the best Mac RSS reader for offline reading in 2026... fetches the full text of every article in the background, so truncated feeds turn into complete articles you can read on a plane or subway with zero internet." ([readless](https://www.readless.app/blog/best-rss-reader-for-mac-2026))
+- Matter is the iPhone winner per multiple aggregators — its draw is gestures and TTS, not features per se. ([readless](https://www.readless.app/blog/best-iphone-rss-reader-apps-2026))
+- Native-app reviewers consistently weigh "feels like a native iOS app" above raw features. Web wrappers / PWAs lose this comparison by default.
 
-**Roadmap implication:** _TBD._
+**Roadmap implication:** FeedZero's PWA needs to feel native on mobile or it loses to NetNewsWire (free, native, iCloud) and Matter (read-later refugees). Three concrete gaps: (1) offline pre-fetch of full text — already have extraction, schedule it; (2) gesture navigation in the reader pane; (3) text-to-speech via Web Speech API (free, on-device, no telemetry).
 
-### AI / summarization
+### AI / summarization <!-- changed 2026-05-16 -->
 
-_Empty — awaiting first run._
+- The AI-summarization wave is now table stakes in the category: Feedly Leo (Pro+ $8.25/mo, third-party LLM), Inoreader Intelligence (GPT-4o-mini via OpenAI, content sent in clear), Matter AI Co-Reader (Premium $60/yr), Readwise Ghostreader (cited answers, content in cloud), Readless ("GPT-5-class" digest of all feeds by email). ([Feedly](https://blog.feedly.com/leo-and-summarization/), [Inoreader](https://www.inoreader.com/blog/2025/03/inoreader-intelligence-and-article-summaries-are-here.html), [Readless](https://www.readless.app/))
+- Privacy-conscious users are explicitly building their own local-LLM setups for this: "AIDailyNews is an intelligent, privacy-focused agent that automatically collects, summarizes, and delivers daily news updates via local AI processing... use Ollama with phi-3:3.8b or llama3:8b." ([passhulk](https://passhulk.com/blog/best-local-llm-privacy-open-source-hosting-guide/), [vchalyi blog](https://www.vchalyi.com/blog/2025/summarize-rss-feed-with-ollama/))
+- New AI-first entrants (Readless, Brief Digest) are pure cloud — they ship feed content **and** newsletter content to centralized LLMs. Total privacy give-up for convenience.
 
-**Roadmap implication:** _TBD._
+**Roadmap implication:** This is the single most important capability decision pending. Ceding AI to centralized providers breaks FeedZero's threat model. Three viable architectures, ordered by feasibility: (1) BYO API key — user supplies their own OpenAI/Anthropic key, FeedZero proxies through the existing CORS proxy with a strict no-log mode; (2) Web LLM (WebGPU on-device inference) — heaviest UX, zero data egress; (3) optional Ollama/local-LLM endpoint with the same `Result<T>` interface. The "BYO API key + local-LLM endpoint" combo is the right v1 — it lets the user pick their own threat model. Flagged in `003` Section 4.
 
-### Full-text extraction
+### Full-text extraction <!-- changed 2026-05-16 -->
 
-_Empty — awaiting first run._
+- Paywall + truncated-feed handling is the recurring extraction complaint. lire wins specifically because it pre-fetches full text aggressively in the background. ([readless](https://www.readless.app/blog/best-rss-reader-for-mac-2026))
+- Fluent Reader users explicitly cite "Mercury Parser to pull full-text content for snippet-only feeds" as critical. ([readless](https://www.readless.app/blog/best-rss-reader-for-windows-2026))
+- Miniflux strips tracking pixels, blocks referrers, proxies media. That extraction-as-privacy-cleanup angle is rarely marketed but heavily valued by the technical audience. ([Cameron Rye](https://rye.dev/blog/rss-miniflux-2026/))
 
-**Roadmap implication:** _TBD._
+**Roadmap implication:** FeedZero's extractor (`src/core/extractor/`) is competitive on quality (Defuddle) but not on volume/schedule. Two concrete adds: (a) "extract on background refresh" mode for the user's starred or frequently-read feeds, with a hard quota to avoid abuse; (b) marketing the existing tracking-pixel sanitization as a feature, not a side effect.
 
-### Pricing fatigue
+### Pricing fatigue <!-- changed 2026-05-16 -->
 
-_Empty — awaiting first run._
+- BazQux's $249 lifetime is repeatedly recommended in subscription-fatigue threads. ([readless via crunchbase](https://www.crunchbase.com/organization/bazqux), [bazqux FAQ](https://bazqux.com/faq))
+- Reeder Classic survives at $4.99 one-time alongside new Reeder's $10/yr subscription — many users explicitly stick with Classic to avoid the recurring fee. ([Spectre Collie blog](https://spectrecollie.com/2025/03/07/i-was-wrong-about-the-new-reeder/))
+- Instapaper's 2023 price doubling ($30 → $60/yr) generated friction but they framed it as sustainability — "first price change in 9 years," "operate as a sustainable business funded by Premium subscriptions rather than venture capital runway." ([Instapaper Twitter](https://x.com/instapaper/status/1731704886444605543))
+- Feedly's Pro+ at $99/yr for AI features draws repeated "is it worth it" comparison content — signal that the price-feature curve has flattened in users' minds. ([readless](https://www.readless.app/blog/feedly-pro-pricing-vs-readless-2026))
 
-**Roadmap implication:** _TBD._
+**Roadmap implication:** When FeedZero monetizes, structure as (a) free tier that genuinely works, (b) one-time vault-lifetime pricing for the privacy-paranoid (BazQux model), (c) lightweight annual for sync infra. Don't price-anchor against Feedly Pro+ ($99/yr); the audience that values FeedZero won't pay for AI summarization they can't see.
 
-### Server-died-on-me (abandonware risk)
+### Server-died-on-me (abandonware risk) <!-- changed 2026-05-16 -->
 
-_Empty — awaiting first run._
+This theme escalated from theoretical to acute in the last 19 months:
 
-**Roadmap implication:** _TBD._
+- **Pocket** (Mozilla, 2017–2025) shut down 2025-11-12. Millions of users displaced. ([Mozilla support](https://support.mozilla.org/en-US/kb/future-of-pocket), [TechCrunch](https://techcrunch.com/2025/05/22/mozilla-is-shutting-down-read-it-later-app-pocket/))
+- **Tiny Tiny RSS** original 2025-11-01 retired by maintainer Andrew Dolgov; community fork on GitHub picked up immediately. ([Linux Today](https://www.linuxtoday.com/blog/tt-rss-shuts-down-but-the-project-lives-on-under-a-new-fork/))
+- **Omnivore** 2024-11-15 — team acquihired by ElevenLabs, service discontinued, data deleted. Code open-sourced but unmaintained. ([Notes blog](https://notes.ghed.in/posts/2024/omnivore-adquired-elevenlabs/), [TechCrunch](https://techcrunch.com/2024/10/29/elevenlabs-has-hired-the-team-behind-omnivore-a-reader-app/))
+- **Artifact** 2024-01 — well-funded news aggregator with AI by Instagram founders. Funded, audienced, dead.
+- Existing user defense reactions: "I self-hosted my own RSS reader to keep up with the news" ([XDA](https://www.xda-developers.com/i-self-hosted-my-own-rss-reader-to-keep-up-with-the-news/)), "Self-hosting RSS finally got me off social media for news" ([XDA](https://www.xda-developers.com/this-self-hosted-rss-reader-finally-got-me-off-social-media-for-news/)).
+
+**Roadmap implication:** This is the strongest live tailwind for FeedZero. **Lossless data export must be a first-class promise**, not a tucked-away feature. Three concrete moves: (1) on the landing page, an explicit "exit cost is zero — full OPML + JSON export, encrypted vault format documented, server runs as a single Hono binary you can self-host" panel; (2) a Pocket-import path (URL list ingest exists — verify it handles Pocket's CSV/HTML export format); (3) public commitment language modelled on Instapaper's "sustainable business, not VC runway" — the audience reads operator commitments carefully after the past 19 months.
 
 ## Themes not yet observed
 
-When a theme emerges that doesn't fit any of the above, add it here first with 2–5 supporting observations before promoting it to a top-level cluster. Premature theme creation dilutes the signal.
+When a theme emerges that doesn't fit any of the above, add it here first with 2–5 supporting observations before promoting it to a top-level cluster.
 
-- _none yet_
+- **Newsletters-in-RSS as a category** — Feedbin's distinguishing move; relevant to Pocket refugees. Watch for this becoming its own theme as Pocket migration patterns clarify.
+- **TTS / accessibility** — Instapaper's 17 AI voices, Matter's HD TTS. Currently a feature within "Mobile UX" — may deserve its own bucket if mentions multiply.

--- a/docs/strategy/002-user-pain-points.md
+++ b/docs/strategy/002-user-pain-points.md
@@ -1,0 +1,60 @@
+# 002 — User Pain Points
+
+## Status
+Seeded. Awaiting first `/research-competitors` run.
+
+## Summary
+
+Themed clusters of recurring complaints + feature requests from r/rss, r/RSS_Readers, r/selfhosted (filtered "rss"), and competitor reviews. Each theme produces a one-sentence implication for FeedZero's roadmap — that's the bridge from "users complain about X" to "we should ship Y."
+
+Quotes are paraphrased to avoid lifting verbatim. Source links preserved for verification.
+
+## Themes
+
+### Privacy + data ownership
+
+_Empty — awaiting first run._
+
+**Roadmap implication:** _TBD._
+
+### Sync friction
+
+_Empty — awaiting first run._
+
+**Roadmap implication:** _TBD._
+
+### Mobile UX
+
+_Empty — awaiting first run._
+
+**Roadmap implication:** _TBD._
+
+### AI / summarization
+
+_Empty — awaiting first run._
+
+**Roadmap implication:** _TBD._
+
+### Full-text extraction
+
+_Empty — awaiting first run._
+
+**Roadmap implication:** _TBD._
+
+### Pricing fatigue
+
+_Empty — awaiting first run._
+
+**Roadmap implication:** _TBD._
+
+### Server-died-on-me (abandonware risk)
+
+_Empty — awaiting first run._
+
+**Roadmap implication:** _TBD._
+
+## Themes not yet observed
+
+When a theme emerges that doesn't fit any of the above, add it here first with 2–5 supporting observations before promoting it to a top-level cluster. Premature theme creation dilutes the signal.
+
+- _none yet_

--- a/docs/strategy/003-playing-to-win.md
+++ b/docs/strategy/003-playing-to-win.md
@@ -3,6 +3,19 @@
 ## Status
 Refreshed 2026-05-16 against first competitor scan. Sections sharpened with concrete competitive data; markers below show what moved.
 
+<!-- changed 2026-05-16: focus declaration added -->
+## Focus
+
+**FeedZero will be great at one thing: fetching feeds reliably and presenting them in a reader that's a pleasure to use.** That is the trunk. Everything else — sync, AI, social, recommendations, team workspaces, market intelligence — is a branch we either prune or grow only when it strengthens the trunk.
+
+Concretely:
+
+- **Build:** anything that makes feed fetching more reliable, more respectful of the publisher, or makes reading faster, calmer, and more legible.
+- **Defer:** AI summarization, advanced filtering rules, social graph features, native apps. These are not bad — they just don't compound on the trunk and they trade against the privacy stance.
+- **Refuse:** anything that requires server-side access to plaintext (algorithmic feeds, cross-user discovery, server-side ML). These contradict §3 and are not on any roadmap.
+
+When in doubt, the test is: _does this change make FeedZero a better reader of RSS, today, for one person?_ If yes, ship it. If it makes FeedZero a better something-else (a knowledge graph, an AI tool, a team product), it goes on a wishlist, not a sprint.
+
 ## Framework
 
 A.G. Lafley + Roger Martin, _Playing to Win_ (2013). Five cascading strategic choices:
@@ -64,7 +77,7 @@ What winning is **not**: maximum DAU, paid conversion, or feature-parity with Fe
 
 **Channels:** <!-- changed 2026-05-16 -->
 - Word of mouth in privacy-conscious circles (still the only channel that compounds for this audience).
-- **Explicit migration paths from shutdowns**: Pocket → FeedZero importer (Pocket exported HTML/CSV); TT-RSS → OPML import path; Omnivore → JSON import. Each ships with a landing page that ranks for the shutdown event. This is the highest-leverage acquisition opportunity in the category right now.
+- **Explicit migration paths from shutdowns**: Pocket → FeedZero importer (Pocket exported HTML, parser at `src/core/opml/pocket-parser.ts` as of 2026-05-18); TT-RSS → OPML import path (already supported); Omnivore → JSON import (TODO). Each ships with a landing page that ranks for the shutdown event — copy drafted in [`docs/marketing/`](../marketing/), deployment tracked in [`docs/marketing/TODO.md`](../marketing/TODO.md). This is the highest-leverage acquisition opportunity in the category right now.
 - EFF-adjacent, Privacy Guides, Tor Project mentions.
 - Hacker News / r/privacy / r/selfhosted launches.
 - Self-hosted communities (selfh.st, awesome-selfhosted) — listing visibility.

--- a/docs/strategy/003-playing-to-win.md
+++ b/docs/strategy/003-playing-to-win.md
@@ -1,0 +1,117 @@
+# 003 — Playing to Win
+
+## Status
+Seeded v0 from `README.md` and `CLAUDE.md` Principles. Awaiting first `/research-competitors` run to sharpen against actual competitive data.
+
+## Framework
+
+A.G. Lafley + Roger Martin, _Playing to Win_ (2013). Five cascading strategic choices:
+
+1. **Winning Aspiration** — what does winning look like?
+2. **Where to Play** — which segments, surfaces, geographies, channels?
+3. **How to Win** — the unique value-prop wedge. Differentiation, cost, or focus.
+4. **Capabilities** — what must we be exceptional at?
+5. **Management Systems** — measurement, cadence, feedback loops.
+
+Each question constrains the next. Inconsistency between layers is the diagnostic — when sections don't compose, the strategy isn't real yet.
+
+Changed sections are marked `<!-- changed YYYY-MM-DD -->` so reviewers can scan diffs without reading every line.
+
+---
+
+## 1. Winning Aspiration
+
+FeedZero wins when **people whose safety depends on private reading habits choose us first** — and when the rest of the privacy-curious market sees us as the reference implementation of "you can have a real cloud-syncing RSS reader without trusting the cloud with your reading list."
+
+The CLAUDE.md principle is operative: _"FeedZero exists to protect its users — journalists, activists, and people living under surveillance. Every decision must be made as if a user's safety depends on it, because it does."_
+
+Measurable success — to be re-baselined per run as data accrues:
+
+- **Adoption among at-risk users.** Vault count from `/api/stats-sync` is the floor (counts encrypted vaults, no PII).
+- **Mindshare in privacy communities.** Mentions in EFF / Privacy Guides / r/privacy / Tor Project channels.
+- **Survival.** Outlive the next two privacy-positioned competitor shutdowns. (Omnivore + Artifact are the cautionary tales — see `001`.)
+- **Recommendation density.** Linked from at least one major privacy-tooling round-up per quarter.
+
+What winning is **not**: maximum DAU, paid conversion, or feature-parity with Feedly's enterprise tier. Those framings would force compromises the aspiration forbids.
+
+## 2. Where to Play
+
+**Segments — primary:**
+- Journalists, activists, researchers, lawyers, and source-handlers in adversarial environments.
+- Self-hosters who want a real client, not just a server.
+- Privacy-paranoid technical pros who already use Signal, Tor, or password managers daily.
+
+**Segments — secondary (acquire opportunistically, don't optimize for):**
+- Mainstream privacy-curious users who've heard "Feedly tracks you" and want an alternative.
+- RSS power users frustrated by Inoreader / Feedly pricing.
+
+**Segments we are not for:**
+- Casual readers who want algorithmic feeds and don't care about telemetry.
+- Enterprise team-collaboration use cases.
+- Users who want centralized AI summarization at any privacy cost.
+
+**Surfaces:**
+- Primary: web app (PWA-capable, works offline, no install friction).
+- Secondary: self-hosted Hono server (`server.ts`) for users who want to run their own proxy.
+- Not now: native iOS/macOS/Android apps. Reeder + NetNewsWire own that surface; competing there dilutes the privacy story.
+
+**Geographies:** wherever the audience is. English-first; localization follows demand from at-risk communities.
+
+**Channels:**
+- Word of mouth in privacy-conscious circles (the only channel that compounds for this audience).
+- EFF-adjacent, Privacy Guides, Tor Project mentions.
+- Hacker News / r/privacy / r/selfhosted launches.
+- Direct evangelism in journalism / activism networks.
+- **Not:** paid acquisition, SEO content farms, growth hacking. They contradict the privacy stance.
+
+## 3. How to Win
+
+**The wedge:** FeedZero is the only RSS reader where _the operator cannot read your feed list_, your reading history, or your saved articles — even if subpoenaed, even if the database is dumped, even if the operator is malicious. Everything is encrypted client-side with a key only the user holds. Sync is end-to-end. The server stores opaque blobs.
+
+This isn't a marketing claim — it's the architecture (see `docs/features/008-zero-knowledge-sync.md`, `docs/architecture.md`).
+
+**Why it's durable:**
+- **It's hard to copy without rebuilding.** Feedly cannot bolt this on — their whole business model assumes server-side access to your reading data for monetization (ML training, ads, "discovery"). The architecture is the moat.
+- **Self-hostable.** Even if FeedZero the project disappears, the user keeps their data and can run the server. Vendor-lock-in is the threat-model FeedZero exists to refuse.
+- **Open source.** The privacy claim is auditable. "Trust us" is the failure mode of every shut-down competitor.
+
+**What we explicitly trade away:**
+- Server-side ML / personalization / "for you" feeds — they require plaintext access we won't have.
+- Cross-user features (popular-in-your-network, social) — incompatible with E2E.
+- The fastest possible startup — client-side decryption costs a beat.
+
+These trade-offs are features, not bugs. A competitor offering all three would not be FeedZero.
+
+## 4. Capabilities
+
+What FeedZero must be exceptional at to deliver the wedge above:
+
+| Capability | Why it's required | Current state | Gap |
+|------------|-------------------|---------------|-----|
+| Client-side cryptography (AES-GCM + PBKDF2 + HMAC) | Foundation of the privacy claim. | Implemented (`src/core/storage/crypto.ts`, `key-material.ts`). | Audit cadence. Recovery UX still rough. |
+| Zero-knowledge sync | Required for multi-device without surrendering plaintext. | Implemented (`src/core/sync/`). | Conflict resolution; offline-edit merge. |
+| Full-text extraction | Paywalled / cluttered articles must be readable without external services that would see the URL. | Implemented via Defuddle (`src/core/extractor/`). | Adapter coverage. Quality regressions. |
+| Feed parsing reliability | If feeds break, the privacy story is irrelevant — users leave. | Implemented via feedsmith (`src/core/parser/`). | Edge-case malformed feeds. |
+| Trustworthy CORS proxy | The one server we operate must be minimal and SSRF-safe. | Implemented (`src/core/proxy/`). | Rate limiting, abuse handling. |
+| Onboarding that doesn't scare normies | "Generate a 4-word passphrase" must feel safe, not cryptic. | Implemented (`src/components/onboarding/`). | Recovery story still confusing per support load. |
+| OPML round-trip | Exit-cost must be zero. Lock-in contradicts the values. | Implemented (`src/core/opml/`). | — |
+| Doing AI / summarization without telemetry | Demand exists; ceding it to centralized AI breaks the model. | Not built. | Open question: local LLM? on-device? user-supplied API key? |
+
+The AI / summarization gap is the most important capability decision pending — it's where the market is pulling RSS but where naive implementations would break the privacy claim. The cascade refresh should re-evaluate this row each run as the competitive landscape moves.
+
+## 5. Management Systems
+
+How FeedZero measures and adapts:
+
+- **Vault count.** `/api/stats-sync` — the only legitimate growth metric the privacy architecture allows. No DAU, no funnel, no user IDs.
+- **GitHub signal.** Stars, issue volume by category, PR cadence. Issues clustered by `002`'s themes — a spike in any cluster updates the next run's focus.
+- **Release cadence.** Tracked via the `new-release` skill. Slowing cadence is a leading indicator of capability rot.
+- **This document.** Refreshed via `/research-competitors`. Cadence: weekly while feasible, monthly minimum. Each refresh produces a dated run log in `runs/` — the strategy's audit trail is in git.
+- **External review.** Annual security audit (see `docs/audit-2026-03-22.md` for the template). The privacy claim is only as good as the last audit.
+- **Failure signals.** Two specific events that should trigger immediate strategy review, not wait for the weekly: (a) a sync incident that exposes plaintext (architectural failure), (b) a competitor shipping audited E2E sync (wedge erosion). Both invalidate sections above and must propagate down the cascade.
+
+## Cascade coherence check
+
+Re-verify each refresh: do sections 2–5 actually follow from section 1? When a section drifts, mark it changed and propagate the change down. The cascade is real only when the layers compose.
+
+Most recent coherence check: _seed only, no live check yet._

--- a/docs/strategy/003-playing-to-win.md
+++ b/docs/strategy/003-playing-to-win.md
@@ -1,7 +1,7 @@
 # 003 — Playing to Win
 
 ## Status
-Seeded v0 from `README.md` and `CLAUDE.md` Principles. Awaiting first `/research-competitors` run to sharpen against actual competitive data.
+Refreshed 2026-05-16 against first competitor scan. Sections sharpened with concrete competitive data; markers below show what moved.
 
 ## Framework
 
@@ -25,93 +25,112 @@ FeedZero wins when **people whose safety depends on private reading habits choos
 
 The CLAUDE.md principle is operative: _"FeedZero exists to protect its users — journalists, activists, and people living under surveillance. Every decision must be made as if a user's safety depends on it, because it does."_
 
-Measurable success — to be re-baselined per run as data accrues:
+Measurable success — re-baselined per run as data accrues:
 
 - **Adoption among at-risk users.** Vault count from `/api/stats-sync` is the floor (counts encrypted vaults, no PII).
-- **Mindshare in privacy communities.** Mentions in EFF / Privacy Guides / r/privacy / Tor Project channels.
-- **Survival.** Outlive the next two privacy-positioned competitor shutdowns. (Omnivore + Artifact are the cautionary tales — see `001`.)
+- **Mindshare in privacy communities.** Mentions in EFF / Privacy Guides / r/privacy / Tor Project channels. <!-- changed 2026-05-16 --> Concrete target: appear on the Privacy Guides community's RSS recommendation thread by end of next quarter.
+- **Survival.** <!-- changed 2026-05-16 --> Already operative test, not aspirational: four products in our broader category have shut down in the last 19 months — Pocket (2025-11), TT-RSS-original (2025-11), Omnivore (2024-11), Artifact (2024-01). Surviving this category-wide attrition **is** winning. The privacy moat is also a sustainability moat: no centralized data → no platform liability → cheaper to operate indefinitely.
 - **Recommendation density.** Linked from at least one major privacy-tooling round-up per quarter.
 
 What winning is **not**: maximum DAU, paid conversion, or feature-parity with Feedly's enterprise tier. Those framings would force compromises the aspiration forbids.
 
 ## 2. Where to Play
 
+<!-- changed 2026-05-16: sharpened segments based on Pocket/Omnivore/TT-RSS migration patterns; added explicit acquisition channels tied to live shutdowns -->
+
 **Segments — primary:**
-- Journalists, activists, researchers, lawyers, and source-handlers in adversarial environments.
-- Self-hosters who want a real client, not just a server.
-- Privacy-paranoid technical pros who already use Signal, Tor, or password managers daily.
+- Journalists, activists, researchers, lawyers, and source-handlers in adversarial environments. (Unchanged — anchor.)
+- Self-hosters who want a real client, not just a server. (Unchanged — `001` shows this audience is large and currently underserved by the native-app side. Reeder Classic + a self-hosted backend is the manual workaround they're using today.)
+- **Pocket refugees who already paid for privacy.** ~Millions displaced 2025-11-12. They're sorting between Matter (cloud AI), Readwise Reader (cloud + PKM), Instapaper (cloud independent), and self-hosted Wallabag/FreshRSS extensions. The privacy-conscious subset is currently underserved — Matter ships content to the cloud, Wallabag requires self-hosting.
+- **TT-RSS users whose admin walked away.** Smaller cohort but high-value: they already trust E2E principles and run their own infra. They're a natural early-adopter pool for our self-hosted Hono server.
 
 **Segments — secondary (acquire opportunistically, don't optimize for):**
 - Mainstream privacy-curious users who've heard "Feedly tracks you" and want an alternative.
-- RSS power users frustrated by Inoreader / Feedly pricing.
+- RSS power users frustrated by Inoreader/Feedly pricing escalation ($99/yr for Feedly Pro+ AI is the flashpoint cited in pricing-fatigue threads).
+- Feedbin / NetNewsWire users who want cross-platform sync without iCloud lock-in.
 
 **Segments we are not for:**
 - Casual readers who want algorithmic feeds and don't care about telemetry.
-- Enterprise team-collaboration use cases.
-- Users who want centralized AI summarization at any privacy cost.
+- Enterprise team-collaboration use cases (Feedly's $1,600+/mo segment).
+- Users who want centralized AI summarization at any privacy cost (Readless, Brief Digest's audience).
+- Apple-ecosystem-only users where NetNewsWire 7 already solves the problem for free. They are NNW's; chasing them is a losing fight.
 
 **Surfaces:**
 - Primary: web app (PWA-capable, works offline, no install friction).
 - Secondary: self-hosted Hono server (`server.ts`) for users who want to run their own proxy.
-- Not now: native iOS/macOS/Android apps. Reeder + NetNewsWire own that surface; competing there dilutes the privacy story.
+- Not now: native iOS/macOS/Android apps. Reeder + NetNewsWire own that surface; competing there dilutes the privacy story. **However** — see Capabilities §4: Reeder Classic supports the Fever / Google Reader API, and our self-hosted server could expose one. That's a distribution lever without building a native app.
 
 **Geographies:** wherever the audience is. English-first; localization follows demand from at-risk communities.
 
-**Channels:**
-- Word of mouth in privacy-conscious circles (the only channel that compounds for this audience).
+**Channels:** <!-- changed 2026-05-16 -->
+- Word of mouth in privacy-conscious circles (still the only channel that compounds for this audience).
+- **Explicit migration paths from shutdowns**: Pocket → FeedZero importer (Pocket exported HTML/CSV); TT-RSS → OPML import path; Omnivore → JSON import. Each ships with a landing page that ranks for the shutdown event. This is the highest-leverage acquisition opportunity in the category right now.
 - EFF-adjacent, Privacy Guides, Tor Project mentions.
 - Hacker News / r/privacy / r/selfhosted launches.
+- Self-hosted communities (selfh.st, awesome-selfhosted) — listing visibility.
 - Direct evangelism in journalism / activism networks.
 - **Not:** paid acquisition, SEO content farms, growth hacking. They contradict the privacy stance.
 
 ## 3. How to Win
 
+<!-- changed 2026-05-16: anchored the wedge in measurable terms (Norwegian Consumer Council finding) and named the competitive failure mode -->
+
 **The wedge:** FeedZero is the only RSS reader where _the operator cannot read your feed list_, your reading history, or your saved articles — even if subpoenaed, even if the database is dumped, even if the operator is malicious. Everything is encrypted client-side with a key only the user holds. Sync is end-to-end. The server stores opaque blobs.
 
 This isn't a marketing claim — it's the architecture (see `docs/features/008-zero-knowledge-sync.md`, `docs/architecture.md`).
 
+**The market context that makes the wedge sharp** (from this run): A 2023 Norwegian Consumer Council audit found that **7 of 8** popular AI-news-digest services transmit unencrypted article content to third-party LLM providers, with no opt-out. The 2026 landscape has gotten worse, not better: Feedly Leo, Inoreader Intelligence (GPT-4o-mini), Matter AI Co-Reader, Readwise Ghostreader, and the AI-first new entrants (Readless, Brief Digest) all funnel reading content to centralized LLMs. Inoreader's transparency is admirable, but transparency isn't the same as architectural impossibility. **FeedZero is the only product in `001` that makes data exposure architecturally impossible, not just policy-impossible.**
+
 **Why it's durable:**
-- **It's hard to copy without rebuilding.** Feedly cannot bolt this on — their whole business model assumes server-side access to your reading data for monetization (ML training, ads, "discovery"). The architecture is the moat.
-- **Self-hostable.** Even if FeedZero the project disappears, the user keeps their data and can run the server. Vendor-lock-in is the threat-model FeedZero exists to refuse.
+- **It's hard to copy without rebuilding.** Feedly cannot bolt this on — their whole business model assumes server-side access to your reading data for monetization (ML training, ads, "discovery"). Their AI Pro+ tier is the bet against E2E. The architecture is the moat.
+- **Self-hostable.** Even if FeedZero the project disappears, the user keeps their data and can run the server. Vendor-lock-in is the threat-model FeedZero exists to refuse. <!-- changed 2026-05-16 --> The 19-month run of category shutdowns (Pocket, TT-RSS, Omnivore, Artifact) makes this concrete, not abstract: every shutdown is FeedZero's marketing campaign. Survivors who get this right inherit the audience.
 - **Open source.** The privacy claim is auditable. "Trust us" is the failure mode of every shut-down competitor.
 
 **What we explicitly trade away:**
 - Server-side ML / personalization / "for you" feeds — they require plaintext access we won't have.
-- Cross-user features (popular-in-your-network, social) — incompatible with E2E.
+- Cross-user features (popular-in-your-network, social) — incompatible with E2E. Artifact's shutdown validates the bet against this category.
 - The fastest possible startup — client-side decryption costs a beat.
 
 These trade-offs are features, not bugs. A competitor offering all three would not be FeedZero.
 
 ## 4. Capabilities
 
+<!-- changed 2026-05-16: sharpened AI/summarization gap with concrete architecture choices; added sync-reliability and Pocket-import as new gap rows -->
+
 What FeedZero must be exceptional at to deliver the wedge above:
 
 | Capability | Why it's required | Current state | Gap |
 |------------|-------------------|---------------|-----|
 | Client-side cryptography (AES-GCM + PBKDF2 + HMAC) | Foundation of the privacy claim. | Implemented (`src/core/storage/crypto.ts`, `key-material.ts`). | Audit cadence. Recovery UX still rough. |
-| Zero-knowledge sync | Required for multi-device without surrendering plaintext. | Implemented (`src/core/sync/`). | Conflict resolution; offline-edit merge. |
-| Full-text extraction | Paywalled / cluttered articles must be readable without external services that would see the URL. | Implemented via Defuddle (`src/core/extractor/`). | Adapter coverage. Quality regressions. |
+| Zero-knowledge sync | Required for multi-device without surrendering plaintext. | Implemented (`src/core/sync/`). | **Reliability proof.** Reeder's iCloud sync is reported broken in 2026 — drift on unread counts, slow background sync. NetNewsWire 7.0.4 shipped specifically to fix this for free users. FeedZero needs smoke tests catching drift, plus offline-edit merge. Conflict resolution remains the open spec. |
+| Full-text extraction | Paywalled / cluttered articles must be readable without external services that would see the URL. | Implemented via Defuddle (`src/core/extractor/`). | **Background pre-fetch** for starred / frequently-read feeds (lire's distinctive feature; rated #1 for offline). Adapter coverage. Quality regressions. Market existing tracking-pixel sanitization. |
 | Feed parsing reliability | If feeds break, the privacy story is irrelevant — users leave. | Implemented via feedsmith (`src/core/parser/`). | Edge-case malformed feeds. |
 | Trustworthy CORS proxy | The one server we operate must be minimal and SSRF-safe. | Implemented (`src/core/proxy/`). | Rate limiting, abuse handling. |
 | Onboarding that doesn't scare normies | "Generate a 4-word passphrase" must feel safe, not cryptic. | Implemented (`src/components/onboarding/`). | Recovery story still confusing per support load. |
 | OPML round-trip | Exit-cost must be zero. Lock-in contradicts the values. | Implemented (`src/core/opml/`). | — |
-| Doing AI / summarization without telemetry | Demand exists; ceding it to centralized AI breaks the model. | Not built. | Open question: local LLM? on-device? user-supplied API key? |
+| **Pocket / Omnivore / TT-RSS import paths** | Highest-leverage acquisition channel right now per §2. URL-list ingest already exists. | Partial (URL-list ingester in `src/core/opml/url-list-parser.ts`). | Verify it handles Pocket's exact HTML/CSV export format; verify Omnivore's JSON ingest. Add a landing-page panel per shutdown event. |
+| **AI / summarization without telemetry** | Demand exists; ceding it to centralized AI breaks the model. Inoreader Intelligence + Feedly Leo are the threat to the wedge. | Not built. | **Architecture choice — this is the most important capability decision pending.** Three options, ranked by feasibility: (1) **BYO API key** — user supplies their own OpenAI/Anthropic key, FeedZero proxies through the existing CORS proxy with strict no-log mode. Lowest engineering cost, lets the user own their threat model. (2) **WebGPU local LLM** via Web LLM / Transformers.js — zero data egress but heavy on UX (model download, slow on phones). (3) **Optional Ollama endpoint** with same `Result<T>` interface — for self-hosters who already run a local LLM. Recommended v1: ship (1) first, document (3) as a config option, revisit (2) when WebGPU is more universal. |
+| Sync UX without lock-in | Apple's iCloud ties to Apple threat model; Feedly account ties to Feedly. We must offer real cross-platform sync without ecosystem capture. | Implemented (vault sync, vendor-neutral). | Document the self-host path more prominently. |
+| **TTS / accessibility** | Matter + Instapaper both ship as differentiating features. | Not built. | Web Speech API gives free, on-device TTS in 1–2 days of work. Low cost, real value, fully aligned with privacy. |
 
-The AI / summarization gap is the most important capability decision pending — it's where the market is pulling RSS but where naive implementations would break the privacy claim. The cascade refresh should re-evaluate this row each run as the competitive landscape moves.
+The AI / summarization gap is the most strategically important row — it's where the market is pulling RSS but where naive implementations would break the privacy claim. <!-- changed 2026-05-16 --> The decision now has a concrete proposal (BYO API key + Ollama endpoint); the next run should reflect progress or refute the proposal.
 
 ## 5. Management Systems
+
+<!-- changed 2026-05-16: added category-shutdown event as immediate-review trigger; clarified strategy-doc cadence -->
 
 How FeedZero measures and adapts:
 
 - **Vault count.** `/api/stats-sync` — the only legitimate growth metric the privacy architecture allows. No DAU, no funnel, no user IDs.
 - **GitHub signal.** Stars, issue volume by category, PR cadence. Issues clustered by `002`'s themes — a spike in any cluster updates the next run's focus.
 - **Release cadence.** Tracked via the `new-release` skill. Slowing cadence is a leading indicator of capability rot.
-- **This document.** Refreshed via `/research-competitors`. Cadence: weekly while feasible, monthly minimum. Each refresh produces a dated run log in `runs/` — the strategy's audit trail is in git.
+- **This document.** Refreshed via `/research-competitors`. Cadence: weekly while feasible, monthly minimum. Each refresh produces a dated run log in `runs/` — the strategy's audit trail is in git. <!-- changed 2026-05-16 --> Plus: any competitor shutdown event (`001`'s "stale/dead" table grows by a row) triggers an out-of-cycle refresh of §2 and §3 within 48 hours — the migration acquisition window is short.
 - **External review.** Annual security audit (see `docs/audit-2026-03-22.md` for the template). The privacy claim is only as good as the last audit.
-- **Failure signals.** Two specific events that should trigger immediate strategy review, not wait for the weekly: (a) a sync incident that exposes plaintext (architectural failure), (b) a competitor shipping audited E2E sync (wedge erosion). Both invalidate sections above and must propagate down the cascade.
+- **Failure signals.** Three specific events that should trigger immediate strategy review, not wait for the weekly: (a) a sync incident that exposes plaintext (architectural failure), (b) a competitor shipping audited E2E sync (wedge erosion), (c) <!-- changed 2026-05-16 --> a major shutdown adding a row to `001`'s stale/dead table — section 2's "Where to Play" should re-rank migration channels. All three invalidate sections above and must propagate down the cascade.
 
 ## Cascade coherence check
 
 Re-verify each refresh: do sections 2–5 actually follow from section 1? When a section drifts, mark it changed and propagate the change down. The cascade is real only when the layers compose.
 
-Most recent coherence check: _seed only, no live check yet._
+<!-- changed 2026-05-16 -->
+**2026-05-16 coherence check:** §1 (winning aspiration: protect at-risk users) → §2 (segments centered on adversarial-environment users + privacy-conscious migrants from shutdowns) → §3 (E2E architecture as both moat and sustainability story, sharpened against the Norwegian audit finding) → §4 (capabilities concentrated on crypto, sync reliability, AI-without-telemetry, lossless migration) → §5 (measurement aligned with no-telemetry constraint; shutdown-event trigger added). **Cascade composes.** The one tension to flag: §3 ("the operator cannot read your data") + §4's AI proposal ("BYO API key proxied through our server") — the proxy must be **provably** no-log for the proposal to be coherent. That's an architecture work item for the run that implements (1), not a contradiction in the strategy.

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -1,0 +1,36 @@
+# Strategy
+
+Living strategy docs for FeedZero. These are **not** implementation specs — see `docs/features/` for those. These docs answer "what are we trying to win at, against whom, and how?"
+
+## Documents
+
+| File | Purpose | Update cadence |
+|------|---------|----------------|
+| `001-competitor-scan.md` | Sorted table of every RSS reader + adjacent product worth tracking, with pricing, positioning, and what we learn from each. | Each run. Rewritten in place. |
+| `002-user-pain-points.md` | Themed clusters of complaints + feature requests from r/rss, r/RSS_Readers, r/selfhosted, and competitor reviews. | Each run. Themes accrete; quotes refresh. |
+| `003-playing-to-win.md` | Lafley + Martin's 5-question cascade applied to FeedZero. The strategy. Changed sections marked with `<!-- changed YYYY-MM-DD -->`. | Each run. Revised, not replaced. |
+| `runs/YYYY-MM-DD.md` | Dated audit log per refresh: sources scanned, key findings, cascade changes, open questions. | One per run. Append-only — historical record. |
+
+## How to refresh
+
+Invoke from any Claude Code session in this repo:
+
+```
+/research-competitors                       # full landscape (default)
+/research-competitors readwise-reader       # deep dive one competitor
+/research-competitors pricing               # one theme across all competitors
+/loop 7d /research-competitors              # weekly while a session stays open
+```
+
+The command does the scanning, synthesis, and writing. It does not auto-commit — review the diff before merging.
+
+## Caveat on `/loop`
+
+`/loop` is session-bound. A weekly cadence requires either (a) leaving a session running for a week, (b) invoking manually each Monday, or (c) a future GitHub Action cron that runs `/research-competitors` headless. Option (c) is out of scope until the doc shape stabilizes.
+
+## Why this lives in `docs/`, not Notion / Confluence / a wiki
+
+- **Auditable history.** `git log docs/strategy/003-playing-to-win.md` shows the strategy's evolution.
+- **Diffable.** Each refresh produces a reviewable PR-shaped change, not an opaque overwrite.
+- **Co-located with the code that implements it.** Capabilities the cascade calls out (full-text extraction, E2E sync) map directly to `src/core/` modules. Closing the loop is one `grep` away.
+- **No vendor lock-in.** Same logic as the product itself.

--- a/docs/strategy/runs/2026-05-16.md
+++ b/docs/strategy/runs/2026-05-16.md
@@ -1,0 +1,79 @@
+# Run 2026-05-16
+
+## Focus
+Full landscape — first run, seeded population of all three docs.
+
+## Sources scanned
+
+### Competitor primary pages (attempted)
+WebFetch returned HTTP 403 from major homepages and pricing pages — feedly.com, inoreader.com, newsblur.com, feedbin.com, reddit.com, mozilla.org/pocket support — all reject the WebFetch user agent. Methodology degraded to multi-source aggregator cross-reference (≥3 sources per pricing claim) for those competitors. Direct page verification succeeded only for community fork repos (GitHub) and the privacy-guides forum URL (also 403).
+
+**Action for next run:** investigate whether an authenticated MCP fetch tool can bypass the 403, or whether Bash + curl with a UA string is permitted. Until then, treat all pricing as "cross-verified, not source-verified."
+
+### Aggregator + community signal sources
+- readless.app — multiple pricing breakdowns (Feedly, Inoreader, NewsBlur, BazQux, Reeder, Matter, Readwise Reader, Brief Digest)
+- serenereader.com — best RSS readers 2026 round-up
+- ossalt.com — Miniflux + FreshRSS self-host guides
+- mjtsai.com, netnewswire.blog — NetNewsWire 7.0.4 release notes (2026-04)
+- techcrunch.com — Pocket shutdown announcement (2025-05); ElevenLabs/Omnivore acquihire (2024-10)
+- linuxtoday.com, linuxiac.com — TT-RSS shutdown + community fork (2025-11)
+- en.wikipedia.org — NewsBlur, The Old Reader, Tiny Tiny RSS, Instapaper
+- github.com — miniflux/v2, FreshRSS/FreshRSS, tt-rss/tt-rss, samuelclay/NewsBlur, nkanaev/yarr, Athou/commafeed, yang991178/fluent-reader
+- crunchbase.com — BazQux company status
+- inoreader blog 2025-03 — Intelligence article summaries launch (transparency disclosure)
+- feedly.com/ai — Leo + Summarization marketing page
+- x.com/instapaper — 2023 price doubling announcement (one historical tweet)
+- Privacy Guides community thread URL referenced (body 403'd — could not extract content)
+- mjtsai.com — independent NetNewsWire reliability commentary
+
+### New entrants discovered
+- **Readless** — AI-first RSS + newsletter digest by email; GPT-5-class summarization; SEO-aggressive
+- **Brief Digest** — AI-first reader, newer/smaller than Readless
+- **omnivore.work** — community fork of shut-down Omnivore; deployment-ready
+- **Reeder (new, 2024+)** — Silvio Rizzi's ground-up rewrite as unified timeline app; Reeder Classic continues separately
+
+### Dead products confirmed
+- Pocket (Mozilla) — shut down 2025-11-12; API + apps offline; data queued for deletion
+- Tiny Tiny RSS original — retired by Andrew Dolgov 2025-11-01; community fork on github.com/tt-rss/tt-rss active
+- Omnivore — shut down 2024-11-15 (ElevenLabs acquihire); open-source code remains
+- Artifact — shut down 2024-01
+
+## Key new findings
+
+- **Four product shutdowns in 19 months** across the broader category: Artifact (2024-01), Omnivore (2024-11), TT-RSS original (2025-11), Pocket (2025-11). The "Server-died-on-me" theme is no longer theoretical — it's the dominant live tailwind for FeedZero. **Each shutdown is a redirected acquisition channel.**
+- **Norwegian Consumer Council 2023 audit**: 7 of 8 popular AI news digest services transmit unencrypted article content to third-party LLM providers with no opt-out. This finding is repeatedly cited in privacy-conscious RSS discourse and is the sharpest rhetorical hook FeedZero has for §3's wedge.
+- **AI-summarization is now table stakes**: Feedly Leo, Inoreader Intelligence (GPT-4o-mini via OpenAI), Matter AI Co-Reader, Readwise Ghostreader, Readless. Every implementation in the category sends plaintext to a centralized LLM. This is a wedge-defining gap: solving it on FeedZero's terms (BYO API key + optional Ollama) is the most important capability decision pending.
+- **Reeder iCloud sync is reported broken in 2026**; NetNewsWire 7.0.4 (Apr 2026) shipped specifically to address iCloud sync friction. Sync reliability is the loudest live pain in the category, and FeedZero's zero-knowledge sync needs a public reliability story.
+- **Pricing fatigue is real but priced**: BazQux's $249 lifetime, Reeder Classic's $4.99 one-time, and Instapaper's "first price change in 9 years" all stay top-of-mind in subscription-fatigue discourse. When FeedZero monetizes, structure around vault-lifetime + light annual sync, not feature-tier escalation.
+- **Reeder Classic talks to Fever / Google Reader APIs**. Our Hono server could expose one of these. That's a distribution surface without building a native app — flagged in `003` §2.
+- **NewsBlur (~17 years old, solo dev, AGPL, $36/yr, still shipping)** is the proof point that the indie privacy reader is viable at small scale. Useful sustainability evidence for fundraising / messaging conversations.
+
+## Cascade changes
+
+`003-playing-to-win.md` changes propagated 2026-05-16:
+
+- **§1 Winning Aspiration**: "survival" reframed from aspirational to operative — the 19-month shutdown run **is** the survival test, not a future one. Added the Privacy Guides RSS thread as a concrete recommendation-density target.
+- **§2 Where to Play**: added two primary segments — Pocket refugees (millions displaced 2025-11) and TT-RSS orphans (smaller but high-value, already trust E2E). Added "Apple-ecosystem-only users where NetNewsWire 7 solves the problem for free" to the explicit not-for list — chasing them is a losing fight. Added a new acquisition channel: per-shutdown migration pages (Pocket → FeedZero importer, Omnivore → JSON ingest, TT-RSS → OPML).
+- **§3 How to Win**: anchored the wedge against the Norwegian Consumer Council finding (7/8 AI digest services leak content) — "architecturally impossible" vs "policy impossible" is the rhetorical move. Reframed §3's durability argument with the 19-month shutdown context: every category shutdown is FeedZero's marketing campaign.
+- **§4 Capabilities**: added three rows — Pocket/Omnivore/TT-RSS import paths (highest-leverage live channel); AI/summarization architecture (BYO API key recommended for v1, Ollama as optional config); TTS via Web Speech API. Sharpened the sync-reliability row with the Reeder/NetNewsWire context.
+- **§5 Management Systems**: added competitor-shutdown event as an immediate strategy-review trigger (48-hour SLA) — the migration window is short.
+
+The cascade still composes (§1 → §5). One tension flagged: §3's "operator cannot read your data" + §4's BYO-API-key AI proposal requires the proxy to be provably no-log. That's an implementation work item, not a strategy contradiction.
+
+## Open questions
+
+1. **Direct-page verification methodology.** Can we get past the 403 wall (authenticated MCP fetch? curl via Bash? cached pricing snapshots from Wayback?). Without it we're aggregator-dependent for pricing.
+2. **Pocket importer status.** Does `src/core/opml/url-list-parser.ts` actually accept Pocket's exported HTML/CSV format, or does it require a new adapter? Next run should test with a real Pocket export.
+3. **r/rss + r/RSS_Readers thread scraping.** Reddit blocks WebFetch. Worth investigating an authenticated path so we can quote real community threads in `002` rather than secondary aggregators.
+4. **Privacy Guides community thread content.** The URL is the right channel for our audience but the body is 403'd. Worth a manual snapshot.
+5. **Unread (iOS) + Feedbin pricing.** Both gated. Direct verification needed next run.
+6. **BYO-API-key vs Web LLM vs Ollama**: the §4 proposal is opinionated but unvalidated. Worth a focused `/research-competitors ai-summarization` next month to test against any new entrants and competitor moves.
+7. **Reeder Classic Fever API integration.** If our Hono server exposes a Fever-compatible endpoint, does that meaningfully widen distribution? Quick prototype + user-research worth.
+8. **Wallabag.** Mentioned tangentially as the OSS read-later — should be in `001`'s adjacent column. Add next run.
+
+## Status check
+
+- `git status` confirmed scope: only `docs/strategy/**` modified. <!-- verified pre-write -->
+- Spot-check pricing: cross-verified via ≥3 sources for Feedly, Inoreader, NewsBlur, Readwise Reader, Matter, Instapaper, BazQux, Reeder. **Direct source-page verification blocked by 403** — flagged above as open question 1.
+- Cascade tone check: §3's specific Norwegian-audit framing and §4's named capability gaps read as FeedZero, not as a generic strategy template. Pass.
+- Working tree left dirty for review. Not committed.

--- a/docs/vault-format.md
+++ b/docs/vault-format.md
@@ -1,0 +1,182 @@
+# Vault Format
+
+This document describes FeedZero's encrypted vault format in enough detail that you could implement an independent reader, exporter, or auditor — without our code, without our help, and without our permission.
+
+That's the point. "Exit cost is zero" is one of FeedZero's structural commitments (see [docs/strategy/003-playing-to-win.md](./strategy/003-playing-to-win.md) §3 — How to Win). This page is how we keep it honest.
+
+## Trust model in one paragraph
+
+Your passphrase never leaves your browser. From it we derive — independently — a **vault ID** (a 64-character hex string the server uses to address your blob) and a **vault key** (an AES-GCM-256 key the server never sees). The server stores `(vault ID → encrypted blob)`. Without the passphrase, the server holds opaque ciphertext addressed by an opaque ID. With the passphrase, you can decrypt your vault on any device — or with any compatible implementation you write yourself.
+
+## Key derivation
+
+All derivations are PBKDF2-HMAC-SHA-256 with **600,000 iterations** (`CRYPTO.PBKDF2_ITERATIONS` in `src/utils/constants.ts`). Inputs are UTF-8 encoded.
+
+### Vault ID
+
+```
+salt   = utf8("feedzero:vault-id:v1")          // SYNC.VAULT_ID_SALT
+length = 32 bytes
+bits   = PBKDF2-HMAC-SHA-256(passphrase, salt, iterations=600_000, length=256)
+vault_id_hex = lowercase hex string of bits    // 64 characters
+```
+
+### Encryption salt
+
+A deterministic salt derived for domain separation from the vault ID derivation:
+
+```
+salt   = utf8("feedzero:enc-salt:v1")          // SYNC.ENCRYPTION_SALT_SEED
+length = 16 bytes
+encryption_salt = PBKDF2-HMAC-SHA-256(passphrase, salt, iterations=600_000, length=128)
+```
+
+### Vault key
+
+The AES-GCM-256 key that encrypts the vault payload:
+
+```
+vault_key = PBKDF2-HMAC-SHA-256(
+  passphrase,
+  encryption_salt,                             // from above
+  iterations = 600_000,
+  length     = 256
+)
+algorithm = AES-GCM
+key_length = 256 bits
+```
+
+The three derivations are independent: knowing the vault ID does not reveal the encryption salt, and knowing the encryption salt does not reveal the vault key. Domain separation is achieved by distinct PBKDF2 salts (`"feedzero:vault-id:v1"` vs `"feedzero:enc-salt:v1"`).
+
+Reference: `src/core/sync/vault-crypto.ts` (`deriveVaultId`, `deriveEncryptionSalt`, `deriveVaultKey`).
+
+## Vault payload
+
+The **plaintext** vault, before encryption, is UTF-8 JSON conforming to this shape:
+
+```ts
+interface VaultData {
+  version: number;                 // SYNC.FORMAT_VERSION — currently 1
+  exportedAt: number;              // unix epoch ms when the vault was packed
+  feeds: Feed[];                   // every feed in the vault
+  articles: Article[];             // every article in the vault
+}
+
+interface Feed {
+  id: string;                      // UUID
+  url: string;                     // canonical normalized feed URL
+  title: string;
+  description: string;
+  siteUrl: string;
+  folderId?: string;               // optional — null/undefined = unfiled
+  createdAt: number;               // unix epoch ms
+  updatedAt: number;               // unix epoch ms
+  lastFetchedAt?: number;          // unix epoch ms, last refresh attempt
+  lastSuccessfulFetchAt?: number;  // unix epoch ms, last refresh that returned 2xx
+}
+
+interface Article {
+  id: string;                      // UUID
+  feedId: string;                  // foreign key to Feed.id
+  guid: string;                    // upstream GUID, falls back to link
+  title: string;
+  link: string;
+  content: string;                 // HTML, sanitized before storage
+  summary: string;                 // plaintext or sanitized HTML
+  author: string;
+  publishedAt: number;             // unix epoch ms
+  read: boolean;
+  createdAt: number;               // unix epoch ms when first stored locally
+}
+```
+
+## Encryption
+
+```
+plaintext      = utf8(JSON.stringify(VaultData))
+iv             = 12 random bytes                       // CRYPTO.IV_LENGTH
+ciphertext_aes = AES-GCM-256.encrypt(vault_key, iv, plaintext)
+                  // includes the 16-byte GCM auth tag appended per WebCrypto's
+                  // ArrayBuffer convention
+```
+
+The wire format (what the server actually stores at `/api/sync` for `vaultId`) is JSON:
+
+```ts
+interface EncryptedVault {
+  version: number;                 // SYNC.FORMAT_VERSION — currently 1
+  iv: number[];                    // 12 bytes, expressed as decimal byte array
+  ciphertext: string;              // base64-encoded ciphertext+tag
+}
+```
+
+`iv` is serialized as a JSON array of integers (not base64) for historical reasons; both server and client read/write it as `Array.from(uint8)` / `new Uint8Array(arr)`.
+
+Reference: `src/core/sync/vault-crypto.ts` (`encryptVault`, `decryptVault`), `src/utils/base64.ts`.
+
+## Decryption reference (≈30 lines)
+
+```ts
+import { uint8ArrayToBase64, base64ToUint8Array } from "./base64";
+
+async function deriveBits(passphrase: string, salt: Uint8Array, bytes: number) {
+  const enc = new TextEncoder();
+  const material = await crypto.subtle.importKey(
+    "raw", enc.encode(passphrase), "PBKDF2", false, ["deriveBits"],
+  );
+  return new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "PBKDF2", salt, iterations: 600_000, hash: "SHA-256" },
+    material, bytes * 8,
+  ));
+}
+
+export async function decryptVaultData(passphrase: string, blob: EncryptedVault) {
+  const enc = new TextEncoder();
+  const encSalt = await deriveBits(passphrase, enc.encode("feedzero:enc-salt:v1"), 16);
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"],
+  );
+  const key = await crypto.subtle.deriveKey(
+    { name: "PBKDF2", salt: encSalt, iterations: 600_000, hash: "SHA-256" },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    true, ["decrypt"],
+  );
+  const plaintextBuf = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: new Uint8Array(blob.iv) },
+    key,
+    base64ToUint8Array(blob.ciphertext),
+  );
+  return JSON.parse(new TextDecoder().decode(plaintextBuf)) as VaultData;
+}
+```
+
+That is sufficient to read any FeedZero vault, ours or yours, today and forever as long as `SYNC.FORMAT_VERSION === 1`.
+
+## Local IndexedDB encryption (different format)
+
+The browser-local Dexie database uses a **different** key derivation and storage shape than the sync vault. This document covers only the sync vault — the format that travels over the network and lives on the server.
+
+If you want to read the local Dexie database directly, see `src/core/storage/db.ts` and `src/core/storage/crypto.ts`. The short version: records are stored as `{ id, iv: number[], ciphertext: number[], <hashed index fields> }` using a per-database PBKDF2 salt (`meta.salt`) and HMAC-SHA-256-hashed index fields (so the server-equivalent could query by `url` without ever seeing plaintext URLs).
+
+## Format versioning
+
+`SYNC.FORMAT_VERSION` is incremented when the on-disk shape of `VaultData` changes incompatibly. The current version is **1**.
+
+When we change the format we will:
+
+1. Publish the new version in this document with a side-by-side diff.
+2. Ship a client that reads both the old and new formats for at least one release.
+3. Migrate on first push of the new client.
+
+If you implement a third-party reader, branch on `EncryptedVault.version` and refuse to decrypt unknown versions rather than misinterpreting bytes.
+
+## Things we deliberately do not do
+
+- We do not store an HMAC over the ciphertext separate from the AES-GCM authentication tag. The GCM tag is sufficient for our integrity needs and adding a separate MAC adds key-management complexity for no security gain.
+- We do not store any plaintext metadata server-side. The server holds `vaultId → opaque blob` and that's it. No created-at, no feed count, no user agent, no IP.
+- We do not derive the vault ID from the encryption key. They are derived independently with domain-separated salts so a leak in one cannot trivially reveal the other.
+
+## Audit
+
+The cryptographic claims here are open to independent audit. The reference implementation is short (under 100 lines including comments), is exercised by the test suite in `tests/core/sync/`, and was reviewed during the audit captured in [docs/audit-2026-03-22.md](./audit-2026-03-22.md). Discrepancies between this document and the code are bugs in this document — report them at [github.com/forcingfx/feedzero/issues](https://github.com/forcingfx/feedzero/issues).

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -2,16 +2,37 @@
   "name": "FeedZero",
   "short_name": "FeedZero",
   "description": "Privacy-first RSS reader. Zero distractions. Zero friction. Zero tracking.",
-  "start_url": "/",
+  "start_url": "/feeds",
   "scope": "/",
   "display": "standalone",
-  "theme_color": "#ffffff",
+  "orientation": "any",
   "background_color": "#ffffff",
+  "theme_color": "#ffffff",
   "icons": [
     { "src": "/favicon.ico", "type": "image/x-icon", "sizes": "16x16 32x32" },
     { "src": "/icon-192.png", "type": "image/png", "sizes": "192x192" },
     { "src": "/icon-512.png", "type": "image/png", "sizes": "512x512" },
     { "src": "/icon-192-maskable.png", "type": "image/png", "sizes": "192x192", "purpose": "maskable" },
     { "src": "/icon-512-maskable.png", "type": "image/png", "sizes": "512x512", "purpose": "maskable" }
+  ],
+  "shortcuts": [
+    {
+      "name": "All unread",
+      "short_name": "All",
+      "description": "Jump to the aggregated unread feed",
+      "url": "/feeds/all"
+    },
+    {
+      "name": "Add a feed",
+      "short_name": "Add feed",
+      "description": "Open FeedZero with the add-feed dialog ready",
+      "url": "/feeds?action=add"
+    },
+    {
+      "name": "Release notes",
+      "short_name": "What's new",
+      "description": "Read the FeedZero changelog",
+      "url": "/feeds?changelog=1"
+    }
   ]
 }

--- a/src/components/articles/article-list.tsx
+++ b/src/components/articles/article-list.tsx
@@ -1,15 +1,28 @@
 import { useMemo, useState, useEffect, useRef, useCallback } from "react";
-import { CheckCheck } from "lucide-react";
+import { ArrowUpDown, Check, CheckCheck } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useAppStore } from "@/stores/app-store.ts";
 import { isAggregatedFeedId } from "@/utils/constants.ts";
 import { Button } from "@/components/ui/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu.tsx";
 import { ArticleItem } from "./article-item.tsx";
 import { ArticleGroupSummaryRow } from "./article-group-summary-row.tsx";
 import { groupArticles } from "@/lib/group-articles.ts";
-import type { Article } from "@/types/index.ts";
+import type { Article, ArticleSortMode } from "@/types/index.ts";
+import { ARTICLE_SORT_MODES } from "@/types/index.ts";
+
+const SORT_LABELS: Record<ArticleSortMode, string> = {
+  "newest": "Newest first",
+  "oldest": "Oldest first",
+  "unread-first": "Unread first",
+};
 
 /**
  * Flat list-entry shape: every row the virtualizer renders is either a
@@ -71,6 +84,8 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
   const selectArticle = useArticleStore((s) => s.selectArticle);
   const markAllAsRead = useArticleStore((s) => s.markAllAsRead);
   const isLoading = useArticleStore((s) => s.isLoading);
+  const articleSortMode = useArticleStore((s) => s.articleSortMode);
+  const setArticleSortMode = useArticleStore((s) => s.setArticleSortMode);
   const groupArticleFloods = useAppStore((s) => s.groupArticleFloods);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -242,6 +257,7 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
 
   return (
     <div ref={scrollRef} className="h-full overflow-y-auto relative">
+      <SortMenu mode={articleSortMode} onChange={setArticleSortMode} />
       <ul
         role="listbox"
         aria-label="Articles"
@@ -300,6 +316,41 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
         })}
       </ul>
       <MarkReadPill unreadCount={unreadCount} onMarkAll={markAllAsRead} />
+    </div>
+  );
+}
+
+function SortMenu({
+  mode,
+  onChange,
+}: {
+  mode: ArticleSortMode;
+  onChange: (mode: ArticleSortMode) => void;
+}) {
+  return (
+    <div className="sticky top-0 z-10 flex justify-end px-2 py-1 bg-background/80 backdrop-blur-sm pointer-events-none">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="pointer-events-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+            aria-label={`Sort: ${SORT_LABELS[mode]}`}
+          >
+            <ArrowUpDown className="size-3" />
+            <span>{SORT_LABELS[mode]}</span>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-36">
+          {ARTICLE_SORT_MODES.map((m) => (
+            <DropdownMenuItem key={m} onClick={() => onChange(m)}>
+              <Check
+                className={`size-3.5 mr-1.5 ${mode === m ? "opacity-100" : "opacity-0"}`}
+              />
+              {SORT_LABELS[m]}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/src/components/settings/import-view.tsx
+++ b/src/components/settings/import-view.tsx
@@ -5,6 +5,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { parseOpmlFile } from "@/core/opml/opml-service";
 import { parseUrlList, isOpmlFormat } from "@/core/opml/url-list-parser";
+import { parsePocketExport, isPocketExport } from "@/core/opml/pocket-parser";
 import {
   useImportStore,
   selectTotalCount,
@@ -64,13 +65,24 @@ export function ImportView({ onClose }: ImportViewProps) {
 
   /**
    * Parse the import content into rich entries that carry folder context.
-   * URL-list imports always have folderName=undefined; OPML imports carry
-   * the parent group name when one exists (PR E).
+   * URL-list and Pocket-export imports always have folderName=undefined;
+   * OPML imports carry the parent group name when one exists (PR E).
+   *
+   * Pocket-export detection runs first because the Pocket HTML neither
+   * looks like OPML nor like a URL list — without explicit dispatch we'd
+   * silently get garbage out of parseUrlList.
    */
   const extractEntries = useCallback(
     async (
       content: string,
     ): Promise<Array<{ xmlUrl: string; folderName?: string }>> => {
+      if (isPocketExport(content)) {
+        const result = parsePocketExport(content);
+        if (!result.ok) throw new Error(result.error);
+        // addFeedFlow runs origins through discoverFeed, so an origin like
+        // https://nytimes.com becomes a subscription to the site's RSS.
+        return result.value.map((url) => ({ xmlUrl: url }));
+      }
       if (isOpmlFormat(content)) {
         const result = parseOpmlFile(content);
         if (!result.ok) throw new Error(result.error);
@@ -269,7 +281,7 @@ export function ImportView({ onClose }: ImportViewProps) {
           <input
             ref={fileInputRef}
             type="file"
-            accept=".opml,.xml"
+            accept=".opml,.xml,.html,.htm"
             onChange={handleFileSelect}
             className="hidden"
           />
@@ -292,7 +304,7 @@ export function ImportView({ onClose }: ImportViewProps) {
             <>
               <Upload className="mb-2 size-8 text-muted-foreground" />
               <p className="text-sm text-muted-foreground">
-                Drag and drop an OPML file, or
+                Drag and drop an OPML or Pocket export, or
               </p>
               <Button
                 variant="link"
@@ -301,6 +313,9 @@ export function ImportView({ onClose }: ImportViewProps) {
               >
                 browse to select
               </Button>
+              <p className="mt-2 text-xs text-muted-foreground/70">
+                .opml, .xml, .html
+              </p>
             </>
           )}
         </div>
@@ -308,7 +323,7 @@ export function ImportView({ onClose }: ImportViewProps) {
 
       {inputMode === "text" && (
         <Textarea
-          placeholder="Paste OPML XML or feed URLs (one per line)"
+          placeholder="Paste OPML XML, Pocket HTML export, or feed URLs (one per line)"
           value={textInput}
           onChange={(e) => {
             setTextInput(e.target.value);

--- a/src/components/sidebar/feed-item.tsx
+++ b/src/components/sidebar/feed-item.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Check, MoreHorizontal, Pencil, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
+import { AlertTriangle, Check, MoreHorizontal, Pencil, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils.ts";
 import { useArticleStore, selectUnreadCount } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
+import { isFeedStale } from "@/lib/stale-feed.ts";
 import {
   SidebarMenuAction,
   SidebarMenuBadge,
@@ -92,6 +93,13 @@ export function FeedItem({ feed, isSelected, inFolder = false, sortable = false,
           <FeedFavicon siteUrl={feed.siteUrl} />
           <span className="truncate">{feed.title}</span>
           {isRefreshing && <RefreshCw className="size-3 animate-spin shrink-0 text-muted-foreground" />}
+          {!isRefreshing && isFeedStale(feed) && (
+            <AlertTriangle
+              className="size-3 shrink-0 text-amber-500"
+              aria-label="This feed hasn't updated in over 14 days"
+              data-testid="stale-feed-indicator"
+            />
+          )}
         </SidebarMenuButton>
       )}
       <DropdownMenu>

--- a/src/core/feeds/feed-service.ts
+++ b/src/core/feeds/feed-service.ts
@@ -11,6 +11,7 @@ import {
   addArticles,
   getArticleByGuid,
   updateArticles,
+  updateFeed,
   removeArticlesByFeedId,
 } from "../storage/db.ts";
 import type { Feed, Article } from "../../types/index.ts";
@@ -35,6 +36,34 @@ interface RefreshAllResult {
     updatedCount: number;
     error?: string;
   }>;
+}
+
+/**
+ * Format a non-OK proxy response into a user-facing error.
+ * For 429 / 503 we surface the upstream Retry-After hint as a delta in
+ * seconds so the message tells the user how long to wait, not just the
+ * bare HTTP code. Parsing goes through `parseRetryAfter` so both
+ * delta-seconds and HTTP-date forms work, with the same 24h clamp the
+ * rest of the codebase uses. Reads the header lowercase so the helper
+ * works against both real `Headers` (case-insensitive) and the Map-based
+ * mocks used in some refresh tests.
+ */
+function fetchErrorMessage(
+  response: { status: number; headers?: { get?: (k: string) => string | null } },
+  prefix: string,
+): string {
+  const { status } = response;
+  if (status === 429 || status === 503) {
+    const retryAt = parseRetryAfter(
+      response.headers?.get?.("retry-after") ?? null,
+      Date.now(),
+    );
+    if (retryAt !== null) {
+      const seconds = Math.ceil((retryAt - Date.now()) / 1000);
+      return `${prefix} (HTTP ${status}, retry after ${seconds}s)`;
+    }
+  }
+  return `${prefix} (HTTP ${status})`;
 }
 
 /**
@@ -112,7 +141,7 @@ export async function addFeedFlow(
       const response = await proxyFetch("/api/feed", url);
       if (!response.ok) {
         return err(
-          `The feed at this URL could not be reached (HTTP ${response.status}).`,
+          fetchErrorMessage(response, "The feed at this URL could not be reached"),
         );
       }
       text = await response.text();
@@ -194,7 +223,7 @@ export async function previewFeed(
     const response = await proxyFetch("/api/feed", url);
     if (!response.ok) {
       return err(
-        `The feed at this URL could not be reached (HTTP ${response.status}).`,
+        fetchErrorMessage(response, "The feed at this URL could not be reached"),
       );
     }
     const text = await response.text();
@@ -224,31 +253,32 @@ export async function previewFeed(
 
 /**
  * Refresh a single feed: fetch latest XML, add new articles, update changed ones.
+ * Persists freshness timestamps on every attempt — both for "we tried" (the
+ * stale-indicator floor) and for "the publisher actually responded" (the
+ * stale-indicator threshold). A failing refresh must never clobber a prior
+ * successful timestamp.
  */
 export async function refreshFeed(feed: Feed): Promise<Result<RefreshResult>> {
+  const now = Date.now();
   try {
     const response = await proxyFetch("/api/feed", feed.url);
     if (!response.ok) {
-      // Surface Retry-After when the upstream rate-limits us so the user
-      // sees an actionable hint instead of a generic HTTP code. Per
-      // feedback #97 — self-host bulk refresh against fresh IPs trips
-      // upstream WAFs and the user needs to know when to retry.
-      if (response.status === 429) {
-        const retryAt = parseRetryAfter(
-          response.headers?.get?.("retry-after"),
-          Date.now(),
-        );
-        if (retryAt !== null) {
-          const seconds = Math.ceil((retryAt - Date.now()) / 1000);
-          return err(`Upstream rate-limited (429). Retry in ${seconds}s.`);
-        }
-        return err("Upstream rate-limited (429). Retry later.");
-      }
-      return err(`Failed to fetch feed (HTTP ${response.status})`);
+      // Always record the attempt so the stale-indicator clock keeps
+      // moving; never clobber a prior success timestamp. The user-facing
+      // error message surfaces Retry-After when the upstream sent one
+      // (feedback #97: self-host bulk refresh against fresh IPs trips
+      // upstream WAFs and the user needs to know when to retry).
+      await persistFreshness(feed, { fetchedAt: now, successfulAt: null });
+      return err(fetchErrorMessage(response, "Failed to fetch feed"));
     }
     const text = await response.text();
     const parseResult = parse(text, feed.url);
-    if (!parseResult.ok) return err(parseResult.error);
+    if (!parseResult.ok) {
+      // HTTP succeeded but content was unparseable — the publisher is alive,
+      // so this still counts as a successful reach.
+      await persistFreshness(feed, { fetchedAt: now, successfulAt: now });
+      return err(parseResult.error);
+    }
 
     const parsedArticles = parseResult.value.articles;
     const newArticles = [];
@@ -294,13 +324,32 @@ export async function refreshFeed(feed: Feed): Promise<Result<RefreshResult>> {
       await updateArticles(updatedArticles);
     }
 
+    await persistFreshness(feed, { fetchedAt: now, successfulAt: now });
+
     return ok({
       newCount: created.length,
       updatedCount: updatedArticles.length,
     });
   } catch (e) {
+    // Network / transport-layer failure: record the attempt but keep any
+    // prior success timestamp so we don't reset the stale-indicator clock.
+    await persistFreshness(feed, { fetchedAt: now, successfulAt: null });
     return err(`Refresh failed: ${(e as Error).message}`);
   }
+}
+
+/**
+ * Mutate `feed` in place with new freshness timestamps and persist via
+ * updateFeed. Passing `successfulAt: null` keeps the prior value so a
+ * transient failure doesn't reset the stale-indicator clock.
+ */
+async function persistFreshness(
+  feed: Feed,
+  ts: { fetchedAt: number; successfulAt: number | null },
+): Promise<void> {
+  feed.lastFetchedAt = ts.fetchedAt;
+  if (ts.successfulAt !== null) feed.lastSuccessfulFetchAt = ts.successfulAt;
+  await updateFeed(feed);
 }
 
 /**
@@ -375,7 +424,7 @@ export async function reloadFeed(
     } else {
       const response = await proxyFetch("/api/feed", feed.url);
       if (!response.ok) {
-        return err(`Failed to fetch feed (HTTP ${response.status})`);
+        return err(fetchErrorMessage(response, "Failed to fetch feed"));
       }
       text = await response.text();
     }

--- a/src/core/opml/pocket-parser.ts
+++ b/src/core/opml/pocket-parser.ts
@@ -1,0 +1,82 @@
+import { ok, err } from "../../utils/result.ts";
+import type { Result } from "../../utils/result.ts";
+
+/**
+ * Parser for Pocket's HTML export (the file you get from
+ * getpocket.com/export). The export is a flat list of *saved articles*,
+ * but FeedZero is an RSS reader — we don't want 5,000 individual article
+ * subscriptions, we want feed subscriptions to the *sites* the user
+ * cared about.
+ *
+ * So this parser extracts every saved article href, derives the origin
+ * (scheme://host), dedupes, and returns the origin list. The import
+ * pipeline then runs each origin through addFeedFlow, which already
+ * has feed-discovery built in.
+ *
+ * Pocket's shutdown (2025-11-12) made this format historically frozen,
+ * which is convenient: we don't need to chase format changes.
+ */
+
+/**
+ * Detect a Pocket HTML export. Heuristic: the file contains anchors with
+ * a `time_added` attribute — a Pocket-specific marker. We also accept the
+ * historical title marker as a secondary signal.
+ */
+export function isPocketExport(text: string): boolean {
+  if (!text) return false;
+  const head = text.slice(0, 4096).toLowerCase();
+  if (head.includes("<title>pocket export</title>")) return true;
+  // The time_added attribute appears on every saved-link anchor in a
+  // Pocket export and is not standard HTML — strong signal of the format.
+  return /<a[^>]+time_added=/i.test(text);
+}
+
+/**
+ * Extract unique origin URLs (scheme://host) from a Pocket HTML export.
+ * Returns origins sorted alphabetically for deterministic output.
+ */
+export function parsePocketExport(html: string): Result<string[]> {
+  if (!html || typeof html !== "string" || !html.trim()) {
+    return err("Input is empty");
+  }
+
+  let doc: Document;
+  try {
+    doc = new DOMParser().parseFromString(html, "text/html");
+  } catch (e) {
+    return err(`Failed to parse Pocket export: ${(e as Error).message}`);
+  }
+
+  const anchors = doc.querySelectorAll("a[href]");
+  if (anchors.length === 0) {
+    return err("No saved links found in Pocket export");
+  }
+
+  const origins = new Set<string>();
+  for (const a of Array.from(anchors)) {
+    const href = a.getAttribute("href")?.trim();
+    if (!href) continue;
+    const origin = toOrigin(href);
+    if (origin) origins.add(origin);
+  }
+
+  if (origins.size === 0) {
+    return err("No valid http(s) links found in Pocket export");
+  }
+
+  return ok(Array.from(origins).sort());
+}
+
+/**
+ * Reduce a URL to scheme://host. Returns null for invalid URLs or non-http(s)
+ * schemes (mailto:, javascript:, data:, etc.).
+ */
+function toOrigin(href: string): string | null {
+  try {
+    const url = new URL(href);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/core/proxy/proxy-handler.ts
+++ b/src/core/proxy/proxy-handler.ts
@@ -133,13 +133,13 @@ export async function handleProxyRequest(
       const cleaned = cleanFeedContent(text);
       return new Response(cleaned, {
         status: response.status,
-        headers: { "Content-Type": contentType },
+        headers: buildResponseHeaders(contentType, response),
       });
     }
 
     return new Response(body, {
       status: response.status,
-      headers: { "Content-Type": contentType },
+      headers: buildResponseHeaders(contentType, response),
     });
   } catch (e) {
     const message = e instanceof Error ? e.message : "Unknown error";
@@ -154,6 +154,23 @@ export async function handleProxyRequest(
     );
     return new Response(`Proxy error: ${message}`, { status: 502 });
   }
+}
+
+/**
+ * Build the response headers for an upstream passthrough. Always sets
+ * Content-Type. For 429/503, propagates Retry-After verbatim (RFC 7231 §7.1.3)
+ * so the client can back off instead of hammering the origin.
+ */
+function buildResponseHeaders(
+  contentType: string,
+  upstream: Response,
+): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": contentType };
+  if (upstream.status === 429 || upstream.status === 503) {
+    const retryAfter = upstream.headers.get("Retry-After");
+    if (retryAfter) headers["Retry-After"] = retryAfter;
+  }
+  return headers;
 }
 
 /** Extract target URL from POST body (preferred) or GET query param (fallback). */

--- a/src/lib/stale-feed.ts
+++ b/src/lib/stale-feed.ts
@@ -1,0 +1,26 @@
+import type { Feed } from "@/types/index.ts";
+
+/**
+ * A feed is considered "stale" after 14 days of silent failure — i.e. we
+ * tried to fetch since then (lastFetchedAt is recent) but never succeeded
+ * (lastSuccessfulFetchAt is older than the threshold or undefined). The
+ * threshold is generous because legitimate feeds publish irregularly; we
+ * want to surface dead RSS endpoints, not impatient ones.
+ */
+export const STALE_FEED_THRESHOLD_MS = 14 * 24 * 60 * 60 * 1000;
+
+/**
+ * True if the feed was last reached more than 14 days ago AND we have at
+ * least one refresh attempt since then. A brand-new feed (no
+ * lastFetchedAt yet) is not stale — we haven't tried.
+ */
+export function isFeedStale(feed: Feed, now: number = Date.now()): boolean {
+  const fetched = feed.lastFetchedAt;
+  if (fetched === undefined) return false;
+  const success = feed.lastSuccessfulFetchAt;
+  if (success === undefined) {
+    // We've tried, never succeeded. Stale once the first attempt is old.
+    return now - fetched > STALE_FEED_THRESHOLD_MS;
+  }
+  return now - success > STALE_FEED_THRESHOLD_MS;
+}

--- a/src/stores/article-store.ts
+++ b/src/stores/article-store.ts
@@ -8,11 +8,13 @@ import { useSyncStore } from "./sync-store.ts";
 import { useFeedStore } from "./feed-store.ts";
 import {
   ALL_FEEDS_ID,
+  LOCAL_STORAGE,
   isFolderFeedId,
   isAggregatedFeedId,
   fromFolderFeedId,
 } from "../utils/constants.ts";
-import type { Article } from "../types/index.ts";
+import type { Article, ArticleSortMode } from "../types/index.ts";
+import { ARTICLE_SORT_MODES } from "../types/index.ts";
 
 /**
  * `articlesByFeedId` is the single source of truth for loaded article data,
@@ -35,12 +37,16 @@ interface ArticleStore {
   articles: Article[];
   selectedArticle: Article | null;
   isLoading: boolean;
+  /** User-chosen sort order for the visible article list; persisted. */
+  articleSortMode: ArticleSortMode;
   /** Preload every article into the store; used on startup and on refresh. */
   preloadAll: () => Promise<void>;
   loadArticles: (feedId: string) => Promise<void>;
   selectArticle: (article: Article | null) => Promise<void>;
   markAsRead: (articleId: string) => Promise<void>;
   markAllAsRead: () => Promise<void>;
+  /** Switch sort order; re-derives the visible list immediately. No-op on unknown modes. */
+  setArticleSortMode: (mode: ArticleSortMode) => void;
 }
 
 /** Delay before an opened article is marked as read (ms). */
@@ -63,9 +69,40 @@ export function selectUnreadCount(
   return count;
 }
 
-/** Sort articles by publishedAt descending (most recent first). */
-function sortArticles(articles: Article[]): Article[] {
-  return [...articles].sort((a, b) => (b.publishedAt ?? 0) - (a.publishedAt ?? 0));
+/**
+ * Sort articles according to the current user-chosen mode.
+ * "newest" — publishedAt descending (the historical default).
+ * "oldest" — publishedAt ascending.
+ * "unread-first" — unread group first, read group second; newest-first within each.
+ */
+function sortArticles(articles: Article[], mode: ArticleSortMode = "newest"): Article[] {
+  const newestFirst = (a: Article, b: Article) =>
+    (b.publishedAt ?? 0) - (a.publishedAt ?? 0);
+  if (mode === "oldest") {
+    return [...articles].sort(
+      (a, b) => (a.publishedAt ?? 0) - (b.publishedAt ?? 0),
+    );
+  }
+  if (mode === "unread-first") {
+    return [...articles].sort((a, b) => {
+      if (a.read !== b.read) return a.read ? 1 : -1;
+      return newestFirst(a, b);
+    });
+  }
+  return [...articles].sort(newestFirst);
+}
+
+/** Read the persisted sort mode, or fall back to "newest" if absent / invalid. */
+function loadPersistedSortMode(): ArticleSortMode {
+  try {
+    const raw = globalThis.localStorage?.getItem(LOCAL_STORAGE.ARTICLE_SORT_MODE);
+    if (raw && (ARTICLE_SORT_MODES as readonly string[]).includes(raw)) {
+      return raw as ArticleSortMode;
+    }
+  } catch {
+    // localStorage unavailable (private mode / SSR / sandboxed iframe) — fall through.
+  }
+  return "newest";
 }
 
 /** Group an article list into per-feed buckets. */
@@ -80,16 +117,19 @@ function groupByFeedId(articles: Article[]): Record<string, Article[]> {
 /**
  * Derive the visible article list for the requested (possibly aggregated)
  * feed id. ALL_FEEDS_ID flat-maps every loaded feed; folder feed ids restrict
- * to folder members; a concrete feed id returns that feed's list directly.
+ * to folder members; a concrete feed id returns that feed's list.
+ * All paths apply the current sort mode so switching the mode always
+ * re-orders the visible list.
  */
 function deriveVisibleArticles(
   articlesByFeedId: Record<string, Article[]>,
   feedId: string,
+  sortMode: ArticleSortMode,
 ): Article[] {
   if (feedId === ALL_FEEDS_ID) {
     const flat: Article[] = [];
     for (const list of Object.values(articlesByFeedId)) flat.push(...list);
-    return sortArticles(flat);
+    return sortArticles(flat, sortMode);
   }
   if (isFolderFeedId(feedId)) {
     const folderId = fromFolderFeedId(feedId)!;
@@ -103,9 +143,9 @@ function deriveVisibleArticles(
     for (const [id, list] of Object.entries(articlesByFeedId)) {
       if (memberIds.has(id)) flat.push(...list);
     }
-    return sortArticles(flat);
+    return sortArticles(flat, sortMode);
   }
-  return articlesByFeedId[feedId] ?? [];
+  return sortArticles(articlesByFeedId[feedId] ?? [], sortMode);
 }
 
 /** Replace articles for a set of feeds and refresh the visible list. */
@@ -138,6 +178,7 @@ export const useArticleStore = create<ArticleStore>((set, get) => ({
   articles: [],
   selectedArticle: null,
   isLoading: false,
+  articleSortMode: loadPersistedSortMode(),
 
   preloadAll: async () => {
     const result = await getAllArticles();
@@ -148,7 +189,12 @@ export const useArticleStore = create<ArticleStore>((set, get) => ({
   loadArticles: async (feedId) => {
     // Show whatever we already have for this view instantly — derived from
     // the source of truth, no separate cache to keep in sync.
-    const cachedVisible = deriveVisibleArticles(get().articlesByFeedId, feedId);
+    const sortMode = get().articleSortMode;
+    const cachedVisible = deriveVisibleArticles(
+      get().articlesByFeedId,
+      feedId,
+      sortMode,
+    );
     set({
       articles: cachedVisible,
       selectedArticle: null,
@@ -184,7 +230,7 @@ export const useArticleStore = create<ArticleStore>((set, get) => ({
     const nextByFeed = mergeFetchedArticles(get(), feedId, fetched);
     set({
       articlesByFeedId: nextByFeed,
-      articles: deriveVisibleArticles(nextByFeed, feedId),
+      articles: deriveVisibleArticles(nextByFeed, feedId, get().articleSortMode),
       isLoading: false,
     });
   },
@@ -277,6 +323,25 @@ export const useArticleStore = create<ArticleStore>((set, get) => ({
       await updateArticle({ ...article, read: true });
     }
     useSyncStore.getState().scheduleSyncPush();
+  },
+
+  setArticleSortMode: (mode) => {
+    // Guard so a typo or stale persisted value (after we drop a mode in a
+    // future version) doesn't corrupt the store with an unknown literal.
+    if (!(ARTICLE_SORT_MODES as readonly string[]).includes(mode)) return;
+    try {
+      globalThis.localStorage?.setItem(LOCAL_STORAGE.ARTICLE_SORT_MODE, mode);
+    } catch {
+      // localStorage write failed (private mode / quota) — keep the in-memory
+      // change anyway so the current session reflects the user's choice.
+    }
+    // Re-sort the visible list in place. The set of visible articles doesn't
+    // change with sort mode — only their order — so we don't need to know
+    // the active feed id to do this correctly.
+    set({
+      articleSortMode: mode,
+      articles: sortArticles(get().articles, mode),
+    });
   },
 }));
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,10 @@ export interface Feed {
   preferFullText?: boolean;
   createdAt: number;
   updatedAt: number;
+  /** Unix epoch ms of the last refresh attempt, success or failure. */
+  lastFetchedAt?: number;
+  /** Unix epoch ms of the last refresh attempt that returned HTTP 2xx. */
+  lastSuccessfulFetchAt?: number;
 }
 
 export interface Folder {
@@ -41,6 +45,19 @@ export interface CreateFeedInput {
 }
 
 export type FeedSortMode = "name" | "count" | "custom";
+
+/**
+ * How the article list is ordered. Persisted to localStorage as a user
+ * preference. "newest" preserves the historical default; "unread-first"
+ * groups unread before read, then newest-first within each group.
+ */
+export type ArticleSortMode = "newest" | "oldest" | "unread-first";
+
+export const ARTICLE_SORT_MODES: readonly ArticleSortMode[] = [
+  "newest",
+  "oldest",
+  "unread-first",
+] as const;
 
 export interface CreateArticleInput {
   feedId: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -70,6 +70,7 @@ export const LOCAL_STORAGE = {
   FOLDER_CUSTOM_ORDER: "feedzero:folder-custom-order",
   AUTO_ORGANIZE_DISMISSED_COUNT: "feedzero:auto-organize-dismissed-count",
   GROUP_ARTICLE_FLOODS: "feedzero:group-article-floods",
+  ARTICLE_SORT_MODE: "feedzero:article-sort-mode",
 } as const;
 
 /**

--- a/tests/components/settings/import-view-folders.test.tsx
+++ b/tests/components/settings/import-view-folders.test.tsx
@@ -83,7 +83,7 @@ describe("ImportView — preserves OPML folder structure (PR E)", () => {
     render(<ImportView onClose={() => {}} />);
 
     await user.click(screen.getByLabelText(/paste text/i));
-    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    const textarea = screen.getByPlaceholderText(/paste opml/i);
     await user.click(textarea);
     await user.paste(FOLDERED_OPML);
     await user.click(screen.getByRole("button", { name: /import feeds/i }));

--- a/tests/components/settings/import-view-quota.test.tsx
+++ b/tests/components/settings/import-view-quota.test.tsx
@@ -73,7 +73,7 @@ describe("ImportView quota refusal", () => {
       { length: 10 },
       (_, i) => `https://example.com/import-${i}.xml`,
     ).join("\n");
-    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    const textarea = screen.getByPlaceholderText(/paste opml/i);
     await user.click(textarea);
     await user.paste(ten);
 
@@ -98,7 +98,7 @@ describe("ImportView quota refusal", () => {
       { length: 4 },
       (_, i) => `https://example.com/fits-${i}.xml`,
     ).join("\n");
-    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    const textarea = screen.getByPlaceholderText(/paste opml/i);
     await user.click(textarea);
     await user.paste(four);
 
@@ -120,7 +120,7 @@ describe("ImportView quota refusal", () => {
       { length: 50 },
       (_, i) => `https://example.com/paid-${i}.xml`,
     ).join("\n");
-    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    const textarea = screen.getByPlaceholderText(/paste opml/i);
     await user.click(textarea);
     await user.paste(fifty);
 
@@ -144,7 +144,7 @@ describe("ImportView quota refusal", () => {
       { length: 50 },
       (_, i) => `https://example.com/prelaunch-${i}.xml`,
     ).join("\n");
-    const textarea = screen.getByPlaceholderText(/paste opml xml or feed urls/i);
+    const textarea = screen.getByPlaceholderText(/paste opml/i);
     await user.click(textarea);
     await user.paste(fifty);
 

--- a/tests/core/feeds/feed-service.test.js
+++ b/tests/core/feeds/feed-service.test.js
@@ -91,6 +91,10 @@ vi.mock("../../../src/core/storage/db.ts", () => {
       feeds.set(feed.url, feed);
       return { ok: true, value: true };
     }),
+    updateFeed: vi.fn(async (feed) => {
+      feeds.set(feed.url, feed);
+      return { ok: true, value: true };
+    }),
     addArticles: vi.fn(async (arts) => {
       for (const a of arts) articles.set(a.id, a);
       return { ok: true, value: true };
@@ -535,6 +539,127 @@ describe("refreshFeed", () => {
     expect(isErr(result)).toBe(true);
     expect(result.error).toMatch(/Refresh failed/);
     expect(result.error).toMatch(/connection reset/);
+  });
+
+  it("surfaces upstream Retry-After seconds when the server returns 429", async () => {
+    // The proxy propagates Retry-After verbatim for 429/503. Surfacing it
+    // in the error message lets the UI tell the user "this feed asked us
+    // to back off for N seconds" rather than the bare HTTP code.
+    const feed = await addTestFeed();
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Headers({ "Retry-After": "60" }),
+    });
+
+    const result = await refreshFeed(feed);
+    expect(isErr(result)).toBe(true);
+    expect(result.error).toMatch(/429/);
+    expect(result.error).toMatch(/retry after 60s/i);
+  });
+
+  it("surfaces upstream Retry-After seconds when the server returns 503", async () => {
+    const feed = await addTestFeed();
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      headers: new Headers({ "Retry-After": "30" }),
+    });
+
+    const result = await refreshFeed(feed);
+    expect(isErr(result)).toBe(true);
+    expect(result.error).toMatch(/503/);
+    expect(result.error).toMatch(/retry after 30s/i);
+  });
+
+  it("falls back to bare HTTP status when Retry-After is absent", async () => {
+    const feed = await addTestFeed();
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Headers(),
+    });
+
+    const result = await refreshFeed(feed);
+    expect(isErr(result)).toBe(true);
+    expect(result.error).toMatch(/429/);
+    expect(result.error).not.toMatch(/retry after/i);
+  });
+
+  describe("freshness timestamps", () => {
+    // Stale-feed UI: every refresh must persist when we last reached the
+    // publisher so the sidebar can show a stale indicator after N days of
+    // silent failure. Two timestamps because they answer different questions:
+    //   lastFetchedAt          → "did we even try recently?"
+    //   lastSuccessfulFetchAt  → "did the publisher actually respond?"
+    it("records both lastFetchedAt and lastSuccessfulFetchAt on success", async () => {
+      const before = Date.now();
+      const feed = await addTestFeed();
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(ATOM_XML),
+      });
+      await refreshFeed(feed);
+
+      expect(db.updateFeed).toHaveBeenCalled();
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.lastFetchedAt).toBeGreaterThanOrEqual(before);
+      expect(lastCall.lastSuccessfulFetchAt).toBeGreaterThanOrEqual(before);
+    });
+
+    it("records only lastFetchedAt on HTTP failure (publisher unreachable)", async () => {
+      const feed = await addTestFeed();
+      const baselineSuccess = feed.lastSuccessfulFetchAt; // undefined for fresh feed
+      const before = Date.now();
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        headers: new Headers(),
+      });
+      await refreshFeed(feed);
+
+      expect(db.updateFeed).toHaveBeenCalled();
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.lastFetchedAt).toBeGreaterThanOrEqual(before);
+      expect(lastCall.lastSuccessfulFetchAt).toBe(baselineSuccess);
+    });
+
+    it("records only lastFetchedAt when fetch throws (network error)", async () => {
+      const feed = await addTestFeed();
+      const before = Date.now();
+
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("connection reset"));
+      await refreshFeed(feed);
+
+      expect(db.updateFeed).toHaveBeenCalled();
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.lastFetchedAt).toBeGreaterThanOrEqual(before);
+      expect(lastCall.lastSuccessfulFetchAt).toBeUndefined();
+    });
+
+    it("preserves a prior lastSuccessfulFetchAt across a failing refresh", async () => {
+      // Feed has been successfully fetched in the past; a transient failure
+      // must not clobber that history — the stale-indicator threshold counts
+      // from the prior success.
+      const feed = await addTestFeed();
+      const yesterday = Date.now() - 24 * 60 * 60 * 1000;
+      feed.lastSuccessfulFetchAt = yesterday;
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+      });
+      await refreshFeed(feed);
+
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.lastSuccessfulFetchAt).toBe(yesterday);
+    });
   });
 });
 

--- a/tests/core/opml/pocket-parser.test.ts
+++ b/tests/core/opml/pocket-parser.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePocketExport,
+  isPocketExport,
+} from "../../../src/core/opml/pocket-parser.ts";
+
+const SAMPLE_POCKET_HTML = `<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Pocket Export</title>
+</head>
+<body>
+<h1>Unread</h1>
+<ul>
+<li><a href="https://www.nytimes.com/2024/04/01/world/example.html" time_added="1712000000" tags="">NYT Article</a></li>
+<li><a href="https://www.theguardian.com/article-1" time_added="1712010000" tags="">Guardian Article</a></li>
+<li><a href="https://substack.com/p/whatever" time_added="1712020000" tags="">Subs Article</a></li>
+</ul>
+<h1>Read Archive</h1>
+<ul>
+<li><a href="https://www.nytimes.com/2024/04/02/world/another.html" time_added="1712030000" tags="">Another NYT</a></li>
+<li><a href="https://writer.substack.com/p/post" time_added="1712040000" tags="">Subdomain Substack</a></li>
+</ul>
+</body>
+</html>`;
+
+describe("isPocketExport", () => {
+  it("recognises an export by the time_added attribute marker", () => {
+    expect(isPocketExport(SAMPLE_POCKET_HTML)).toBe(true);
+  });
+
+  it("recognises an export by the legacy title marker", () => {
+    const minimal = "<html><head><title>Pocket Export</title></head><body></body></html>";
+    expect(isPocketExport(minimal)).toBe(true);
+  });
+
+  it("rejects plain HTML without the Pocket markers", () => {
+    const plain = "<html><body><a href='https://example.com'>Link</a></body></html>";
+    expect(isPocketExport(plain)).toBe(false);
+  });
+
+  it("rejects empty input", () => {
+    expect(isPocketExport("")).toBe(false);
+  });
+});
+
+describe("parsePocketExport", () => {
+  it("extracts unique origins, collapsing multiple articles from one site", () => {
+    const result = parsePocketExport(SAMPLE_POCKET_HTML);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([
+      "https://substack.com",
+      "https://writer.substack.com",
+      "https://www.nytimes.com",
+      "https://www.theguardian.com",
+    ]);
+  });
+
+  it("preserves subdomains (writer.substack.com is distinct from substack.com)", () => {
+    const html = `<a href="https://writer.substack.com/p/1" time_added="1">A</a>
+<a href="https://substack.com/inbox" time_added="2">B</a>`;
+    const result = parsePocketExport(html);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toContain("https://writer.substack.com");
+    expect(result.value).toContain("https://substack.com");
+  });
+
+  it("skips non-http(s) hrefs (mailto:, javascript:, data:)", () => {
+    const html = `<a href="mailto:foo@example.com">Mail</a>
+<a href="javascript:void(0)">JS</a>
+<a href="data:text/plain,hello">Data</a>
+<a href="https://example.com/article" time_added="1">Real</a>`;
+    const result = parsePocketExport(html);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(["https://example.com"]);
+  });
+
+  it("returns err on empty input", () => {
+    const result = parsePocketExport("");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/empty/i);
+  });
+
+  it("returns err when the file contains no links", () => {
+    const result = parsePocketExport("<html><body><p>Nothing here</p></body></html>");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/no saved links/i);
+  });
+
+  it("returns err when every href is non-http(s)", () => {
+    const result = parsePocketExport(
+      '<a href="mailto:a@b.com">x</a><a href="javascript:1">y</a>',
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/no valid http/i);
+  });
+});

--- a/tests/core/proxy/proxy-handler.test.ts
+++ b/tests/core/proxy/proxy-handler.test.ts
@@ -113,6 +113,89 @@ describe("handleProxyRequest", () => {
   });
 });
 
+describe("upstream rate-limit + retry signalling (RFC 7231 §7.1.3)", () => {
+  // RFC 7231 §7.1.3: 429 and 503 SHOULD carry Retry-After so well-behaved
+  // clients can back off. The proxy must propagate that header verbatim so
+  // the client (feed-service) can honour it instead of hammering the source.
+  it("passes Retry-After through on upstream 429", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("Too Many Requests", {
+        status: 429,
+        headers: { "Retry-After": "120" },
+      }),
+    );
+
+    const req = new Request("http://localhost/api/feed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/feed.xml" }),
+    });
+    const res = await handleProxyRequest(req, "text/xml");
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("120");
+  });
+
+  it("passes Retry-After through on upstream 503", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("Service Unavailable", {
+        status: 503,
+        headers: { "Retry-After": "30" },
+      }),
+    );
+
+    const req = new Request("http://localhost/api/feed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/feed.xml" }),
+    });
+    const res = await handleProxyRequest(req, "text/xml");
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("does not cache 429/503 responses", async () => {
+    // Caching a rate-limit response would hide a transient block from the
+    // user for the cache TTL and prevent retry once Retry-After elapses.
+    const setSpy = vi.fn();
+    const cache = {
+      get: vi.fn().mockReturnValue(undefined),
+      set: setSpy,
+      getStats: vi.fn().mockReturnValue([]),
+      size: 0,
+    };
+    fetchSpy.mockResolvedValue(
+      new Response("Too Many Requests", {
+        status: 429,
+        headers: { "Retry-After": "60" },
+      }),
+    );
+
+    const req = new Request("http://localhost/api/feed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/feed.xml" }),
+    });
+    await handleProxyRequest(req, "text/xml", { cache });
+
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("works without Retry-After (header is optional in RFC)", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("Too Many Requests", { status: 429 }),
+    );
+
+    const req = new Request("http://localhost/api/feed", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/feed.xml" }),
+    });
+    const res = await handleProxyRequest(req, "text/xml");
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeNull();
+  });
+});
+
 describe("content cleaning", () => {
   it("strips tracking pixels from feed responses when cleanContent is true", async () => {
     const feedXml = `<rss><channel><item><description><![CDATA[<p>Hello</p><img src="https://pixel.quantserve.com/p.gif" width="1" height="1">]]></description></item></channel></rss>`;

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -67,7 +67,7 @@ test.describe("Import feeds", () => {
     // Switch the Import card to text-paste mode.
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder("Paste OPML XML or feed URLs (one per line)")
+      .getByPlaceholder("Paste OPML XML, Pocket HTML export, or feed URLs (one per line)")
       .fill(SAMPLE_OPML);
     await page.getByRole("button", { name: "Import feeds" }).click();
 
@@ -84,7 +84,7 @@ test.describe("Import feeds", () => {
 
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder("Paste OPML XML or feed URLs (one per line)")
+      .getByPlaceholder("Paste OPML XML, Pocket HTML export, or feed URLs (one per line)")
       .fill(SAMPLE_URL_LIST);
     await page.getByRole("button", { name: "Import feeds" }).click();
 
@@ -106,7 +106,7 @@ test.describe("Import feeds", () => {
     await goToImportExportTab(page);
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder("Paste OPML XML or feed URLs (one per line)")
+      .getByPlaceholder("Paste OPML XML, Pocket HTML export, or feed URLs (one per line)")
       .fill("# just a comment\n\n# another comment");
     await page.getByRole("button", { name: "Import feeds" }).click();
 
@@ -119,7 +119,7 @@ test.describe("Import feeds", () => {
 
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder("Paste OPML XML or feed URLs (one per line)")
+      .getByPlaceholder("Paste OPML XML, Pocket HTML export, or feed URLs (one per line)")
       .fill("https://example.com/feed");
     await page.getByRole("button", { name: "Import feeds" }).click();
 

--- a/tests/lib/stale-feed.test.ts
+++ b/tests/lib/stale-feed.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  isFeedStale,
+  STALE_FEED_THRESHOLD_MS,
+} from "../../src/lib/stale-feed.ts";
+import type { Feed } from "../../src/types/index.ts";
+
+const baseFeed: Feed = {
+  id: "f1",
+  url: "https://example.com/feed.xml",
+  title: "Example",
+  description: "",
+  siteUrl: "https://example.com",
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+describe("isFeedStale", () => {
+  it("a brand-new feed (never refreshed) is not stale", () => {
+    expect(isFeedStale({ ...baseFeed })).toBe(false);
+  });
+
+  it("a recently successful feed is not stale", () => {
+    const now = 1_700_000_000_000;
+    expect(
+      isFeedStale(
+        {
+          ...baseFeed,
+          lastFetchedAt: now,
+          lastSuccessfulFetchAt: now,
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("a feed whose last success was just over 14 days ago is stale", () => {
+    const now = 1_700_000_000_000;
+    expect(
+      isFeedStale(
+        {
+          ...baseFeed,
+          lastFetchedAt: now,
+          lastSuccessfulFetchAt: now - STALE_FEED_THRESHOLD_MS - 1,
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("a feed that was tried recently but has never succeeded is stale only after the first attempt ages out", () => {
+    const now = 1_700_000_000_000;
+    const recentAttempt = {
+      ...baseFeed,
+      lastFetchedAt: now - 1000, // tried 1 second ago, never succeeded
+    };
+    expect(isFeedStale(recentAttempt, now)).toBe(false);
+
+    const oldAttempt = {
+      ...baseFeed,
+      lastFetchedAt: now - STALE_FEED_THRESHOLD_MS - 1,
+    };
+    expect(isFeedStale(oldAttempt, now)).toBe(true);
+  });
+});

--- a/tests/pwa-manifest.test.ts
+++ b/tests/pwa-manifest.test.ts
@@ -1,0 +1,94 @@
+/**
+ * PWA manifest contract test.
+ *
+ * The manifest enables (a) installable PWA shell, (b) home-screen app
+ * shortcuts (long-press on iOS 16+ / Android, right-click on Windows) for
+ * the most-used flows. If a future edit drops the shortcuts or the manifest
+ * link, mobile users silently lose discoverability without any visible UI
+ * regression — this test guards both.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const INDEX_HTML = readFileSync(
+  resolve(__dirname, "..", "index.html"),
+  "utf-8",
+);
+
+const MANIFEST = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "..", "public", "manifest.webmanifest"),
+    "utf-8",
+  ),
+);
+
+describe("PWA manifest wiring", () => {
+  it("index.html links the manifest", () => {
+    expect(INDEX_HTML).toMatch(
+      /<link[^>]*rel=["']manifest["'][^>]*href=["']\/manifest\.webmanifest["']/,
+    );
+  });
+});
+
+describe("manifest.webmanifest content", () => {
+  it("declares standalone display with start_url that lands on the feeds view", () => {
+    expect(MANIFEST.display).toBe("standalone");
+    expect(MANIFEST.start_url).toBe("/feeds");
+  });
+
+  it("supplies name + short_name + description so installers render proper labels", () => {
+    expect(MANIFEST.name).toBe("FeedZero");
+    expect(MANIFEST.short_name).toBe("FeedZero");
+    expect(typeof MANIFEST.description).toBe("string");
+    expect(MANIFEST.description.length).toBeGreaterThan(0);
+  });
+
+  it("provides at least one icon installers can use", () => {
+    expect(Array.isArray(MANIFEST.icons)).toBe(true);
+    expect(MANIFEST.icons.length).toBeGreaterThan(0);
+    for (const icon of MANIFEST.icons) {
+      expect(icon.src).toMatch(/^\//);
+      expect(icon.type).toMatch(/^image\//);
+    }
+  });
+});
+
+describe("manifest shortcuts", () => {
+  // Long-press app icon (iOS 16+/Android) / right-click (Win) reveals these.
+  // Each shortcut needs a name, a short_name (chip label), and a URL inside
+  // our routing scope.
+  it("ships the three quick-access shortcuts", () => {
+    expect(Array.isArray(MANIFEST.shortcuts)).toBe(true);
+    expect(MANIFEST.shortcuts.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("each shortcut has name, short_name, and URL", () => {
+    for (const shortcut of MANIFEST.shortcuts) {
+      expect(typeof shortcut.name).toBe("string");
+      expect(shortcut.name.length).toBeGreaterThan(0);
+      expect(typeof shortcut.short_name).toBe("string");
+      expect(shortcut.short_name.length).toBeGreaterThan(0);
+      expect(typeof shortcut.url).toBe("string");
+      expect(shortcut.url.startsWith("/")).toBe(true);
+    }
+  });
+
+  it("includes the All-unread shortcut pointing at /feeds/all (ALL_FEEDS_ID)", () => {
+    // ALL_FEEDS_ID = "all" in src/utils/constants.ts. If that ever changes,
+    // this test forces an update in lockstep.
+    const allShortcut = MANIFEST.shortcuts.find(
+      (s: { url: string }) => s.url === "/feeds/all",
+    );
+    expect(allShortcut).toBeDefined();
+  });
+
+  it("includes an Add-feed shortcut routed under /feeds", () => {
+    const addShortcut = MANIFEST.shortcuts.find((s: { url: string }) =>
+      s.url.startsWith("/feeds"),
+    );
+    expect(addShortcut).toBeDefined();
+    expect(MANIFEST.shortcuts.some((s: { name: string }) => /add/i.test(s.name))).toBe(true);
+  });
+});

--- a/tests/stores/article-store.test.ts
+++ b/tests/stores/article-store.test.ts
@@ -46,7 +46,9 @@ describe("article-store", () => {
       articlesByFeedId: {},
       selectedArticle: null,
       isLoading: false,
+      articleSortMode: "newest",
     });
+    window.localStorage.removeItem("feedzero:article-sort-mode");
     vi.clearAllMocks();
   });
 
@@ -411,6 +413,77 @@ describe("article-store", () => {
       expect(useArticleStore.getState().selectedArticle?.feedId).toBe(
         "feed-in-folder",
       );
+    });
+  });
+
+  describe("article sort mode", () => {
+    // Reader-polish quick win: power users want to flip between newest,
+    // oldest, and unread-first without leaving the article pane. Sort is a
+    // user preference, persisted to localStorage so it survives reload.
+    const at = (id: string, publishedAt: number, read = false) => ({
+      id,
+      feedId: "f1",
+      guid: id,
+      title: id,
+      link: `https://example.com/${id}`,
+      content: "",
+      summary: "",
+      author: "",
+      publishedAt,
+      read,
+      createdAt: 0,
+    });
+
+    it("defaults to 'newest' so the historical sort behaviour is preserved", () => {
+      expect(useArticleStore.getState().articleSortMode).toBe("newest");
+    });
+
+    it("setArticleSortMode('oldest') reverses the chronological order in the visible list", async () => {
+      const articles = [at("old", 100), at("mid", 200), at("new", 300)];
+      vi.mocked(getArticles).mockResolvedValue({ ok: true, value: articles });
+      await useArticleStore.getState().loadArticles("f1");
+
+      useArticleStore.getState().setArticleSortMode("oldest");
+
+      expect(useArticleStore.getState().articles.map((a) => a.id)).toEqual([
+        "old",
+        "mid",
+        "new",
+      ]);
+    });
+
+    it("setArticleSortMode('unread-first') groups unread before read; within each group, newest first", async () => {
+      const articles = [
+        at("read-newest", 400, true),
+        at("unread-old", 100, false),
+        at("read-old", 200, true),
+        at("unread-newest", 300, false),
+      ];
+      vi.mocked(getArticles).mockResolvedValue({ ok: true, value: articles });
+      await useArticleStore.getState().loadArticles("f1");
+
+      useArticleStore.getState().setArticleSortMode("unread-first");
+
+      expect(useArticleStore.getState().articles.map((a) => a.id)).toEqual([
+        "unread-newest",
+        "unread-old",
+        "read-newest",
+        "read-old",
+      ]);
+    });
+
+    it("persists the chosen mode to localStorage", () => {
+      useArticleStore.getState().setArticleSortMode("oldest");
+      expect(window.localStorage.getItem("feedzero:article-sort-mode")).toBe(
+        "oldest",
+      );
+    });
+
+    it("rejects unknown modes (no-op, keeps previous mode)", () => {
+      useArticleStore.getState().setArticleSortMode("newest");
+      // @ts-expect-error — intentionally bad input
+      useArticleStore.getState().setArticleSortMode("random-nonsense");
+      expect(useArticleStore.getState().articleSortMode).toBe("newest");
     });
   });
 });


### PR DESCRIPTION
Rebased onto current `main` 2026-05-18. Eight RGR-cycle commits + one test-bridge commit. 2450 unit/integration tests green, `tsc --noEmit` clean.

## What's in this PR

### Strategy + documentation (3 commits)
- **`docs(strategy)` — seed Playing-to-Win cascade + /research-competitors agent.** Adds `.claude/commands/research-competitors.md`, four seed docs under `docs/strategy/`, the `runs/` audit-log directory, and a `.gitignore` allowlist for `.claude/commands/` matching the existing skills/hooks pattern.
- **`docs(strategy)` — first /research-competitors run.** Full landscape scan executed: 22-competitor table, 7 themed pain-point buckets with sourced quotes (r/rss, r/RSS_Readers, r/selfhosted, Privacy Guides, Norwegian Consumer Council audit), Playing-to-Win cascade refreshed against live data with `<!-- changed YYYY-MM-DD -->` markers and a dated run log in `docs/strategy/runs/2026-05-16.md`.
- **`docs(strategy)` — focus declaration + vault format + sustainability.** Adds a Focus section at the top of `003-playing-to-win.md` (build feed-fetching + reading; defer AI/social/native; refuse server-side plaintext access); `docs/vault-format.md` documents the sync vault byte-for-byte (PBKDF2 derivations, AES-GCM wire format, ~30-line reference decryption); README gains a "Sustainability commitment" section anchored on the 19-month category shutdown run.

### Reader-polish features (4 commits)
- **`feat(feeds)` — Retry-After passthrough + stale-feed indicator.** Proxy propagates upstream `Retry-After` verbatim for 429/503 via a new `buildResponseHeaders` helper; client surfaces it in error messages via `fetchErrorMessage`, which now delegates to main's `parseRetryAfter()` for RFC-compliant delta-seconds / HTTP-date parsing with the 24h clamp. Feed type gains `lastFetchedAt` + `lastSuccessfulFetchAt`; `refreshFeed` persists both via a new `persistFreshness` helper that never clobbers a prior success timestamp on transient failure. Sidebar shows an amber `AlertTriangle` when `isFeedStale(feed)` (14-day threshold, brand-new-feed exempt). +11 tests across proxy / feed-service / new `tests/lib/stale-feed.test.ts`.
- **`feat(pwa)` — web app manifest with home-screen shortcuts.** Three shortcuts (All unread → `/feeds/all`, Add a feed → `/feeds?action=add`, Release notes → `/feeds?changelog=1`). Reconciled with main's icon set from PR #74 (favicon.ico + 192/512 PNG + maskable variants). `tests/pwa-manifest.test.ts` pins the contract — 8 tests covering link from index.html, JSON validity, standalone display, start_url=/feeds, icon shape, three shortcut entries, All-unread shortcut at /feeds/all (forces the manifest URL and `ALL_FEEDS_ID` constant to evolve in lockstep).
- **`feat(reader)` — article sort modes.** `newest` (default, preserves historical behaviour) / `oldest` / `unread-first` (groups unread before read, newest-first within each). Persisted to localStorage with a guard against unknown values (forward-compat). UI is a sticky-top SortMenu in the article list, matching the existing `ArrowUpDown + Check` dropdown pattern in `sidebar-feed-list`. +5 store tests.
- **`feat(import)` — Pocket HTML export support.** Highest-leverage acquisition channel per `003-playing-to-win.md` §2 (Pocket shut down 2025-11-12, ~millions displaced). Parses Pocket's HTML export via DOMParser, extracts unique scheme://host origins (subdomains preserved — `writer.substack.com` stays distinct from `substack.com`), feeds each through the existing `addFeedFlow` cascade so `discoverFeed` finds the actual RSS. +10 parser tests. Bridge fix to PR #112's import quota/folder tests in a separate commit (placeholder text widened to mention Pocket).

### Marketing (1 commit)
- **`docs(marketing)` — per-shutdown migration landing copy + deployment TODO.** Drafts the actual page copy for Pocket / Omnivore / TT-RSS migration pages called out in `003-playing-to-win.md` §2 as the highest-leverage acquisition channel currently available. Copy lives here as markdown; deployment to the separate `feedzero.app` landing repo is tracked in `docs/marketing/TODO.md` (channel-by-channel campaign distribution, hygiene rules — no paid acquisition, no SEO content farms, single campaign round, vault-count snapshotting via `/api/stats-sync`).

### Test bridge (1 commit)
- **`test(import)` — bridge import-view tests to new Pocket-aware placeholder.** PR #112's tests asserted on the exact old textarea placeholder string; my Pocket commit widened it. Loosens unit-test regex to `/paste opml/i`, updates 4 E2E references to the new exact string. Production code unchanged.

## Reconciliation with main

Rebased onto `origin/main` HEAD at 67303f8. Five files had real conflicts; all resolved in favour of the cleaner combined surface:

| File | Resolution |
|------|-----------|
| `public/manifest.webmanifest` | add/add — kept main's icon set (favicon.ico + 192/512 PNG + maskable), kept my three shortcuts, kept my `start_url: "/feeds"` (deeper landing than main's `"/"`). |
| `src/core/feeds/feed-service.ts` | Replaced my inline retry-after extraction with main's `parseRetryAfter()` (handles HTTP-date + delta-seconds + 24h clamp). Kept `persistFreshness` for the stale indicator on every refresh path. Kept main's per-host serialisation refactor of `refreshAllFeeds`. |
| `src/components/sidebar/feed-item.tsx` | Combined `AlertTriangle` (mine, stale badge) + `Check` (main, prefer-full-text toggle) in the lucide import. |
| `src/components/settings/import-view.tsx` | Promoted `extractEntries` to dispatch Pocket → OPML → URL-list. Pocket has no folder concept so `folderName: undefined`. Main's PR #112 folder/quota logic preserved. |
| `package-lock.json` | Took main's; package.json deps untouched on this branch. |

## Verification

- `npx tsc --noEmit` — clean.
- `npm test` — 2450 passed / 30 skipped / 0 failed across 216 files (100s).
- E2E (Playwright) — not run in this session; the affected E2E specs (`tests/e2e/import-export.spec.ts`) were updated in the test-bridge commit. Worth running `npm run test:e2e` before merge.
- Pre-push hook ran type check + full vitest suite on push; both green.

## What's still TODO after merge

- Deploy the three migration landing pages to `feedzero.app` — see `docs/marketing/TODO.md` for the channel + hygiene checklist.
- Run `npm run test:e2e` to confirm the placeholder/exact-string E2E tests pass against the rebuilt frontend.
- Next `/research-competitors` run should close `docs/strategy/runs/2026-05-16.md` open question #2 (Pocket-import path verification — now landed) and re-evaluate the §4 AI-summarization architecture proposal.