### PR TITLE
fix(e2e): retarget remaining stale selectors in shard 6/6

### DIFF
--- a/tests/e2e/sidebar-width-stability.spec.ts
+++ b/tests/e2e/sidebar-width-stability.spec.ts
@@ -56,7 +56,8 @@ test.describe("Sidebar width stability across routes (ADR 013)", () => {
     const widened = await sidebarWidth(page);
     expect(widened, "drag should actually change the sidebar width").not.toBe(startingWidth);
 
-    await page.getByRole("link", { name: /explore/i }).first().click();
+    // Explore is rendered as a SidebarMenuButton (role="button"), not a link.
+    await page.getByRole("button", { name: /explore/i }).first().click();
     await page.waitForURL(/\/explore/);
     const afterExplore = await sidebarWidth(page);
     expect(afterExplore, "navigating to /explore must not reset sidebar width").toBe(widened);

--- a/tests/e2e/sync.spec.ts
+++ b/tests/e2e/sync.spec.ts
@@ -97,7 +97,7 @@ test.describe("Sync", () => {
     await page.waitForURL(/\/settings/, { timeout: 5000 });
   });
 
-  test("delete all data: confirm → resets to Explore catalog", async ({
+  test("delete all data: confirm closes the dialog and clears feeds", async ({
     feedPage: page,
   }) => {
     await addFeedForSync(page);
@@ -113,9 +113,12 @@ test.describe("Sync", () => {
     ).toBeVisible({ timeout: 5000 });
     await confirm.getByRole("button", { name: /delete everything/i }).click();
 
-    // After reset the DB is empty; feedPage's release-auto-subscribe block
-    // keeps it that way, so the redirect lands the user on /explore (the
-    // 0–1 feed default per feeds-page.tsx).
-    await page.waitForURL(/\/explore/, { timeout: 15000 });
+    // resetApp() doesn't navigate — it just clears the DB and re-onboards
+    // silently. The deterministic post-reset signal is the dialog closing,
+    // and the previously-added Test Feed no longer appearing in the sidebar.
+    await expect(confirm).toBeHidden({ timeout: 15000 });
+    await expect(
+      page.locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" }),
+    ).toHaveCount(0, { timeout: 5000 });
   });
 });

--- a/tests/e2e/viewport-resize.spec.ts
+++ b/tests/e2e/viewport-resize.spec.ts
@@ -24,10 +24,13 @@ test.describe("Viewport resize", () => {
       { timeout: 10000 },
     );
 
-    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    // The desktop sidebar uses collapsible="none", which renders the outer
+    // container with data-slot="sidebar" (the data-sidebar="sidebar"
+    // attribute only appears in the collapsible="offcanvas" branch).
+    const sidebar = page.locator('[data-slot="sidebar"]');
     await expect(sidebar).toBeVisible({ timeout: 5000 });
 
-    // Resize to mobile — sidebar should hide (offcanvas)
+    // Resize to mobile — desktop sidebar unmounts; the Vaul drawer takes over.
     await page.setViewportSize({ width: 393, height: 851 });
     await page.waitForTimeout(500); // let React re-render after breakpoint change
 
@@ -38,16 +41,17 @@ test.describe("Viewport resize", () => {
     await expect(sidebar).toBeVisible({ timeout: 5000 });
   });
 
-  test("three-panel desktop layout renders at 900px (no gap zone)", async ({
+  test("three-panel desktop layout renders at the lg breakpoint (1024px)", async ({
     page,
   }) => {
-    // useIsDesktop and useIsMobile both use 768px as their threshold, so
-    // there is no gap zone. At 900px the full desktop 3-panel layout should
-    // render with the persistent sidebar — no offcanvas trigger needed.
+    // PR F intentionally raised useIsDesktop to >=1024px (Tailwind `lg`) so
+    // the narrow-viewport canvas-blank bug couldn't recur. Below 1024px the
+    // mobile snap-scroll layout takes over. This test pins the threshold —
+    // at exactly 1024px the desktop 3-panel layout must render.
     await skipOnboarding(page);
     await mockFeedEndpoint(page, SAMPLE_RSS);
 
-    await page.setViewportSize({ width: 900, height: 720 });
+    await page.setViewportSize({ width: 1024, height: 720 });
     await page.goto("/feeds");
     await page.waitForFunction(
       () => !document.body.textContent?.includes("Loading"),
@@ -62,8 +66,9 @@ test.describe("Viewport resize", () => {
       .first();
     await expect(panels).toBeVisible({ timeout: 5000 });
 
-    // Persistent sidebar should be visible (no trigger needed to open it)
-    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    // Persistent sidebar should be visible (no trigger needed to open it).
+    // See the sibling test above for why data-slot, not data-sidebar.
+    const sidebar = page.locator('[data-slot="sidebar"]');
     await expect(sidebar).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #123. After the previous alignment pass merged, shard 6/6 still timed out on four tests — all from stale assumptions unrelated to product code:

- `sidebar-width-stability.spec.ts:34` — `getByRole("link", /explore/i)` never resolves. Explore in the sidebar is a `SidebarMenuButton` (role="button"), not a link.
- `sync.spec.ts:100` — `resetApp()` clears the DB and re-onboards silently; it doesn't navigate. The previous fix swapped `/feeds/all` → `/explore`, but the underlying assumption that delete triggers a route change was wrong from the start.
- `viewport-resize.spec.ts:13` — `[data-sidebar="sidebar"]` only exists in the `collapsible="offcanvas"` branch of the Sidebar component. The desktop sidebar uses `collapsible="none"`, which renders `<div data-slot="sidebar">` without the `data-sidebar` attribute. The selector has matched nothing on desktop since that switch.
- `viewport-resize.spec.ts:41` — the comment claimed "useIsDesktop and useIsMobile both use 768px so no gap zone", but #95 (PR F) intentionally raised `useIsDesktop` to ≥1024px (Tailwind `lg`) to fix a canvas-blank-on-narrow-resize bug. 900px now lands in mobile by design.

## Changes

`tests/e2e/sidebar-width-stability.spec.ts`
- Switch the Explore click to `getByRole("button", { name: /explore/i })`.

`tests/e2e/sync.spec.ts`
- Rename `delete all data: confirm → resets to Explore catalog` to `…closes the dialog and clears feeds` and replace the URL assertion with two deterministic post-reset signals: the AlertDialog hides, and "Test Feed" leaves the sidebar.

`tests/e2e/viewport-resize.spec.ts`
- Switch both sidebar lookups to `[data-slot="sidebar"]` (present in all collapsible modes).
- Bump the "renders at 900px" test viewport to 1024px and rename it to match the actual `lg`-breakpoint contract.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` clean (pre-push hook)
- [ ] Re-run desktop e2e shard 6/6 in CI


---
_Generated by [Claude Code](https://claude.ai/code/session_01BvWicAxh8CeGU9nqSd24ax)_