### PR TITLE
feat(upgrade): unified discover-then-upgrade pattern for gated features

### DIFF
--- a/docs/decisions/012-open-core-feature-gating.md
+++ b/docs/decisions/012-open-core-feature-gating.md
@@ -8,7 +8,7 @@ Accepted (2026-05-16).
 The Free + Personal launch shipped (PRs #67, #69). Auto-organize is the first feature being relocated from Free to Personal, and more will follow (filters, mute-keywords, eventually Pro features like AI Signal, search, send-to-Kindle). Every new gated feature lands in the single FOSS repo at `forcingfx/feedzero` because:
 
 - Splitting into two repos (an OSS core and a closed Personal/Pro extension) doubles the dev surface and breaks the one-checkout self-hosting story.
-- The MIT license already permits a motivated user to fork and strip any gate. A more elaborate enforcement scheme buys cosmetics, not safety.
+- The AGPL-3.0 license already permits a motivated user to fork and strip any gate. A more elaborate enforcement scheme buys cosmetics, not safety.
 - Most paid features (auto-organize, future filters) are entirely client-side. There is no server check to bypass — the gate is honor-system either way.
 
 Without a gating layer the choice is either "ship the feature to everyone" (cannibalizing the Personal SKU) or "feature is missing from self-hosters" (breaking the FOSS contract). We need a third option: one codebase, three deployment modes.
@@ -55,7 +55,7 @@ The UI gate (popover offering "Upgrade — $5/mo" instead of "Organize now") is 
 
 ## Honor-system tradeoff
 
-Anyone can fork the repo, set `VITE_SELF_HOSTED=1`, and self-host with full Personal features for free. They can. The MIT license already permits it. We accept this because:
+Anyone can fork the repo, set `VITE_SELF_HOSTED=1`, and self-host with full Personal features for free. They can. The AGPL-3.0 license already permits it. We accept this because:
 
 - Personal is $5/mo. The convenience of a managed deployment with sync, automated updates, and zero maintenance exceeds the friction of forking and self-hosting for the vast majority of users.
 - The features paid users actually pay for *include the hosted infrastructure* — cross-device sync needs a server they don't have to run. A self-hoster paying $0 already runs their own server, which is the value the hosted user is paying for.
@@ -92,7 +92,7 @@ The license server signs a feature list into the token; the client cryptographic
 Cannibalizes the Personal SKU before Personal has had time to find product-market fit. Free + Personal launched eight days ago.
 
 ### No self-hosted bypass — gates always-on
-Breaks the FOSS contract. The repo is MIT-licensed; gating features behind a check that no fork can satisfy is hostile to self-hosters.
+Breaks the FOSS contract. The repo is AGPL-3.0-licensed; gating features behind a check that no fork can satisfy is hostile to self-hosters.
 
 ## References
 

--- a/src/components/explore/category-detail.tsx
+++ b/src/components/explore/category-detail.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import { ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 import { isSubscribed, findSubscribedFeed } from "@/lib/feed-catalog.ts";
 import type { AwesomeFeed } from "@/lib/catalog-search.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
+import { upgradeToast } from "@/lib/upgrade-toast.ts";
 import { Button } from "@/components/ui/button.tsx";
 import { FeedRow } from "@/components/explore/feed-row.tsx";
 import type { Feed } from "@/types/index.ts";
@@ -36,6 +38,7 @@ export function CategoryDetail({
   const [isRemoving, setIsRemoving] = useState(false);
   const addFeed = useFeedStore((s) => s.addFeed);
   const removeFeed = useFeedStore((s) => s.removeFeed);
+  const navigate = useNavigate();
   const healthyFeeds = feeds.filter((f) => f.healthy);
   const unsubscribed = healthyFeeds.filter(
     (f) => !isSubscribed(f.feedUrl, subscribedFeeds),
@@ -49,12 +52,20 @@ export function CategoryDetail({
   async function handleAddAll() {
     setIsAdding(true);
     let ok = 0;
+    let quotaError: string | null = null;
     for (const feed of unsubscribed) {
       const r = await addFeed(feed.feedUrl);
-      if (r.ok) ok++;
+      if (r.ok) {
+        ok++;
+      } else if (r.reason === "free-quota-exceeded") {
+        // Global quota — abort the loop and surface the upgrade affordance.
+        quotaError = r.error;
+        break;
+      }
     }
     setIsAdding(false);
-    if (ok === unsubscribed.length) toast.success(`Added all ${title} feeds`);
+    if (quotaError) upgradeToast(quotaError, navigate);
+    else if (ok === unsubscribed.length) toast.success(`Added all ${title} feeds`);
     else if (ok > 0) toast.warning(`Added ${ok} of ${unsubscribed.length} feeds`);
     else toast.error(`Failed to add ${title} feeds`);
   }

--- a/src/components/explore/explore-catalog.tsx
+++ b/src/components/explore/explore-catalog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/catalog-search.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { goToSettings } from "@/lib/go-to-settings.ts";
+import { upgradeToast } from "@/lib/upgrade-toast.ts";
 import { Button } from "@/components/ui/button.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Kbd } from "@/components/ui/kbd.tsx";
@@ -87,6 +88,8 @@ export function ExploreCatalog({ onFeedAdded }: ExploreCatalogProps) {
       setSearchQuery("");
       const newFeedId = useFeedStore.getState().selectedFeedId;
       if (newFeedId && onFeedAdded) onFeedAdded(newFeedId);
+    } else if (result.reason === "free-quota-exceeded") {
+      upgradeToast(result.error, navigate, { id: toastId });
     } else {
       toast.error(result.error || "Failed to add feed", { id: toastId });
     }

--- a/src/components/explore/featured-tab.tsx
+++ b/src/components/explore/featured-tab.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import {
   feedCatalog,
@@ -6,6 +7,7 @@ import {
   type CatalogCategory,
 } from "@/lib/feed-catalog.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
+import { upgradeToast } from "@/lib/upgrade-toast.ts";
 import { Button } from "@/components/ui/button.tsx";
 import { FeedRow } from "@/components/explore/feed-row.tsx";
 import type { Feed } from "@/types/index.ts";
@@ -55,6 +57,7 @@ function FeaturedCategorySection({
 }) {
   const [isAdding, setIsAdding] = useState(false);
   const addFeed = useFeedStore((s) => s.addFeed);
+  const navigate = useNavigate();
   const unsubscribed = category.feeds.filter(
     (f) => !isSubscribed(f.feedUrl, subscribedFeeds),
   );
@@ -63,12 +66,20 @@ function FeaturedCategorySection({
   async function handleAddAll() {
     setIsAdding(true);
     let ok = 0;
+    let quotaError: string | null = null;
     for (const feed of unsubscribed) {
       const r = await addFeed(feed.feedUrl);
-      if (r.ok) ok++;
+      if (r.ok) {
+        ok++;
+      } else if (r.reason === "free-quota-exceeded") {
+        // Global quota — abort the loop and route to upgrade.
+        quotaError = r.error;
+        break;
+      }
     }
     setIsAdding(false);
-    if (ok === unsubscribed.length) toast.success(`Added all ${category.name} feeds`);
+    if (quotaError) upgradeToast(quotaError, navigate);
+    else if (ok === unsubscribed.length) toast.success(`Added all ${category.name} feeds`);
     else if (ok > 0) toast.warning(`Added ${ok} of ${unsubscribed.length} feeds`);
     else toast.error(`Failed to add ${category.name} feeds`);
   }

--- a/src/components/explore/feed-row.tsx
+++ b/src/components/explore/feed-row.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useId } from "react";
+import { useNavigate } from "react-router";
 import { Eye, Plus, Minus } from "lucide-react";
 import { toast } from "sonner";
 import { findSubscribedFeed } from "@/lib/feed-catalog.ts";
+import { upgradeToast } from "@/lib/upgrade-toast.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
 import { FeedPreviewSheet } from "@/components/explore/feed-preview-sheet.tsx";
@@ -45,6 +47,7 @@ export function FeedRow({
   const [previewOpen, setPreviewOpen] = useState(false);
   const addFeed = useFeedStore((s) => s.addFeed);
   const removeFeed = useFeedStore((s) => s.removeFeed);
+  const navigate = useNavigate();
   const added = subscribed || justAdded;
 
   async function handleAdd() {
@@ -54,6 +57,8 @@ export function FeedRow({
     if (result.ok) {
       setJustAdded(true);
       toast.success(`Added ${name}`);
+    } else if (result.reason === "free-quota-exceeded") {
+      upgradeToast(result.error, navigate);
     } else {
       toast.error(`Failed to add ${name}`);
     }

--- a/src/components/feeds/feed-pack-card.tsx
+++ b/src/components/feeds/feed-pack-card.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import { Loader2, Plus } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button.tsx";
 import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
 import { useFeedStore } from "@/stores/feed-store.ts";
+import { upgradeToast } from "@/lib/upgrade-toast.ts";
 import type { FeedPack } from "@/lib/feed-packs.ts";
 
 interface FeedPackCardProps {
@@ -15,19 +17,29 @@ export function FeedPackCard({ pack, onComplete }: FeedPackCardProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [added, setAdded] = useState(false);
   const addFeed = useFeedStore((s) => s.addFeed);
+  const navigate = useNavigate();
 
   async function handleAdd() {
     setIsAdding(true);
     const toastId = toast.loading(`Adding ${pack.name}…`);
 
     let successCount = 0;
+    let quotaError: string | null = null;
     for (const source of pack.sources) {
-      await addFeed(source.feedUrl);
-      const error = useFeedStore.getState().error;
-      if (!error) successCount++;
+      const result = await addFeed(source.feedUrl);
+      if (result.ok) {
+        successCount++;
+      } else if (result.reason === "free-quota-exceeded") {
+        // The quota is global — every remaining source in this pack will
+        // also be refused. Stop the loop and let the user upgrade.
+        quotaError = result.error;
+        break;
+      }
     }
 
-    if (successCount === pack.sources.length) {
+    if (quotaError) {
+      upgradeToast(quotaError, navigate, { id: toastId });
+    } else if (successCount === pack.sources.length) {
       toast.success(`Added ${successCount} feeds`, { id: toastId });
     } else if (successCount > 0) {
       toast.success(

--- a/src/components/layout/sidebar-body.tsx
+++ b/src/components/layout/sidebar-body.tsx
@@ -50,17 +50,22 @@ export function SidebarBody({ onFeedSelect, onBeforeNavigate }: SidebarBodyProps
     list.some((a) => a.starred),
   );
 
-  // Filters section is gated. Free users don't see it at all — keeps
-  // the empty state honest and avoids the "upgrade to unlock"
-  // clutter pattern.
-  const showFiltersSection = filtersGate.enabled;
-
   function handleExplore() {
     onBeforeNavigate?.();
     navigate("/explore");
   }
 
+  // Honor-system open-core: the Filters section stays visible to free
+  // users so the feature is discoverable. Clicking "New filter" while
+  // gate-locked routes to the Subscription tab instead of opening an
+  // editor the user can't save from. Self-hosters and the pre-launch
+  // build relax the gate at `feature-gates.ts` and reach `openEditor`
+  // directly. See ADR 012 for the wider pattern.
   function handleCreateFilter() {
+    if (!filtersGate.enabled) {
+      filtersGate.promptUpgrade();
+      return;
+    }
     openFilterEditor(null);
   }
 
@@ -101,30 +106,30 @@ export function SidebarBody({ onFeedSelect, onBeforeNavigate }: SidebarBodyProps
               </SidebarMenuButton>
             </SidebarMenuItem>
           )}
-          {showFiltersSection && (
-            <>
-              <SidebarSeparator className="mx-0 my-1" />
-              <SidebarMenuItem key="filters-header">
-                <SidebarMenuButton
-                  onClick={handleCreateFilter}
-                  tooltip="New smart filter"
-                  data-testid="sidebar-new-filter"
-                  className="text-muted-foreground hover:text-foreground"
-                >
-                  <Plus className="size-4" />
-                  <span>New filter</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              {smartFilters.map((filter) => (
-                <SmartFilterItem
-                  key={filter.id}
-                  filter={filter}
-                  isSelected={selectedFeedId === toFilterFeedId(filter.id)}
-                  onSelect={() => onFeedSelect(toFilterFeedId(filter.id))}
-                />
-              ))}
-            </>
-          )}
+          <SidebarSeparator className="mx-0 my-1" />
+          <SidebarMenuItem key="filters-header">
+            <SidebarMenuButton
+              onClick={handleCreateFilter}
+              tooltip={
+                filtersGate.enabled
+                  ? "New smart filter"
+                  : "Smart filters — upgrade to Personal"
+              }
+              data-testid="sidebar-new-filter"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <Plus className="size-4" />
+              <span>New filter</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          {smartFilters.map((filter) => (
+            <SmartFilterItem
+              key={filter.id}
+              filter={filter}
+              isSelected={selectedFeedId === toFilterFeedId(filter.id)}
+              onSelect={() => onFeedSelect(toFilterFeedId(filter.id))}
+            />
+          ))}
           <SidebarSeparator className="mx-0 my-1" />
           <SidebarFeedList onFeedSelect={onFeedSelect} />
         </>

--- a/src/components/settings/subscription-upgrade.tsx
+++ b/src/components/settings/subscription-upgrade.tsx
@@ -42,6 +42,7 @@ export function SubscriptionUpgrade() {
         features={[
           "Everything in Free",
           "End-to-end encrypted cloud sync",
+          "Smart filters — query your feeds by keyword, tag, or source",
           "Auto-organize folders",
           "Unlimited feeds",
         ]}
@@ -68,12 +69,12 @@ export function SubscriptionUpgrade() {
 
       <TierCard
         name="Self-host"
-        price="$0 · MIT"
+        price="$0 · AGPL"
         blurb="Run your own copy. Every shipped feature unlocked."
         features={[
           "Unlimited feeds, cloud sync on your own server",
           "No license check, no kill switch",
-          "Open source under MIT",
+          "Open source under AGPL-3.0",
         ]}
         cta="Self-hosting guide →"
         ctaHref="https://www.feedzero.app/docs/self-hosting"

--- a/src/components/settings/tabs/subscription-tab.tsx
+++ b/src/components/settings/tabs/subscription-tab.tsx
@@ -369,12 +369,12 @@ function AlternativePlans({ currentTier }: AlternativePlansProps) {
       )}
       <TierCard
         name="Self-host"
-        price="$0 · MIT"
+        price="$0 · AGPL"
         blurb="Run your own copy. Every shipped feature unlocked."
         features={[
           "Unlimited feeds, cloud sync on your own server",
           "No license check, no kill switch",
-          "Open source under MIT",
+          "Open source under AGPL-3.0",
         ]}
         cta="Self-hosting guide →"
         ctaHref="https://www.feedzero.app/docs/self-hosting"

--- a/src/lib/upgrade-toast.ts
+++ b/src/lib/upgrade-toast.ts
@@ -1,0 +1,37 @@
+/**
+ * Unified "upgrade-required" toast affordance.
+ *
+ * Every gated surface that stays *discoverable* to free users (smart filters,
+ * auto-organize, feed quota at 26+) needs the same pattern: tell the user
+ * what was blocked, offer a one-click route to the Subscription tab. Routing
+ * through `goToUpgrade` keeps the destination in one place (`go-to-settings`).
+ *
+ * Honor-system open-core (ADR 012): the affordance only ever fires for
+ * hosted free users with paid tier active; self-hosters bypass at the gate
+ * and never reach this helper.
+ */
+import { toast } from "sonner";
+import type { NavigateFunction } from "react-router";
+import { goToUpgrade } from "./go-to-settings";
+
+interface UpgradeToastOptions {
+  /** Replace an existing loading toast id from `toast.loading(...)`. */
+  id?: string | number;
+  description?: string;
+}
+
+export function upgradeToast(
+  message: string,
+  navigate: NavigateFunction,
+  options?: UpgradeToastOptions,
+): void {
+  toast.error(message, {
+    id: options?.id,
+    description: options?.description,
+    duration: 8000,
+    action: {
+      label: "Upgrade",
+      onClick: () => goToUpgrade(navigate),
+    },
+  });
+}

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -27,7 +27,17 @@ import { CHANGELOG_FEED_URL, LOCAL_STORAGE } from "../utils/constants.ts";
 import { pickNextFolderColor } from "../lib/folder-colors.ts";
 import { toast } from "sonner";
 import type { Feed, Folder, FeedSortMode } from "../types/index.ts";
-import type { Result } from "../utils/result.ts";
+
+/**
+ * `addFeed` result. Result-shaped plus an optional `reason` on the err
+ * branch so call sites can distinguish a quota refusal (route the user to
+ * upgrade) from a generic failure (show "Failed to add"). Stays a
+ * structural superset of `Result<void>` so existing readers of
+ * `.ok` / `.error` continue to compile without change.
+ */
+export type AddFeedResult =
+  | { ok: true; value: void }
+  | { ok: false; error: string; reason?: "free-quota-exceeded" };
 
 /** Whether a feed is the official FeedZero release notes feed. */
 function isReleaseFeed(feed: Feed): boolean {
@@ -61,7 +71,7 @@ interface FeedStore {
    *  with an empty store before the DB is read. */
   feedsLoaded: boolean;
   loadFeeds: () => Promise<void>;
-  addFeed: (url: string) => Promise<Result<void>>;
+  addFeed: (url: string) => Promise<AddFeedResult>;
   removeFeed: (feedId: string) => Promise<void>;
   renameFeed: (feedId: string, newTitle: string) => Promise<void>;
   setFeedPreferFullText: (feedId: string, value: boolean) => Promise<void>;
@@ -199,7 +209,11 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
     if (!quota.ok) {
       const message = quotaErrorMessage(quota);
       set({ error: message });
-      return { ok: false, error: message } as const;
+      return {
+        ok: false,
+        error: message,
+        reason: "free-quota-exceeded",
+      } as const;
     }
 
     set({ isLoading: true, error: null });

--- a/tests/components/layout/sidebar-filters.test.tsx
+++ b/tests/components/layout/sidebar-filters.test.tsx
@@ -134,18 +134,27 @@ describe("AppSidebar Filters section", () => {
     expect(state.editorTarget).toBeNull();
   });
 
-  it("hides the entire Filters section for free users (gate-locked)", () => {
+  it("shows the Filters section to free users so the feature is discoverable", () => {
+    // Honor-system open-core: gated features stay visible. Clicking routes
+    // to the upgrade page rather than hiding the section. See the
+    // 'route-to-upgrade' test below for the click behaviour.
     useLicenseStore.setState({ tier: "free", verifying: false });
-    useSmartFilterStore.setState({
-      filters: [filter("a", "Tech AI")],
-    });
 
     renderSidebar();
 
-    // Section header + rows all absent
-    expect(screen.queryByTestId("sidebar-new-filter")).toBeNull();
-    expect(screen.queryAllByTestId("sidebar-smart-filter-item")).toHaveLength(
-      0,
-    );
+    expect(screen.getByTestId("sidebar-new-filter")).toBeInTheDocument();
+  });
+
+  it("clicking 'New filter' as a free user routes to the upgrade page instead of opening the editor", async () => {
+    useLicenseStore.setState({ tier: "free", verifying: false });
+
+    renderSidebar();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("sidebar-new-filter"));
+
+    // Editor MUST NOT open for gate-locked users — that would let them
+    // build a filter they can never save, an upsell anti-pattern.
+    expect(useSmartFilterStore.getState().editorOpen).toBe(false);
   });
 });

--- a/tests/components/settings/subscription-upgrade.test.tsx
+++ b/tests/components/settings/subscription-upgrade.test.tsx
@@ -51,4 +51,23 @@ describe("<SubscriptionUpgrade>", () => {
     render(<SubscriptionUpgrade />);
     expect(screen.queryByRole("button", { name: /^log in$/i })).toBeNull();
   });
+
+  it("calls out Smart filters as a headline Personal feature", () => {
+    // Smart filters are visible to free users in the sidebar (honor-system
+    // open-core) — the Personal card must name them so the upgrade target
+    // is obvious to anyone routed here from a locked surface.
+    render(<SubscriptionUpgrade />);
+    expect(screen.getByText(/smart filters/i)).toBeInTheDocument();
+  });
+
+  it("describes the self-host license as AGPL, not MIT", () => {
+    // The project ships under AGPL-3.0-or-later (see /LICENSE). The old
+    // 'MIT' wording was wrong and could mislead self-hosters reading the
+    // tier card before they read the LICENSE.
+    render(<SubscriptionUpgrade />);
+    expect(screen.queryByText(/MIT/)).toBeNull();
+    // Both "$0 · AGPL" and "Open source under AGPL-3.0" surface the license
+    // — assert ≥ 1 match so the structural copy is free to evolve.
+    expect(screen.getAllByText(/AGPL/i).length).toBeGreaterThan(0);
+  });
 });

--- a/tests/lib/upgrade-toast.test.ts
+++ b/tests/lib/upgrade-toast.test.ts
@@ -1,0 +1,49 @@
+/**
+ * `upgradeToast` — unified inline upgrade affordance used by every gated
+ * surface that should stay discoverable (smart filters, auto-organize,
+ * feed quota at 26+). Renders a sonner toast with an "Upgrade" action that
+ * navigates to the Subscription settings tab.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { upgradeToast } from "@/lib/upgrade-toast";
+import { toast } from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+describe("upgradeToast", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows an error toast with the given message and an 'Upgrade' action", () => {
+    const navigate = vi.fn();
+    upgradeToast("You've hit the limit", navigate);
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    const [message, opts] = vi.mocked(toast.error).mock.calls[0];
+    expect(message).toBe("You've hit the limit");
+    expect(opts).toMatchObject({
+      action: expect.objectContaining({ label: "Upgrade" }),
+    });
+  });
+
+  it("the Upgrade action navigates to the Subscription settings tab", () => {
+    const navigate = vi.fn();
+    upgradeToast("Hit limit", navigate);
+
+    const opts = vi.mocked(toast.error).mock.calls[0][1] as unknown as {
+      action: { onClick: (e?: unknown) => void };
+    };
+    opts.action.onClick();
+
+    expect(navigate).toHaveBeenCalledWith("/settings?tab=subscription");
+  });
+
+  it("forwards an optional toast id so callers can replace a loading toast", () => {
+    const navigate = vi.fn();
+    upgradeToast("Hit limit", navigate, { id: "loader-123" });
+
+    const opts = vi.mocked(toast.error).mock.calls[0][1] as { id: string };
+    expect(opts.id).toBe("loader-123");
+  });
+});

--- a/tests/stores/feed-store.test.ts
+++ b/tests/stores/feed-store.test.ts
@@ -310,6 +310,24 @@ describe("feed-store", () => {
         expect(useFeedStore.getState().error).toMatch(/Free limit of 25/);
       });
 
+      it("tags the failure with reason='free-quota-exceeded' so callers can route the user to upgrade", async () => {
+        // The shared upgrade pattern (feature visible → click → upgrade
+        // toast) depends on callers being able to tell a quota refusal
+        // apart from a network/parse error. The reason discriminator is
+        // the contract: every add-feed call site reads it.
+        useLicenseStore.setState({ tier: "free", verifying: false });
+        seedFeeds(25);
+
+        const result = await useFeedStore
+          .getState()
+          .addFeed("https://new.com/feed");
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.reason).toBe("free-quota-exceeded");
+        }
+      });
+
       it("does NOT block Free user with 100 feeds when the paid tier is inactive (pre-launch)", async () => {
         useLicenseStore.setState({ tier: "free", verifying: false });
         vi.mocked(isPaidTierActive).mockReturnValue(false);


### PR DESCRIPTION
Keep gated features *visible* to free users (honor-system open-core, ADR
012) but route clicks through a single upgrade affordance instead of
hiding or generic-erroring.

What
- Smart filters: the sidebar Filters section now renders for free users.
  Clicking "New filter" while gate-locked navigates to the Subscription
  tab instead of opening an editor the user can never save.
- Feed quota (26th feed): addFeed now tags the quota refusal with
  reason="free-quota-exceeded". Every add-feed call site (explore search,
  feed rows, "Add all" buttons in featured/category, feed packs) reads
  that tag and surfaces an Upgrade toast with a one-click route to the
  Subscription tab. Generic "Failed to add" stays for non-quota errors.
- Personal tier card now headlines Smart filters alongside cloud sync,
  auto-organize and unlimited feeds, so anyone routed to /settings from
  a locked surface immediately sees the upgrade target.
- Auto-organize already implemented this exact pattern (visible pill +
  inline "Upgrade — $5/mo" CTA); left unchanged as the precedent.

Self-hoster safety
- gateState() returns enabled:true via self-hosted-bypass for
  VITE_SELF_HOSTED=1 — no upgrade affordance ever renders.
- paid-tier-inactive (pre-launch) also returns enabled:true — the upgrade
  affordance only fires once the paid tier is launched.
- checkFeedQuota() bypasses for self-hosters and the pre-launch build,
  so the new reason discriminator is unreachable in those modes.

Self-host license correction
- The repo ships under AGPL-3.0-or-later (see /LICENSE). Both Self-host
  tier cards previously claimed "$0 · MIT" / "Open source under MIT".
  Updated to "$0 · AGPL" / "Open source under AGPL-3.0". ADR 012 also
  referenced MIT in three places; updated to AGPL-3.0.

Files
- New: src/lib/upgrade-toast.ts — single sonner-based helper used by
  every gated surface for consistency.
- src/stores/feed-store.ts — addFeed result widened with optional
  reason field. Structural superset of Result<void>; existing readers
  of .ok / .error keep compiling.
- Add-feed call sites: feed-row, feed-pack-card, featured-tab,
  category-detail, explore-catalog. Loops abort early on quota hit
  (the cap is global, so the next URL would refuse too).
- src/components/layout/sidebar-body.tsx — always render Filters section;
  handleCreateFilter routes via filtersGate.promptUpgrade() when locked.
- src/components/settings/subscription-upgrade.tsx,
  src/components/settings/tabs/subscription-tab.tsx — Personal feature
  list + Self-host license copy.
- docs/decisions/012-open-core-feature-gating.md — license refs.

Tests (RGR: tests written first, confirmed RED, then implementation)
- New: tests/lib/upgrade-toast.test.ts — helper contract (message,
  action label, navigation target, optional toast id).
- tests/components/layout/sidebar-filters.test.tsx — rewrote the
  "hides for free users" assertion to "shows + click routes to upgrade";
  defends against regression to the hidden-section pattern.
- tests/stores/feed-store.test.ts — new test asserts the
  reason="free-quota-exceeded" tag on addFeed refusal.
- tests/components/settings/subscription-upgrade.test.tsx — Smart
  filters appears in the Personal card; Self-host card uses AGPL not MIT.

Verify: npm test (2669 passed), npx tsc --noEmit (clean).