### PR TITLE
fix(e2e): align stale tests with current redirect + panel selectors

### DIFF
--- a/tests/e2e/article-navigation.spec.ts
+++ b/tests/e2e/article-navigation.spec.ts
@@ -138,25 +138,14 @@ test.describe("Article navigation — mobile", () => {
     await mockFeedEndpoint(page, SAMPLE_RSS);
     await addFeedViaUI(page, "https://example.com/feed");
 
-    // After adding via Explore, the app navigates to /feeds/{feedId}.
+    // After adding via Explore, the app navigates to /feeds/{feedId}. On
+    // mobile this lands directly on the article list — no need to re-select
+    // the feed through the bottom drawer.
     await page.waitForURL(/\/feeds\//, { timeout: 10000 });
-
-    // Open sidebar to select the feed
-    await page.getByRole("button", { name: /toggle sidebar/i }).click();
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible({ timeout: 5000 });
-
-    // Click the feed — on mobile, this lands on the article list (no auto-select).
-    await dialog
-      .locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" })
-      .click();
-
-    // Sidebar closes
-    await expect(dialog).toBeHidden({ timeout: 5000 });
 
     // Article list is visible; back pill is NOT (we're not in the reader yet)
     await expect(page.locator('[role="listbox"]')).toBeVisible({
-      timeout: 5000,
+      timeout: 10000,
     });
     await expect(
       page.locator('[data-testid="back-pill"]'),
@@ -170,11 +159,12 @@ test.describe("Article navigation — mobile", () => {
     await expect(page.locator('[data-testid="back-pill"]')).toBeVisible();
   });
 
-  test("navigating to /feeds lands on All items list (not explore)", async ({
+  test("navigating to /feeds with no feeds redirects to explore", async ({
     feedPage: page,
   }) => {
-    // On mobile at /feeds with no feeds, app redirects to /feeds/all
-    // (the All items article list). Explore is reachable via the sidebar.
-    await page.waitForURL(/\/feeds\/all/, { timeout: 10000 });
+    // feedPage's release-auto-subscribe block keeps feedCount at 0, so the
+    // redirect logic in feeds-page.tsx (feedCount <= 1 → /explore) sends
+    // the user to the catalog. /feeds/all kicks in once they have 2+ feeds.
+    await page.waitForURL(/\/explore/, { timeout: 10000 });
   });
 });

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Onboarding", () => {
-  test("new user auto-initializes and lands on All items article list", async ({
+  test("new user auto-initializes and lands on Explore", async ({
     page,
   }) => {
     // Clear localStorage so the app starts fresh, but suppress changelog dialog
@@ -11,9 +11,11 @@ test.describe("Onboarding", () => {
     });
     await page.goto("/feeds");
 
-    // App should auto-initialize and redirect to /feeds/all — the article
-    // list, not the Explore catalog. Explore is reachable via the sidebar.
-    await page.waitForURL(/\/feeds\/all/, { timeout: 15000 });
+    // App auto-initializes (no onboarding modal) and redirects to /explore.
+    // The redirect logic in feeds-page.tsx sends users with 0–1 feeds to
+    // /explore (still in starter mode); the auto-subscribed release-notes
+    // feed counts as one. /feeds/all kicks in once the user has 2+ feeds.
+    await page.waitForURL(/\/explore/, { timeout: 15000 });
   });
 
   test("returning user skips onboarding and loads directly", async ({
@@ -30,8 +32,8 @@ test.describe("Onboarding", () => {
 
     // No dialog should appear
     await expect(page.getByRole("dialog")).toBeHidden({ timeout: 5000 });
-    // App should load and land on the All items list
-    await page.waitForURL(/\/feeds\/all/, { timeout: 15000 });
+    // Returning user with 0–1 feeds also lands on /explore (see above).
+    await page.waitForURL(/\/explore/, { timeout: 15000 });
   });
 
   test("no onboarding modal appears for new users", async ({ page }) => {
@@ -51,7 +53,7 @@ test.describe("Onboarding", () => {
     // No dialog should be visible — auto-initialization is silent
     await expect(page.getByRole("dialog")).toBeHidden({ timeout: 5000 });
 
-    // App should land on the article list rather than Explore
-    await page.waitForURL(/\/feeds\/all/, { timeout: 15000 });
+    // Fresh user lands on /explore (catalog), not /feeds/all.
+    await page.waitForURL(/\/explore/, { timeout: 15000 });
   });
 });

--- a/tests/e2e/sidebar-width-stability.spec.ts
+++ b/tests/e2e/sidebar-width-stability.spec.ts
@@ -18,10 +18,10 @@ import { test, expect, addFeedViaUI, selectFeedInSidebar } from "./fixtures";
 import { SAMPLE_RSS, mockFeedEndpoint } from "./feed-fixtures";
 
 async function sidebarWidth(page: import("@playwright/test").Page) {
-  // The first panel inside the outer group is the sidebar (left of the
-  // stage). data-panel-id values come from react-resizable-panels' own
-  // attribute conventions — they're stable across versions.
-  const sidebar = page.locator("[data-panel-group-id='feedzero:layout:main'] [data-panel]").first();
+  // react-resizable-panels renders each Panel as <div data-panel id="<id>">.
+  // Only the outer group has a panel with id="sidebar"; the inner stage
+  // group's panels are id="article-list" and "reader". No need to scope.
+  const sidebar = page.locator('[data-panel][id="sidebar"]');
   await expect(sidebar).toBeVisible();
   const box = await sidebar.boundingBox();
   if (!box) throw new Error("sidebar panel had no bounding box");
@@ -40,8 +40,11 @@ test.describe("Sidebar width stability across routes (ADR 013)", () => {
     // Make the sidebar a different size than the default so we can detect
     // a "reset to default" regression. Drag is preferable to a synthetic
     // setSize because it exercises the real persistence path.
+    // The outer group's resize handle sits between [sidebar] and [stage].
+    // Our wrapper marks separators with data-slot="resizable-handle" — the
+    // inner stage group adds its own handle, so .first() picks the outer one.
     const handle = page
-      .locator("[data-panel-group-id='feedzero:layout:main'] [data-resize-handle]")
+      .locator('[data-slot="resizable-handle"]')
       .first();
     const handleBox = await handle.boundingBox();
     if (!handleBox) throw new Error("resize handle had no bounding box");

--- a/tests/e2e/sync.spec.ts
+++ b/tests/e2e/sync.spec.ts
@@ -97,7 +97,7 @@ test.describe("Sync", () => {
     await page.waitForURL(/\/settings/, { timeout: 5000 });
   });
 
-  test("delete all data: confirm → resets to All items article list", async ({
+  test("delete all data: confirm → resets to Explore catalog", async ({
     feedPage: page,
   }) => {
     await addFeedForSync(page);
@@ -113,8 +113,9 @@ test.describe("Sync", () => {
     ).toBeVisible({ timeout: 5000 });
     await confirm.getByRole("button", { name: /delete everything/i }).click();
 
-    // After reset: auto-init lands the user on /feeds/all (the post-reset
-    // default).
-    await page.waitForURL(/\/feeds\/all/, { timeout: 15000 });
+    // After reset the DB is empty; feedPage's release-auto-subscribe block
+    // keeps it that way, so the redirect lands the user on /explore (the
+    // 0–1 feed default per feeds-page.tsx).
+    await page.waitForURL(/\/explore/, { timeout: 15000 });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #122. The merged PR fixed the layout-scroll + import-export shards, but two more shards turned up failures the previous `--max-failures=5` budget had been masking:

- **Shard 1/6 (article-navigation, 2 failures)** — mobile "feed selection" still clicked the old `Toggle Sidebar` button (gone — Vaul drawer now), and the "/feeds with no feeds → /feeds/all" test contradicted the redirect logic introduced by #73.
- **Shard 6/6 (onboarding × 3, sidebar-width-stability, sync, 5 failures)** — three onboarding tests + sync's `delete all data` still asserted `/feeds/all` on a fresh DB, but `feeds-page.tsx` has sent users with 0–1 feeds to `/explore` since #73. `sidebar-width-stability.spec.ts` used selectors (`data-panel-group-id`, `data-resize-handle`) that the current `react-resizable-panels` version + our `resizable.tsx` wrapper never emit.

## Changes

`tests/e2e/onboarding.spec.ts`
- Three tests now assert the user lands on `/explore` (matches the `feedCount <= 1 → /explore` redirect from #73). Test intent is unchanged: auto-init, no modal, fresh-DB redirect lands somewhere sensible.

`tests/e2e/article-navigation.spec.ts`
- :135 ("feed selection shows article list, then reader on tap") — drop the obsolete mobile drawer-tap round-trip. After `addFeedViaUI` on mobile the user is already on the article list; no re-select needed.
- :173 ("navigating to /feeds…") — rename to "redirects to explore", flip the URL assertion.

`tests/e2e/sync.spec.ts`
- :100 ("delete all data") — rename to "resets to Explore catalog", flip the URL assertion (post-reset DB is empty → `/explore`).

`tests/e2e/sidebar-width-stability.spec.ts`
- Replace `[data-panel-group-id='feedzero:layout:main'] [data-panel]` with `[data-panel][id="sidebar"]` (same convention `layout-scroll.spec.ts`'s inner-handle test uses).
- Replace `[data-resize-handle]` with `[data-slot="resizable-handle"]`.

All four files now share the selector vocabulary used by `layout-scroll.spec.ts` and `fixtures.ts`, so a future renderer change will break them together and surface in CI rather than rot silently.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` → 2474 passed / 31 skipped
- [ ] Re-run desktop e2e shards 1/6 + 6/6 in CI
- [ ] Confirm `release-feed.spec.ts` still passes (uses raw `page`, unaffected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BvWicAxh8CeGU9nqSd24ax)_