### PR TITLE
fix(e2e): retarget layout-scroll selectors at the current UI

### DIFF
--- a/tests/e2e/layout-scroll.spec.ts
+++ b/tests/e2e/layout-scroll.spec.ts
@@ -17,70 +17,26 @@ async function setupFeed(page: import("@playwright/test").Page) {
 }
 
 /**
- * Adds a feed on mobile: adds via Explore, then opens sidebar and clicks feed.
- * On mobile the sidebar is hidden, so we must open it to interact with feeds.
+ * Adds a feed on mobile. After adding via Explore, the app already navigates
+ * the user to the new feed's article list — no need to re-select via the
+ * mobile drawer (it lives in MobileNavDrawer with aria-label "Open feed list",
+ * not the old "Toggle Sidebar" sheet).
  */
 async function setupFeedMobile(page: import("@playwright/test").Page) {
   await mockFeedEndpoint(page, SAMPLE_RSS);
   await addFeedViaUI(page, "https://example.com/feed");
 
-  // After adding via Explore, the app navigates to the feed page.
-  // Wait for the URL to change to /feeds/
   await page.waitForURL(/\/feeds\//, { timeout: 10000 });
-
-  // Open the sidebar to click the feed
-  await page.getByRole("button", { name: /toggle sidebar/i }).click();
-  const dialog = page.getByRole("dialog");
-  await expect(dialog).toBeVisible({ timeout: 5000 });
-
-  // Click the feed in the sidebar
-  await dialog
-    .locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" })
-    .click();
-
-  // Sidebar closes automatically on mobile
-  await expect(dialog).toBeHidden({ timeout: 5000 });
-
-  // On mobile, tapping a feed lands on the article list (no auto-select).
   await expect(articleOption(page, "First Article")).toBeVisible({
     timeout: 10000,
   });
 }
 
 test.describe("Layout and scroll", () => {
-  test("header stays pinned at top when content overflows", async ({
-    feedPage: page,
-  }) => {
-    await setupFeed(page);
-
-    // Select the fourth article which has long content for scroll testing
-    await articleOption(page, "Fourth Article").click();
-    await page.waitForTimeout(500);
-
-    // Inject extra tall content into the reader to force overflow
-    await page.evaluate(() => {
-      const article = document.querySelector("article");
-      if (article) {
-        const tall = document.createElement("div");
-        tall.style.height = "5000px";
-        tall.textContent = "Tall spacer for scroll testing";
-        article.appendChild(tall);
-      }
-    });
-
-    // Scroll the reader panel
-    const scrollArea = page.locator('[data-slot="scroll-area"]').last();
-    await scrollArea.evaluate((el) => {
-      const viewport = el.querySelector("[data-slot='scroll-area-viewport']");
-      if (viewport) viewport.scrollTop = 1000;
-    });
-
-    // Header should still be at the top of the viewport
-    const header = page.locator("header").first();
-    const headerBox = await header.boundingBox();
-    expect(headerBox).toBeTruthy();
-    expect(headerBox!.y).toBeLessThanOrEqual(5); // Pinned at top
-  });
+  // Note: the desktop layout has no page-level pinned header — the only
+  // <header> is the reader's article meta block, which scrolls inside the
+  // reader panel. The mobile equivalent does pin a page header and is
+  // tested in the "Layout — mobile" describe below.
 
   test("no document-level scroll", async ({ feedPage: page }) => {
     await setupFeed(page);
@@ -112,33 +68,26 @@ test.describe("Layout and scroll", () => {
   test("article list scrolls independently", async ({ feedPage: page }) => {
     await setupFeed(page);
 
-    // Get the left panel's scroll area viewport
-    const leftScrollViewport = page
-      .locator('[data-slot="scroll-area-viewport"]')
-      .first();
-    const rightScrollViewport = page
-      .locator('[data-slot="scroll-area-viewport"]')
-      .last();
+    // Article-list panel's scroll container is the direct div child of the
+    // ResizablePanel; the reader panel exposes data-testid="reader-scroll-container".
+    // Neither uses Radix ScrollArea — they're plain overflow-y-auto divs.
+    const listScroll = page.locator('[data-panel][id="article-list"] > div');
+    const readerScroll = page.getByTestId("reader-scroll-container");
 
-    // Get initial scroll positions
-    const rightBefore = await rightScrollViewport.evaluate(
-      (el) => el.scrollTop,
-    );
+    const readerBefore = await readerScroll.evaluate((el) => el.scrollTop);
 
-    // Scroll the left panel
-    await leftScrollViewport.evaluate((el) => {
+    await listScroll.evaluate((el) => {
       el.scrollTop = 200;
     });
 
-    // Right panel should not have scrolled
-    const rightAfter = await rightScrollViewport.evaluate((el) => el.scrollTop);
-    expect(rightAfter).toBe(rightBefore);
+    const readerAfter = await readerScroll.evaluate((el) => el.scrollTop);
+    expect(readerAfter).toBe(readerBefore);
   });
 
   test("reader scrolls independently", async ({ feedPage: page }) => {
     await setupFeed(page);
 
-    // Inject tall content
+    // Inject tall content into the reader so it has somewhere to scroll to.
     await page.evaluate(() => {
       const article = document.querySelector("article");
       if (article) {
@@ -148,23 +97,17 @@ test.describe("Layout and scroll", () => {
       }
     });
 
-    const leftScrollViewport = page
-      .locator('[data-slot="scroll-area-viewport"]')
-      .first();
-    const rightScrollViewport = page
-      .locator('[data-slot="scroll-area-viewport"]')
-      .last();
+    const listScroll = page.locator('[data-panel][id="article-list"] > div');
+    const readerScroll = page.getByTestId("reader-scroll-container");
 
-    const leftBefore = await leftScrollViewport.evaluate((el) => el.scrollTop);
+    const listBefore = await listScroll.evaluate((el) => el.scrollTop);
 
-    // Scroll the right (reader) panel
-    await rightScrollViewport.evaluate((el) => {
+    await readerScroll.evaluate((el) => {
       el.scrollTop = 300;
     });
 
-    // Left panel should not have scrolled
-    const leftAfter = await leftScrollViewport.evaluate((el) => el.scrollTop);
-    expect(leftAfter).toBe(leftBefore);
+    const listAfter = await listScroll.evaluate((el) => el.scrollTop);
+    expect(listAfter).toBe(listBefore);
   });
 
   test("outer handle resizes sidebar vs stage", async ({ feedPage: page }) => {
@@ -251,67 +194,46 @@ test.describe("Layout and scroll", () => {
     expect(Math.abs(sidebarWidthAfter - sidebarWidthBefore)).toBeLessThan(2);
   });
 
-  test("sidebar collapse/expand via trigger", async ({ feedPage: page }) => {
-    await setupFeed(page);
-
-    // Sidebar should be visible initially on desktop
-    const sidebar = page.locator('[data-slot="sidebar"]');
-    await expect(sidebar).toBeVisible();
-
-    // Click the sidebar trigger button (not the rail) to collapse
-    const trigger = page.locator('[data-sidebar="trigger"]');
-    await trigger.click({ force: true });
-
-    // Wait for sidebar animation (duration-200) to complete
-    const sidebarEl = page.locator('div[data-slot="sidebar"][data-state]');
-    await expect(sidebarEl).toHaveAttribute("data-state", "collapsed", {
-      timeout: 5000,
-    });
-
-    // Click again to expand
-    await trigger.click({ force: true });
-    await expect(sidebarEl).toHaveAttribute("data-state", "expanded", {
-      timeout: 5000,
-    });
-  });
+  // Note: there is no "sidebar collapse via trigger" test. The desktop
+  // sidebar uses collapsible="none" — it's a static ResizablePanel that
+  // users resize via the drag handle (covered by the outer-handle test
+  // above). No SidebarTrigger is rendered. See ADR 013.
 });
 
 test.describe("Layout — mobile", () => {
   test.use({ viewport: { width: 393, height: 851 } });
 
-  test("sidebar opens as offcanvas sheet", async ({ feedPage: page }) => {
-    // Sidebar should not be visible initially on mobile
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeHidden();
+  test("nav drawer opens when the handle is tapped", async ({
+    feedPage: page,
+  }) => {
+    // Mobile feed nav is a Vaul bottom drawer (MobileNavDrawer), not the
+    // desktop Sidebar's offcanvas sheet. The trigger is a button with
+    // aria-label "Open feed list"; the content lives under
+    // data-testid="drawer-content".
+    const drawerContent = page.getByTestId("drawer-content");
+    await expect(drawerContent).toBeHidden();
 
-    // Click trigger to open
-    await page.getByRole("button", { name: /toggle sidebar/i }).click();
+    await page.getByRole("button", { name: /open feed list/i }).click();
 
-    // Should appear as a dialog (Sheet)
-    await expect(dialog).toBeVisible({ timeout: 5000 });
-
-    // Should contain the app name
-    await expect(page.getByText("FeedZero")).toBeVisible();
+    await expect(drawerContent).toBeVisible({ timeout: 5000 });
+    await expect(drawerContent.getByText("Settings")).toBeVisible();
   });
 
-  test("sidebar closes when a feed is tapped", async ({ feedPage: page }) => {
+  test("nav drawer closes when a feed is tapped", async ({
+    feedPage: page,
+  }) => {
     await setupFeedMobile(page);
 
-    // Navigate back to a state where we can see article list
-    // Then open the sidebar to tap the feed again
-    await page.getByRole("button", { name: /toggle sidebar/i }).click();
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await page.getByRole("button", { name: /open feed list/i }).click();
+    const drawerContent = page.getByTestId("drawer-content");
+    await expect(drawerContent).toBeVisible({ timeout: 5000 });
 
-    // Tap the feed in the sidebar
-    await dialog
+    await drawerContent
       .locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" })
       .click();
 
-    // Sidebar should close automatically
-    await expect(dialog).toBeHidden({ timeout: 5000 });
+    await expect(drawerContent).toBeHidden({ timeout: 5000 });
 
-    // Article list should be visible
     await expect(articleOption(page, "First Article")).toBeVisible({
       timeout: 10000,
     });


### PR DESCRIPTION
What:
  Five layout-scroll tests in the desktop project shard timed out
  consistently at locator resolution — `[data-slot=scroll-area-viewport]`,
  `[data-sidebar=trigger]`, and `getByRole(button, /toggle sidebar/i)`
  never appeared on the page.

Why:
  The selectors describe a UI that no longer exists:
    - Radix ScrollArea is only used on the stats/settings/explore stage
      content; the article-list and reader panels use plain
      overflow-y-auto divs (article-list: a direct div child of the
      ResizablePanel; reader: data-testid="reader-scroll-container").
    - The desktop sidebar is a static ResizablePanel with
      collapsible="none" — no SidebarTrigger is rendered and there is
      no collapse-via-trigger behaviour to test (sidebar width is the
      drag handle's job; covered by the outer-handle test).
    - Mobile feed nav is a Vaul bottom drawer (MobileNavDrawer) with
      aria-label "Open feed list" + data-testid="drawer-content", not
      the Sidebar's old offcanvas Sheet.

Fix:
  - Rewrite "article list/reader scrolls independently" to use the real
    scroll containers.
  - Delete "sidebar collapse/expand via trigger" — feature was removed
    by ADR 013; the drag-handle resize tests cover the remaining
    behaviour.
  - Rewrite the two mobile sidebar tests around the Vaul drawer.
  - Simplify setupFeedMobile: addFeedViaUI already lands the user on
    /feeds/{newFeedId} on mobile, so the drawer-tap-feed round trip is
    unnecessary and was the actual source of the timeout in
    "header stays visible when scrolling article list".
  - Drop the stale "header stays pinned at top" desktop test — the
    desktop layout has no page-level pinned header (the only <header>
    is the reader's article meta block, which scrolls with content).
    The mobile equivalent in "Layout — mobile" still covers the pinned
    page header.

Prevention:
  Other e2e suites (sync.spec.ts) already use the Vaul drawer's
  "Open feed list" selector. Aligning layout-scroll here removes the
  remaining "Toggle Sidebar" reference in tests/e2e.

Tests:
  npm test → 2450 passed / 30 skipped
  npx tsc --noEmit → clean