### PR TITLE
feat(rules): per-feed auto-action rules engine

### DIFF
--- a/docs/features/017-per-feed-rules.md
+++ b/docs/features/017-per-feed-rules.md
@@ -1,0 +1,131 @@
+# Feature 017: Per-Feed Rules
+
+## Status
+Implemented
+
+## Summary
+
+Per-feed auto-action rules. A feed can carry a list of rules; each rule
+pairs a condition (the same `ConditionGroup` AST as smart filters) with
+one or more actions (`mark-read`, `star`, `mute`, `route-to-folder`).
+Rules run on ingest during `refreshFeed` — matching articles get every
+action applied before they are encrypted and written to IndexedDB, so
+the final shape rides through the vault to every device.
+
+Rules are **per-feed by design**: they live on `Feed.rules`, not in a
+global collection. A user's mental model is "this feed is noisy in
+these specific ways" — managed from the feed's own dropdown, not a
+global rules dashboard. Global rules can be layered on later by
+composing `[...globalRules, ...feed.rules]` into the same engine;
+nothing about the v1 design forecloses that.
+
+The mute action subsumes the never-shipped `mute-keywords` tier-matrix
+entry — one feature, one engine.
+
+## Behaviour
+
+```gherkin
+Feature: Per-feed rules
+
+  Scenario: Mute a noisy keyword
+    Given I subscribe to Tech Crunchies
+    And I add a rule "title contains 'Sponsored' → mute"
+    When Tech Crunchies publishes "Sponsored: Buy this"
+    Then the article appears with muted = true
+    And it does not show in the default article list
+    And the "Show muted (N)" count for that feed reads 1
+
+  Scenario: Star a favourite author
+    Given I subscribe to Acoup
+    And I add a rule "author equals 'Bret Devereaux' → star"
+    When Acoup publishes a new post by Bret Devereaux
+    Then the article appears starred at ingest
+    And it cascades into existing offline-prefetch (starred → cached)
+
+  Scenario: Route an article to a different folder
+    Given f-tech lives in folder "Tech"
+    And I add a rule "title contains 'crypto' → route-to-folder folder-Crypto"
+    When f-tech publishes "Crypto winter, again"
+    Then the article shows up under folder "Crypto"
+    And it does not show under folder "Tech"
+    And it still shows under f-tech's own view (the feed never loses its history)
+
+  Scenario: A disabled rule does not run
+    Given I have a rule, but I have flipped its "Enabled" switch off
+    When matching articles arrive
+    Then no action runs
+    And the rule is preserved (paused, not deleted)
+
+  Scenario: Multiple rules + multiple actions per rule
+    Given rule A: title contains "Press release" → mark-read
+    And rule B: title contains "Press release" → star
+    When a matching article arrives
+    Then it is both read and starred (every matching rule runs, every action runs, in order)
+
+  Scenario: Free tier user cannot create rules
+    Given I am on the Free tier with paid-tier launched
+    When I open a feed's "Rules…" menu
+    Then the editor toasts an upgrade prompt and does not mutate the feed
+```
+
+## Architecture
+
+### Flow
+
+1. User opens a feed's dropdown menu → "Rules…" sets `rulesEditorFeedId` in feed-store.
+2. `<RulesEditorDialog>` mounts (at app root) and reads that slice. List view shows existing rules; add/edit transitions to the edit view.
+3. The edit view reuses `<ConditionGroupEditor>` (from smart filters) for the predicate and a new `<ActionPicker>` for the actions. Save → `feed-store.addFeedRule` or `feed-store.updateFeedRule`.
+4. Mutators flow through `persistFeedRules()` — a shared helper that pulls the feed from db, rewrites `Feed.rules`, writes back via `dbUpdateFeed`, reloads, schedules a sync push. One place to look when "rules don't sync" comes up in support.
+5. On `refreshFeed` ingest, after dedup but before persistence, `applyRules(article, feed.rules ?? [], buildContext(...))` produces the final article shape. Disabled rules and feeds with no rules short-circuit.
+6. The article rides through `addArticles` → encryption → IndexedDB; `muted`, `starred`, `read`, and `folderId` are all the final values from the rule pass.
+7. View derivation: default views (`ALL_FEEDS_ID`, specific feed, folder) drop muted articles unless `showMuted` is on. Folder views honour `article.folderId` override (route destination). Starred + smart-filter views are user-explicit and always show muted.
+
+### Files
+
+| File | Role |
+|------|------|
+| `src/types/index.ts` | `Rule`, `RuleAction`, `CreateRuleInput`; `Feed.rules?`; `Article.muted?`, `Article.folderId?` |
+| `src/core/storage/schema.ts` | `createRule` factory + `validateRule` for older-vault tolerance |
+| `src/core/rules/engine.ts` | Pure `applyRules(article, rules, ctx) → Article` |
+| `src/core/feeds/feed-service.ts` | Wires `applyRules` into the `refreshFeed` ingest path |
+| `src/core/features/tier-matrix.ts` | `rules` entry (Personal+, shipped); `mute-keywords` dropped |
+| `src/stores/feed-store.ts` | CRUD mutators + dialog open/close state |
+| `src/stores/article-store.ts` | `showMuted` slice + `setShowMuted` + `selectMutedCount` + folder-override-aware derivation |
+| `src/components/rules/rules-editor-dialog.tsx` | Two-mode editor (list + edit) |
+| `src/components/rules/action-picker.tsx` | Action chip list + add-action dropdown |
+| `src/components/settings/tabs/rules-audit-panel.tsx` | Read-only audit view across all feeds |
+| `src/components/sidebar/feed-item.tsx` | "Rules…" dropdown entry |
+| `src/app.tsx` | Mounts `<RulesEditorDialog>` at root |
+
+### Tests
+
+| File | Coverage |
+|------|----------|
+| `tests/core/storage/rule-schema.test.ts` | `createRule` defaults, validation rejections, `validateRule` shapes |
+| `tests/core/rules/engine.test.ts` | Pure engine: every action kind, multi-action rules, multi-rule composition, deterministic last-wins for route-to-folder, disabled-rule short-circuit, AND/OR groups, no mutation of input |
+| `tests/core/feeds/refresh-rules.test.ts` | Integration: ingest applies rules (mocks the db boundary only); covers mute, multi-action, disabled, route-to-folder, no-rules no-op, undefined-rules-array no-op |
+| `tests/stores/article-store-muted-view.test.ts` | Default views hide muted; starred view shows everything; `setShowMuted(true)` makes muted reappear; `selectMutedCount` is honest; unread badge ignores muted state |
+| `tests/stores/article-store-folder-override.test.ts` | `article.folderId` routes the article to its target folder; specific-feed view still shows everything; un-overridden articles inherit feed's folder |
+| `tests/stores/feed-store-rules.test.ts` | CRUD mutators (add, update, remove, reorder), gate-locked refusal for free tier, schema validation pass-through |
+| `tests/core/features/tier-matrix.test.ts`, `tests/core/features/feature-gates.test.ts` | `rules` is Personal+ shipped; `mute-keywords` removed from the matrix |
+| `tests/components/rules/rules-editor-dialog.test.tsx` | List + edit modes, empty state, save-disabled-until-valid, create-rule end-to-end |
+| `tests/components/rules/rules-audit-panel.test.tsx` | Empty state, grouped-by-feed rendering, paused marker, Edit button opens the right feed |
+
+## Design Decisions
+
+- **Per-feed, not global, in v1.** A noisy feed is the user's mental anchor for a rule. Per-feed scoping means the editor's discoverability matches intent (open the feed, add a rule) and the blast radius of a typo is one feed, not every feed. Global rules can be layered later by composing into the same `applyRules` call.
+- **Reuse the smart-filter `ConditionGroup` AST.** Rules and filters share predicate semantics; the only new surface is the action layer. Free regex safety, cycle guards, and unknown-feed tolerance from `evaluator.ts`.
+- **Rules nest on `Feed`, not a top-level vault collection.** Avoids a new Dexie table, a new sync field, and a migration. `Feed[]` already rides the vault — rules ride with it.
+- **Actions run at ingest, not on every render.** Smart filters re-evaluate continuously; rules transform once and persist. Different lifecycles → different concepts (see commit messages and Feature 016 for the contrast).
+- **Mute is hide, not delete.** Reversible. The article still rides the vault and still counts toward the unread badge so the user can tell when a rule has caught something. `setShowMuted(true)` brings them back.
+- **`mute-keywords` subsumed.** It was a placeholder coming-soon entry that became a single action of the broader engine. No migration needed — it never shipped.
+- **Defense-in-depth gating.** The dialog gates via `useFeatureGate("rules")`; the store mutators gate again via `isRulesGateOpen()`. A console-prodded mutator can't bypass the UI.
+- **`persistFeedRules` helper.** All four mutators flow through it, so the get-rewrite-save-reload-push dance happens in exactly one place. The "extract when the same multi-step dance repeats" rule from CLAUDE.md.
+
+## Limitations
+
+- **Single-pass on ingest only.** Edits to an existing rule don't retroactively apply to articles already in the vault. A future "Apply to existing articles" action in the editor will close this — needs a UI affordance and a batched mutator (idempotent: re-applying actions on already-correct state is a no-op).
+- **No global rules yet.** The engine takes a `Rule[]` and doesn't care where they came from; adding a `globalRules` slice + composing it into the ingest call is the v1.1 path.
+- **No tag action yet.** `apply-tag` is the most-asked-for v1.1 action per the competitor scan; it's a one-line addition to `RuleAction` plus a tag store, blocked only on whether we want to introduce tags as a first-class concept yet.
+- **No "Apply rules to existing articles" pass.** Same shape as the single-pass limitation above — would surface as a button in the editor.
+- **No browser-notification action.** `notify` was in the v1.1 candidate list; will land alongside the notifications permission UX, not before.

--- a/docs/tier-matrix.md
+++ b/docs/tier-matrix.md
@@ -48,7 +48,7 @@ Legend:
 | Feature | Free | Personal | Pro | Status |
 |---|---|---|---|---|
 | **Smart filters** — Saved queries combining feeds, keywords, authors, and read state. | — | ✓ | ✓ | Shipped |
-| **Mute keywords** — Hide articles whose title or body matches a muted keyword. | — | ✓ | ✓ | Coming soon |
+| **Rules** — Per-feed auto-action rules: mute, star, mark-read, or route articles by title, author, content, date, and more. | — | ✓ | ✓ | Shipped |
 | **Full-text search** — Search across every cached article body, title, and author. | — | — | ✓ | Coming soon |
 | **AI signal** — Local LLM ranks unread articles by relevance to topics you follow. | — | — | ✓ | Coming soon |
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
 import { CHANGELOG_FEED_URL } from "@/utils/constants.ts";
 import { Toaster } from "@/components/ui/sonner.tsx";
 import { SmartFilterEditorDialog } from "@/components/smart-filters/smart-filter-editor-dialog.tsx";
+import { RulesEditorDialog } from "@/components/rules/rules-editor-dialog.tsx";
 import { DeviceSetupWizard } from "@/components/billing/device-setup-wizard.tsx";
 import { NavigateWithSearch } from "@/components/routing/navigate-with-search.tsx";
 import { AppLayout } from "@/pages/app-layout.tsx";
@@ -268,6 +269,7 @@ export function App() {
             have router context. */}
         <DeviceSetupWizard />
         <SmartFilterEditorDialog />
+        <RulesEditorDialog />
         <Toaster position="bottom-center" />
       </BrowserRouter>
     </>

--- a/src/components/rules/action-picker.tsx
+++ b/src/components/rules/action-picker.tsx
@@ -1,0 +1,131 @@
+/**
+ * Editor for a Rule's action list. Renders each action as a chip with
+ * an inline parameter editor (folder picker for route-to-folder) and
+ * a delete button. The "Add action" dropdown surfaces the kinds the
+ * current selection does not already include — duplicate boolean
+ * actions are meaningless so we don't offer them twice.
+ */
+
+import { Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu.tsx";
+import type { Folder, RuleAction } from "@/types/index.ts";
+
+interface ActionPickerProps {
+  value: RuleAction[];
+  onChange: (next: RuleAction[]) => void;
+  folders: Folder[];
+}
+
+const KIND_LABELS: Record<RuleAction["kind"], string> = {
+  "mark-read": "Mark as read",
+  star: "Star",
+  mute: "Mute",
+  "route-to-folder": "Route to folder",
+};
+
+export function ActionPicker({ value, onChange, folders }: ActionPickerProps) {
+  const presentKinds = new Set(value.map((a) => a.kind));
+
+  function add(kind: RuleAction["kind"]) {
+    if (kind === "route-to-folder") {
+      const first = folders[0];
+      if (!first) return;
+      onChange([...value, { kind: "route-to-folder", folderId: first.id }]);
+      return;
+    }
+    onChange([...value, { kind }]);
+  }
+
+  function update(index: number, next: RuleAction) {
+    onChange(value.map((a, i) => (i === index ? next : a)));
+  }
+
+  function remove(index: number) {
+    onChange(value.filter((_, i) => i !== index));
+  }
+
+  // Boolean actions can only appear once; route-to-folder can repeat
+  // but later-wins, so usually one is enough — surface it only if not
+  // already present for the same UX consistency.
+  const available = (
+    ["mark-read", "star", "mute", "route-to-folder"] as const
+  ).filter((kind) => {
+    if (presentKinds.has(kind)) return false;
+    if (kind === "route-to-folder" && folders.length === 0) return false;
+    return true;
+  });
+
+  return (
+    <div className="space-y-2" data-testid="rule-action-picker">
+      {value.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No actions yet. Add one to make the rule do something.
+        </p>
+      )}
+      {value.map((action, index) => (
+        <div
+          key={`${action.kind}-${index}`}
+          className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm"
+        >
+          <span className="font-medium">{KIND_LABELS[action.kind]}</span>
+          {action.kind === "route-to-folder" && (
+            <select
+              value={action.folderId}
+              onChange={(e) =>
+                update(index, {
+                  kind: "route-to-folder",
+                  folderId: e.target.value,
+                })
+              }
+              className="ml-2 h-8 rounded-md border bg-background px-2 text-sm"
+              data-testid="rule-action-folder-select"
+            >
+              {folders.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.name}
+                </option>
+              ))}
+            </select>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="ml-auto h-7 w-7 p-0"
+            aria-label={`Remove ${KIND_LABELS[action.kind]}`}
+            onClick={() => remove(index)}
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      ))}
+      {available.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              data-testid="rule-action-add"
+            >
+              <Plus className="size-3.5" /> Add action
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            {available.map((kind) => (
+              <DropdownMenuItem key={kind} onClick={() => add(kind)}>
+                {KIND_LABELS[kind]}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}

--- a/src/components/rules/rules-editor-dialog.tsx
+++ b/src/components/rules/rules-editor-dialog.tsx
@@ -1,0 +1,327 @@
+/**
+ * Per-feed rules editor. A single dialog with two modes:
+ *  - LIST: shows the feed's existing rules with edit + delete actions.
+ *  - EDIT: shows the rule editor for one rule (new or existing).
+ *
+ * Mode lives in component state; the store only tracks which feed is
+ * open. Opening the dialog from a feed's dropdown sets
+ * `rulesEditorFeedId`; closing clears it.
+ */
+
+import { useEffect, useState } from "react";
+import { Plus, Trash2, Pencil, ChevronLeft, Settings2 } from "lucide-react";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Input } from "@/components/ui/input.tsx";
+import { Label } from "@/components/ui/label.tsx";
+import { Switch } from "@/components/ui/switch.tsx";
+import { ConditionGroupEditor } from "@/components/smart-filters/condition-group-editor.tsx";
+import { ActionPicker } from "./action-picker.tsx";
+import type {
+  ConditionGroup,
+  Feed,
+  Rule,
+  RuleAction,
+} from "@/types/index.ts";
+
+type Mode = { kind: "list" } | { kind: "edit"; rule: Rule | null };
+
+const EMPTY_CONDITION: ConditionGroup = {
+  kind: "group",
+  match: "all",
+  children: [],
+};
+
+export function RulesEditorDialog() {
+  const feedId = useFeedStore((s) => s.rulesEditorFeedId);
+  const closeEditor = useFeedStore((s) => s.closeRulesEditor);
+  const feeds = useFeedStore((s) => s.feeds);
+  const folders = useFeedStore((s) => s.folders);
+  const addFeedRule = useFeedStore((s) => s.addFeedRule);
+  const updateFeedRule = useFeedStore((s) => s.updateFeedRule);
+  const removeFeedRule = useFeedStore((s) => s.removeFeedRule);
+
+  const feed: Feed | undefined = feeds.find((f) => f.id === feedId);
+  const rules = feed?.rules ?? [];
+
+  const [mode, setMode] = useState<Mode>({ kind: "list" });
+
+  useEffect(() => {
+    if (!feedId) setMode({ kind: "list" });
+  }, [feedId]);
+
+  return (
+    <Dialog
+      open={Boolean(feedId)}
+      onOpenChange={(open) => {
+        if (!open) closeEditor();
+      }}
+    >
+      <DialogContent
+        data-testid="rules-editor-dialog"
+        className="max-w-2xl max-h-[85vh] overflow-y-auto"
+      >
+        {mode.kind === "list" ? (
+          <ListView
+            feed={feed}
+            rules={rules}
+            onEdit={(rule) => setMode({ kind: "edit", rule })}
+            onAdd={() => setMode({ kind: "edit", rule: null })}
+            onDelete={async (id) => {
+              if (!feedId) return;
+              await removeFeedRule(feedId, id);
+            }}
+            onClose={closeEditor}
+          />
+        ) : (
+          <EditView
+            feed={feed}
+            target={mode.rule}
+            folders={folders}
+            onBack={() => setMode({ kind: "list" })}
+            onSave={async (next) => {
+              if (!feedId) return;
+              if (mode.rule) {
+                await updateFeedRule(feedId, { ...mode.rule, ...next });
+              } else {
+                await addFeedRule(feedId, next);
+              }
+              setMode({ kind: "list" });
+            }}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ListViewProps {
+  feed: Feed | undefined;
+  rules: Rule[];
+  onEdit: (rule: Rule) => void;
+  onAdd: () => void;
+  onDelete: (id: string) => void | Promise<void>;
+  onClose: () => void;
+}
+
+function ListView({ feed, rules, onEdit, onAdd, onDelete, onClose }: ListViewProps) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <Settings2 className="size-4 text-violet-500" />
+          Rules for {feed?.title ?? "this feed"}
+        </DialogTitle>
+        <DialogDescription>
+          Rules run as new articles arrive. They modify the article — star
+          it, mark it read, hide it, or route it to a folder — before it
+          shows up in your reader.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-2">
+        {rules.length === 0 && (
+          <p
+            data-testid="rules-empty-state"
+            className="text-sm text-muted-foreground"
+          >
+            No rules yet. Add one to filter what shows up here automatically.
+          </p>
+        )}
+        {rules.map((rule) => (
+          <div
+            key={rule.id}
+            data-testid="rule-list-item"
+            className="flex items-center gap-2 rounded-md border bg-background px-3 py-2"
+          >
+            <div className="flex-1 min-w-0">
+              <p className="truncate text-sm font-medium">{rule.name}</p>
+              <p className="truncate text-xs text-muted-foreground">
+                {summariseActions(rule.actions)}
+              </p>
+            </div>
+            {!rule.enabled && (
+              <span className="text-xs text-muted-foreground">Paused</span>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              aria-label="Edit rule"
+              onClick={() => onEdit(rule)}
+            >
+              <Pencil className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0 text-destructive"
+              aria-label="Delete rule"
+              onClick={() => onDelete(rule.id)}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onAdd}
+          data-testid="rule-add"
+        >
+          <Plus className="size-4" /> Add rule
+        </Button>
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onClose}>
+          Done
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+interface EditViewProps {
+  feed: Feed | undefined;
+  target: Rule | null;
+  folders: import("@/types/index.ts").Folder[];
+  onBack: () => void;
+  onSave: (
+    next:
+      | { name: string; condition: ConditionGroup; actions: RuleAction[]; enabled?: boolean },
+  ) => void | Promise<void>;
+}
+
+function EditView({ feed, target, folders, onBack, onSave }: EditViewProps) {
+  const [name, setName] = useState(target?.name ?? "");
+  const [enabled, setEnabled] = useState(target?.enabled ?? true);
+  const [condition, setCondition] = useState<ConditionGroup>(
+    target?.condition ?? EMPTY_CONDITION,
+  );
+  const [actions, setActions] = useState<RuleAction[]>(target?.actions ?? []);
+  const [saving, setSaving] = useState(false);
+
+  const canSave = !saving && name.trim().length > 0 && actions.length > 0;
+
+  async function save() {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      await onSave({ name: name.trim(), condition, actions, enabled });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            aria-label="Back to rules list"
+            onClick={onBack}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <DialogTitle>
+            {target ? "Edit rule" : "New rule"} — {feed?.title ?? "this feed"}
+          </DialogTitle>
+        </div>
+        <DialogDescription>
+          Define when this rule matches and what it does to matching articles.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="flex-1 space-y-1.5">
+            <Label htmlFor="rule-name">Name</Label>
+            <Input
+              id="rule-name"
+              data-testid="rule-name-input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Mute sponsored posts"
+              autoFocus
+            />
+          </div>
+          <div className="flex items-center gap-2 self-end pb-1.5">
+            <Switch
+              id="rule-enabled"
+              checked={enabled}
+              onCheckedChange={setEnabled}
+              data-testid="rule-enabled-switch"
+            />
+            <Label htmlFor="rule-enabled" className="text-sm">
+              Enabled
+            </Label>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>When an article matches</Label>
+          <div className="rounded-md border bg-muted/30 p-3">
+            <ConditionGroupEditor group={condition} onChange={setCondition} />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Do this</Label>
+          <ActionPicker
+            value={actions}
+            onChange={setActions}
+            folders={folders}
+          />
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onBack}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          onClick={save}
+          disabled={!canSave}
+          data-testid="rule-save"
+        >
+          {target ? "Save changes" : "Create rule"}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function summariseActions(actions: RuleAction[]): string {
+  if (actions.length === 0) return "No actions";
+  return actions
+    .map((a) => {
+      switch (a.kind) {
+        case "mark-read":
+          return "mark as read";
+        case "star":
+          return "star";
+        case "mute":
+          return "mute";
+        case "route-to-folder":
+          return "route to folder";
+      }
+    })
+    .join(", ");
+}

--- a/src/components/settings/tabs/reading-tab.tsx
+++ b/src/components/settings/tabs/reading-tab.tsx
@@ -17,6 +17,7 @@ import { useAppStore } from "@/stores/app-store";
 import { useFeedStore } from "@/stores/feed-store";
 import { AutoOrganizeDialog } from "@/components/folders/auto-organize-dialog";
 import { ThemeToggle } from "../theme-toggle";
+import { RulesAuditPanel } from "./rules-audit-panel";
 
 export function ReadingTab() {
   const groupArticleFloods = useAppStore((s) => s.groupArticleFloods);
@@ -78,6 +79,8 @@ export function ReadingTab() {
           </Button>
         </div>
       )}
+
+      <RulesAuditPanel />
 
       <AutoOrganizeDialog
         open={autoOrganizeOpen}

--- a/src/components/settings/tabs/rules-audit-panel.tsx
+++ b/src/components/settings/tabs/rules-audit-panel.tsx
@@ -1,0 +1,123 @@
+/**
+ * Read-only audit view of every rule across every subscribed feed.
+ *
+ * Answers the "what's hiding articles from me right now?" question.
+ * Clicking a row opens the rules editor for that feed (write-side
+ * happens in the editor dialog; this view never mutates).
+ */
+
+import { Settings2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useFeedStore } from "@/stores/feed-store";
+import type { Feed, Rule, RuleAction } from "@/types/index.ts";
+
+interface FeedWithRules {
+  feed: Feed;
+  rules: Rule[];
+}
+
+function flattenFeedRules(feeds: Feed[]): FeedWithRules[] {
+  const out: FeedWithRules[] = [];
+  for (const f of feeds) {
+    if (f.rules && f.rules.length > 0) out.push({ feed: f, rules: f.rules });
+  }
+  return out;
+}
+
+function summariseActions(actions: RuleAction[]): string {
+  return actions
+    .map((a) => {
+      switch (a.kind) {
+        case "mark-read":
+          return "mark read";
+        case "star":
+          return "star";
+        case "mute":
+          return "mute";
+        case "route-to-folder":
+          return "route";
+      }
+    })
+    .join(", ");
+}
+
+export function RulesAuditPanel() {
+  const feeds = useFeedStore((s) => s.feeds);
+  const openRulesEditor = useFeedStore((s) => s.openRulesEditor);
+
+  const groups = flattenFeedRules(feeds);
+  const totalRules = groups.reduce((sum, g) => sum + g.rules.length, 0);
+
+  return (
+    <div
+      className="rounded-lg border border-border bg-card p-4 space-y-3"
+      data-testid="rules-audit-panel"
+    >
+      <div className="flex items-center gap-2">
+        <Settings2 className="size-4 text-muted-foreground" />
+        <p className="text-sm font-medium">Rules</p>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Per-feed rules run as new articles arrive — mute, star, mark
+        read, or route to a folder. Edit rules from each feed&apos;s menu.
+      </p>
+
+      {totalRules === 0 ? (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="rules-audit-empty"
+        >
+          No rules yet. Open any feed&apos;s menu and choose &quot;Rules…&quot;
+          to add one.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {groups.map(({ feed, rules }) => (
+            <div
+              key={feed.id}
+              className="rounded-md border bg-background"
+              data-testid="rules-audit-feed-group"
+            >
+              <div className="flex items-center gap-2 border-b px-3 py-2">
+                <p className="flex-1 truncate text-sm font-medium">
+                  {feed.title}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {rules.length} rule{rules.length === 1 ? "" : "s"}
+                </p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => openRulesEditor(feed.id)}
+                  aria-label={`Edit rules for ${feed.title}`}
+                >
+                  Edit
+                </Button>
+              </div>
+              <ul className="divide-y">
+                {rules.map((rule) => (
+                  <li
+                    key={rule.id}
+                    data-testid="rules-audit-rule"
+                    className="flex items-center gap-2 px-3 py-2 text-sm"
+                  >
+                    <span className="flex-1 truncate">{rule.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {summariseActions(rule.actions)}
+                    </span>
+                    {!rule.enabled && (
+                      <span className="text-xs text-muted-foreground">
+                        (paused)
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/feed-item.tsx
+++ b/src/components/sidebar/feed-item.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AlertTriangle, Check, MoreHorizontal, Pencil, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
+import { AlertTriangle, Check, MoreHorizontal, Pencil, RefreshCw, RotateCcw, Settings2, Trash2 } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -43,6 +43,7 @@ export function FeedItem({ feed, isSelected, inFolder = false, sortable = false,
   const refreshingFeedIds = useFeedStore((s) => s.refreshingFeedIds);
   const folders = useFeedStore((s) => s.folders);
   const moveFeedToFolder = useFeedStore((s) => s.moveFeedToFolder);
+  const openRulesEditor = useFeedStore((s) => s.openRulesEditor);
   const isRefreshing = refreshingFeedIds.has(feed.id);
 
   // Both hooks are always called (hooks must not be conditional).
@@ -136,6 +137,12 @@ export function FeedItem({ feed, isSelected, inFolder = false, sortable = false,
               ))}
             </>
           )}
+          <DropdownMenuItem
+            onClick={() => openRulesEditor(feed.id)}
+            data-testid="feed-item-rules"
+          >
+            <Settings2 className="size-4" /> Rules…
+          </DropdownMenuItem>
           <DropdownMenuItem onClick={() => refreshSingleFeed(feed.id)}>
             <RefreshCw className="size-4" /> Refresh
           </DropdownMenuItem>

--- a/src/core/features/tier-matrix.ts
+++ b/src/core/features/tier-matrix.ts
@@ -251,12 +251,13 @@ export const TIER_MATRIX = {
     status: "shipped",
     tiers: { free: UNAVAILABLE, personal: AVAILABLE, pro: AVAILABLE },
   },
-  "mute-keywords": {
-    id: "mute-keywords",
-    name: "Mute keywords",
-    description: "Hide articles whose title or body matches a muted keyword.",
+  rules: {
+    id: "rules",
+    name: "Rules",
+    description:
+      "Per-feed auto-action rules: mute, star, mark-read, or route articles by title, author, content, date, and more.",
     category: "filtering-and-search",
-    status: "coming-soon",
+    status: "shipped",
     tiers: { free: UNAVAILABLE, personal: AVAILABLE, pro: AVAILABLE },
   },
   search: {
@@ -384,7 +385,7 @@ export const GATED_FEATURE_IDS = [
   "auto-organize",
   "offline-prefetch",
   "filters",
-  "mute-keywords",
+  "rules",
   "search",
   "ai-signal",
   "authenticated-fetchers",

--- a/src/core/feeds/feed-service.ts
+++ b/src/core/feeds/feed-service.ts
@@ -18,6 +18,8 @@ import type { Feed, Article } from "../../types/index.ts";
 import { proxyFetch } from "../proxy/proxy-fetch.ts";
 import { groupByHostForRefresh } from "./group-by-host.ts";
 import { parseRetryAfter } from "./parse-retry-after.ts";
+import { applyRules } from "../rules/engine.ts";
+import { buildContext } from "../filters/evaluator.ts";
 
 interface AddFeedResult {
   feed: Feed;
@@ -307,7 +309,12 @@ export async function refreshFeed(feed: Feed): Promise<Result<RefreshResult>> {
       }
     }
 
-    // Store new articles
+    // Store new articles, applying any per-feed rules first so
+    // `muted` / `starred` / `read` / `folderId` ride into IndexedDB
+    // (and the encrypted vault) in their final post-rule shape. The
+    // rule engine reuses the smart-filter EvalContext; rules can't
+    // reference other rules or smart filters yet, so an empty
+    // `filters` list is fine.
     const created = newArticles
       .map((a) => {
         const r = createArticle({ feedId: feed.id, ...a });
@@ -315,8 +322,15 @@ export async function refreshFeed(feed: Feed): Promise<Result<RefreshResult>> {
       })
       .filter((a): a is Article => a !== null);
 
-    if (created.length > 0) {
-      await addArticles(created);
+    const rulesToApply = feed.rules ?? [];
+    const ruleCtx = buildContext({ feeds: [feed], filters: [] });
+    const finalArticles =
+      rulesToApply.length > 0
+        ? created.map((a) => applyRules(a, rulesToApply, ruleCtx))
+        : created;
+
+    if (finalArticles.length > 0) {
+      await addArticles(finalArticles);
     }
 
     // Update changed articles in bulk

--- a/src/core/rules/engine.ts
+++ b/src/core/rules/engine.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure rules engine: applies a feed's per-feed rules to an article.
+ *
+ * No I/O, no React, no stores. Same inputs → same output, so callers
+ * can run this on a batch of articles during `refreshFeed` ingest
+ * (mutating the article shape pre-persist) or during an explicit
+ * "Apply to existing" pass without worrying about side effects.
+ *
+ * Conflict semantics:
+ * - Multiple rules whose conditions match all apply, in the order
+ *   they appear in the feed's `rules` list (deterministic).
+ * - When two rules set conflicting fields (e.g. both
+ *   `route-to-folder` with different folderIds), the later rule
+ *   wins — the editor warns users on save when this is detectable.
+ * - Boolean actions (mute, star, mark-read) are idempotent: applying
+ *   them to an already-true field is a no-op.
+ *
+ * Pure: returns a new Article object; never mutates the input.
+ */
+
+import { evaluateGroup } from "../filters/evaluator.ts";
+import type { EvalContext } from "../filters/evaluator.ts";
+import type { Article, Rule, RuleAction } from "../../types/index.ts";
+
+/**
+ * Apply each enabled rule whose condition matches the article. Returns
+ * a new Article with all actions composed in rule order.
+ */
+export function applyRules(
+  article: Article,
+  rules: Rule[],
+  ctx: EvalContext,
+): Article {
+  let next = article;
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    if (!evaluateGroup(rule.condition, next, ctx)) continue;
+    for (const action of rule.actions) {
+      next = applyAction(next, action);
+    }
+  }
+  return next;
+}
+
+/**
+ * Apply one action to one article. Exhaustive switch — TypeScript
+ * forces every action kind to be covered, so adding a new kind to
+ * `RuleAction` is a compile-time error until the engine handles it.
+ */
+function applyAction(article: Article, action: RuleAction): Article {
+  switch (action.kind) {
+    case "mark-read":
+      return article.read ? article : { ...article, read: true };
+    case "star":
+      return article.starred
+        ? article
+        : { ...article, starred: true, starredAt: Date.now() };
+    case "mute":
+      return article.muted ? article : { ...article, muted: true };
+    case "route-to-folder":
+      return article.folderId === action.folderId
+        ? article
+        : { ...article, folderId: action.folderId };
+  }
+}

--- a/src/core/storage/schema.ts
+++ b/src/core/storage/schema.ts
@@ -5,9 +5,12 @@ import type {
   Feed,
   Article,
   SmartFilter,
+  Rule,
+  RuleAction,
   CreateFeedInput,
   CreateArticleInput,
   CreateSmartFilterInput,
+  CreateRuleInput,
 } from "../../types/index.ts";
 
 export { SCHEMA_VERSION };
@@ -110,4 +113,72 @@ export function createSmartFilter({
     createdAt: now,
     updatedAt: now,
   });
+}
+
+/**
+ * Create a new per-feed rule with sensible defaults. Rules without
+ * actions are rejected — that would just be a smart filter, and we
+ * keep the two concepts separate so a user editing a saved view
+ * doesn't accidentally mutate state.
+ */
+export function createRule({
+  name,
+  condition,
+  actions,
+  enabled = true,
+}: CreateRuleInput): Result<Rule> {
+  const trimmed = name?.trim() ?? "";
+  if (!trimmed) return err("Rule requires a name");
+  if (!condition) return err("Rule requires a condition");
+  if (!Array.isArray(actions) || actions.length === 0) {
+    return err("Rule requires at least one action");
+  }
+  const now = Date.now();
+  return ok({
+    id: crypto.randomUUID(),
+    name: trimmed,
+    enabled,
+    condition,
+    actions,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+function isValidAction(action: unknown): action is RuleAction {
+  if (!action || typeof action !== "object") return false;
+  const a = action as Record<string, unknown>;
+  switch (a.kind) {
+    case "mark-read":
+    case "star":
+    case "mute":
+      return true;
+    case "route-to-folder":
+      return typeof a.folderId === "string" && a.folderId.length > 0;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Validate a rule object. Tolerant of older shapes only where defaults
+ * make sense (missing `enabled` defaults to true in callers); rejects
+ * anything that would crash the engine at runtime — e.g. a
+ * `route-to-folder` action with no `folderId` from a malformed vault.
+ */
+export function validateRule(rule: unknown): Result<Rule> {
+  if (!rule || typeof rule !== "object") return err("Rule must be an object");
+  const r = rule as Record<string, unknown>;
+  if (typeof r.id !== "string" || !r.id) return err("Rule missing id");
+  if (typeof r.name !== "string" || !r.name) return err("Rule missing name");
+  if (!r.condition || typeof r.condition !== "object") {
+    return err("Rule missing condition");
+  }
+  if (!Array.isArray(r.actions) || r.actions.length === 0) {
+    return err("Rule must have at least one action");
+  }
+  if (!r.actions.every(isValidAction)) {
+    return err("Rule contains an invalid action");
+  }
+  return ok(rule as Rule);
 }

--- a/src/stores/article-store.ts
+++ b/src/stores/article-store.ts
@@ -47,6 +47,13 @@ interface ArticleStore {
   isLoading: boolean;
   /** User-chosen sort order for the visible article list; persisted. */
   articleSortMode: ArticleSortMode;
+  /**
+   * When false (default), muted articles are hidden from default views
+   * (ALL_FEEDS, specific feed, folder). When true, they reappear in
+   * those views. Starred and smart-filter views always show muted
+   * articles regardless — those are user-explicit selections.
+   */
+  showMuted: boolean;
   /** Preload every article into the store; used on startup and on refresh. */
   preloadAll: () => Promise<void>;
   loadArticles: (feedId: string) => Promise<void>;
@@ -61,6 +68,12 @@ interface ArticleStore {
   toggleStar: (articleId: string) => Promise<void>;
   /** Switch sort order; re-derives the visible list immediately. No-op on unknown modes. */
   setArticleSortMode: (mode: ArticleSortMode) => void;
+  /**
+   * Toggle the "Show muted" affordance. Re-derives the visible list
+   * immediately so the UI reflects the change without another action.
+   * Active feed id is recovered from feed-store rather than tracked here.
+   */
+  setShowMuted: (value: boolean) => void;
 }
 
 /** Delay before an opened article is marked as read (ms). */
@@ -80,6 +93,23 @@ export function selectUnreadCount(
   if (!articles) return 0;
   let count = 0;
   for (const a of articles) if (!a.read) count++;
+  return count;
+}
+
+/**
+ * Derived count of muted articles for a single feed. Pure function over
+ * store state — drives the "Show muted (N)" affordance in the article
+ * list footer. Muted articles are hidden by default but still counted
+ * here so the user can tell when their rules have caught something.
+ */
+export function selectMutedCount(
+  state: Pick<ArticleStore, "articlesByFeedId">,
+  feedId: string,
+): number {
+  const articles = state.articlesByFeedId[feedId];
+  if (!articles) return 0;
+  let count = 0;
+  for (const a of articles) if (a.muted) count++;
   return count;
 }
 
@@ -154,10 +184,18 @@ function deriveVisibleArticles(
   articlesByFeedId: Record<string, Article[]>,
   feedId: string,
   sortMode: ArticleSortMode,
+  showMuted: boolean,
 ): Article[] {
+  // Default views (ALL_FEEDS, specific feed, folder) suppress muted
+  // unless the user has flipped showMuted. Starred and smart-filter
+  // views are user-explicit selections and always show everything.
+  const dropMuted = (a: Article) => showMuted || !a.muted;
+
   if (feedId === ALL_FEEDS_ID) {
     const flat: Article[] = [];
-    for (const list of Object.values(articlesByFeedId)) flat.push(...list);
+    for (const list of Object.values(articlesByFeedId)) {
+      for (const a of list) if (dropMuted(a)) flat.push(a);
+    }
     return sortArticles(flat, sortMode);
   }
   if (isStarredFeedId(feedId)) {
@@ -180,11 +218,13 @@ function deriveVisibleArticles(
     );
     const flat: Article[] = [];
     for (const [id, list] of Object.entries(articlesByFeedId)) {
-      if (memberIds.has(id)) flat.push(...list);
+      if (!memberIds.has(id)) continue;
+      for (const a of list) if (dropMuted(a)) flat.push(a);
     }
     return sortArticles(flat, sortMode);
   }
-  return sortArticles(articlesByFeedId[feedId] ?? [], sortMode);
+  const list = articlesByFeedId[feedId] ?? [];
+  return sortArticles(list.filter(dropMuted), sortMode);
 }
 
 /**
@@ -257,6 +297,7 @@ export const useArticleStore = create<ArticleStore>((set, get) => ({
   selectedArticle: null,
   isLoading: false,
   articleSortMode: loadPersistedSortMode(),
+  showMuted: false,
 
   preloadAll: async () => {
     const result = await getAllArticles();
@@ -272,6 +313,7 @@ export const useArticleStore = create<ArticleStore>((set, get) => ({
       get().articlesByFeedId,
       feedId,
       sortMode,
+      get().showMuted,
     );
     set({
       articles: cachedVisible,
@@ -317,7 +359,12 @@ export const useArticleStore = create<ArticleStore>((set, get) => ({
     const nextByFeed = mergeFetchedArticles(get(), feedId, fetched);
     set({
       articlesByFeedId: nextByFeed,
-      articles: deriveVisibleArticles(nextByFeed, feedId, get().articleSortMode),
+      articles: deriveVisibleArticles(
+        nextByFeed,
+        feedId,
+        get().articleSortMode,
+        get().showMuted,
+      ),
       isLoading: false,
     });
   },
@@ -466,6 +513,22 @@ export const useArticleStore = create<ArticleStore>((set, get) => ({
     set({
       articleSortMode: mode,
       articles: sortArticles(get().articles, mode),
+    });
+  },
+
+  setShowMuted: (value) => {
+    // Re-derive against the currently-selected feed so the change is
+    // visible in the active view immediately. ALL_FEEDS_ID is the
+    // default when no feed is selected — same path the sidebar uses.
+    const activeFeedId = useFeedStore.getState().selectedFeedId ?? ALL_FEEDS_ID;
+    set({
+      showMuted: value,
+      articles: deriveVisibleArticles(
+        get().articlesByFeedId,
+        activeFeedId,
+        get().articleSortMode,
+        value,
+      ),
     });
   },
 }));

--- a/src/stores/article-store.ts
+++ b/src/stores/article-store.ts
@@ -210,16 +210,18 @@ function deriveVisibleArticles(
   }
   if (isFolderFeedId(feedId)) {
     const folderId = fromFolderFeedId(feedId)!;
-    const memberIds = new Set(
-      useFeedStore
-        .getState()
-        .feeds.filter((f) => f.folderId === folderId)
-        .map((f) => f.id),
-    );
+    const feeds = useFeedStore.getState().feeds;
+    const feedFolderById = new Map(feeds.map((f) => [f.id, f.folderId]));
     const flat: Article[] = [];
-    for (const [id, list] of Object.entries(articlesByFeedId)) {
-      if (!memberIds.has(id)) continue;
-      for (const a of list) if (dropMuted(a)) flat.push(a);
+    for (const list of Object.values(articlesByFeedId)) {
+      for (const a of list) {
+        if (!dropMuted(a)) continue;
+        // Article-level folderId override wins; otherwise inherit
+        // the article's feed folder. An article whose effective folder
+        // doesn't match the requested view is skipped.
+        const effective = a.folderId ?? feedFolderById.get(a.feedId);
+        if (effective === folderId) flat.push(a);
+      }
     }
     return sortArticles(flat, sortMode);
   }

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -116,6 +116,13 @@ interface FeedStore {
   updateFeedRule: (feedId: string, rule: Rule) => Promise<Result<Rule>>;
   removeFeedRule: (feedId: string, ruleId: string) => Promise<void>;
   reorderFeedRules: (feedId: string, orderedIds: string[]) => Promise<void>;
+  /**
+   * When non-null, the rules-editor dialog is open against this feed.
+   * Dialog mounts at the app root and reads this slice.
+   */
+  rulesEditorFeedId: string | null;
+  openRulesEditor: (feedId: string) => void;
+  closeRulesEditor: () => void;
 }
 
 function readSortMode(): FeedSortMode {
@@ -244,6 +251,9 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
   folderCustomOrder: readJsonArray(LOCAL_STORAGE.FOLDER_CUSTOM_ORDER),
   folderOpenState: {},
   feedsLoaded: false,
+  rulesEditorFeedId: null,
+  openRulesEditor: (feedId) => set({ rulesEditorFeedId: feedId }),
+  closeRulesEditor: () => set({ rulesEditorFeedId: null }),
 
   loadFeeds: async () => {
     const [feedsResult, foldersResult] = await Promise.all([getFeeds(), dbGetFolders()]);

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -9,6 +9,7 @@ import {
   updateFolder as dbUpdateFolder,
   removeFolder as dbRemoveFolder,
 } from "../core/storage/db.ts";
+import { createRule } from "../core/storage/schema.ts";
 import {
   addFeedFlow,
   refreshFeed,
@@ -26,7 +27,15 @@ import { checkFeedQuota, quotaErrorMessage } from "../core/features/quotas.ts";
 import { CHANGELOG_FEED_URL, LOCAL_STORAGE } from "../utils/constants.ts";
 import { pickNextFolderColor } from "../lib/folder-colors.ts";
 import { toast } from "sonner";
-import type { Feed, Folder, FeedSortMode } from "../types/index.ts";
+import type {
+  Feed,
+  Folder,
+  FeedSortMode,
+  Rule,
+  CreateRuleInput,
+} from "../types/index.ts";
+import type { Result } from "../utils/result.ts";
+import { ok, err } from "../utils/result.ts";
 
 /**
  * `addFeed` result. Result-shaped plus an optional `reason` on the err
@@ -94,6 +103,19 @@ interface FeedStore {
   folderOpenState: Record<string, boolean>;
   setFolderOpen: (folderId: string, open: boolean) => void;
   toggleFolderOpen: (folderId: string) => void;
+  /**
+   * Per-feed rule CRUD. Rules nest on Feed.rules and ride the existing
+   * encrypted vault payload — no new collection. Every mutator is gated
+   * on the `rules` feature (Personal+) for defense-in-depth; the UI
+   * gates again via `useFeatureGate`.
+   */
+  addFeedRule: (
+    feedId: string,
+    input: CreateRuleInput,
+  ) => Promise<Result<Rule>>;
+  updateFeedRule: (feedId: string, rule: Rule) => Promise<Result<Rule>>;
+  removeFeedRule: (feedId: string, ruleId: string) => Promise<void>;
+  reorderFeedRules: (feedId: string, orderedIds: string[]) => Promise<void>;
 }
 
 function readSortMode(): FeedSortMode {
@@ -114,6 +136,43 @@ function readJsonArray(key: string): string[] {
 
 function sortFoldersByName(folders: Folder[]): Folder[] {
   return [...folders].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** True when the current session may mutate per-feed rules. */
+function isRulesGateOpen(): boolean {
+  return gateState(
+    "rules",
+    useLicenseStore.getState().tier,
+    isSelfHosted(),
+    isPaidTierActive(),
+  ).enabled;
+}
+
+/**
+ * Rewrite a feed's `rules` list, persist via dbUpdateFeed, and refresh
+ * the in-memory snapshot. Shared by every rule mutator so reload + sync
+ * push happen in exactly one place — the "extract a helper when the
+ * same multi-step dance repeats" rule from CLAUDE.md.
+ */
+async function persistFeedRules(
+  feedId: string,
+  rewrite: (current: Rule[]) => Rule[],
+  set: (
+    partial: Partial<FeedStore> | ((s: FeedStore) => Partial<FeedStore>),
+  ) => void,
+): Promise<Result<Rule[]>> {
+  const feedResult = await getFeed(feedId);
+  if (!feedResult.ok) return err(feedResult.error);
+  const current = feedResult.value.rules ?? [];
+  const next = rewrite(current);
+  await dbUpdateFeed({
+    ...feedResult.value,
+    rules: next,
+    updatedAt: Date.now(),
+  });
+  await reloadFeeds(set);
+  schedulePush();
+  return ok(next);
 }
 
 /**
@@ -466,6 +525,70 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
 
     await reloadFeeds(set);
     schedulePush();
+  },
+
+  addFeedRule: async (feedId, input) => {
+    if (!isRulesGateOpen()) {
+      toast("Rules are a Personal feature. Subscribe to unlock.");
+      return err("Rules require the Personal tier");
+    }
+    const created = createRule(input);
+    if (!created.ok) return err(created.error);
+
+    const persisted = await persistFeedRules(
+      feedId,
+      (current) => [...current, created.value],
+      set,
+    );
+    if (!persisted.ok) return err(persisted.error);
+    return ok(created.value);
+  },
+
+  updateFeedRule: async (feedId, rule) => {
+    if (!isRulesGateOpen()) {
+      toast("Rules are a Personal feature. Subscribe to unlock.");
+      return err("Rules require the Personal tier");
+    }
+    let found = false;
+    const result = await persistFeedRules(
+      feedId,
+      (current) =>
+        current.map((r) => {
+          if (r.id !== rule.id) return r;
+          found = true;
+          return { ...rule, updatedAt: Date.now() };
+        }),
+      set,
+    );
+    if (!result.ok) return err(result.error);
+    if (!found) return err(`Rule ${rule.id} not found on feed ${feedId}`);
+    return ok({ ...rule, updatedAt: Date.now() });
+  },
+
+  removeFeedRule: async (feedId, ruleId) => {
+    if (!isRulesGateOpen()) return;
+    await persistFeedRules(
+      feedId,
+      (current) => current.filter((r) => r.id !== ruleId),
+      set,
+    );
+  },
+
+  reorderFeedRules: async (feedId, orderedIds) => {
+    if (!isRulesGateOpen()) return;
+    await persistFeedRules(
+      feedId,
+      (current) => {
+        const byId = new Map(current.map((r) => [r.id, r]));
+        const reordered: Rule[] = [];
+        for (const id of orderedIds) {
+          const r = byId.get(id);
+          if (r) reordered.push(r);
+        }
+        return reordered;
+      },
+      set,
+    );
   },
 }));
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,15 @@ export interface Feed {
   lastFetchedAt?: number;
   /** Unix epoch ms of the last refresh attempt that returned HTTP 2xx. */
   lastSuccessfulFetchAt?: number;
+  /**
+   * Per-feed auto-action rules evaluated on ingest. Each rule's
+   * condition is matched against newly-fetched articles; matching
+   * articles get every action in `rule.actions` applied before
+   * persistence. Rules are scoped to this feed only — global rules
+   * may be layered later by composing additional lists into the same
+   * `applyRules` call.
+   */
+  rules?: Rule[];
 }
 
 export interface Folder {
@@ -39,6 +48,19 @@ export interface Article {
   starred?: boolean;
   /** Unix epoch ms of the most recent star action; used to sort the starred view. */
   starredAt?: number;
+  /**
+   * Hidden from default article lists. Set by a rule's `mute` action on
+   * ingest, surfaceable via a "Show muted" affordance. Muted is distinct
+   * from `read`: read articles still appear in read-views, muted articles
+   * don't appear anywhere by default.
+   */
+  muted?: boolean;
+  /**
+   * Per-article folder override set by a `route-to-folder` rule action.
+   * When absent, the article inherits its feed's `folderId`. When present,
+   * the article appears under this folder regardless of its feed's folder.
+   */
+  folderId?: string;
   /**
    * Sanitized full-text HTML extracted from `link` and persisted for offline
    * reading. Populated by the background prefetch service for starred
@@ -151,4 +173,43 @@ export interface CreateSmartFilterInput {
   color?: string;
   sortMode?: ArticleSortMode;
   limit?: number;
+}
+
+/**
+ * A side-effecting action a `Rule` applies to a matching article on
+ * ingest. Discriminated on `kind` so adding a new action forces an
+ * exhaustive update to `applyRules`. Reversible state — never delete.
+ */
+export type RuleAction =
+  | { kind: "mark-read" }
+  | { kind: "star" }
+  | { kind: "mute" }
+  | { kind: "route-to-folder"; folderId: string };
+
+/**
+ * Per-feed auto-action rule. Stored nested on `Feed.rules` and synced
+ * through the same vault payload as the feed itself — no new collection
+ * required. Rules evaluate on `refreshFeed` ingest, before articles
+ * are persisted; they may also be re-applied to existing articles via
+ * an explicit "Apply to existing" action in the editor.
+ */
+export interface Rule {
+  id: string;
+  /** Human-readable label shown in the rule editor list. */
+  name: string;
+  /** Paused rules persist but do not run. Saves users from deleting + recreating. */
+  enabled: boolean;
+  /** Same boolean AST as smart filters — reuses `evaluateGroup`. */
+  condition: ConditionGroup;
+  /** Applied in order; every action in the list runs when the rule matches. */
+  actions: RuleAction[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CreateRuleInput {
+  name: string;
+  condition: ConditionGroup;
+  actions: RuleAction[];
+  enabled?: boolean;
 }

--- a/tests/components/rules/rules-audit-panel.test.tsx
+++ b/tests/components/rules/rules-audit-panel.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { RulesAuditPanel } from "@/components/settings/tabs/rules-audit-panel";
+import { useFeedStore } from "@/stores/feed-store";
+import type { Feed, Rule } from "@/types/index.ts";
+
+vi.mock("@/core/storage/db.ts", () => ({
+  getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getFeed: vi.fn(),
+  updateFeed: vi.fn(),
+  addFolder: vi.fn(),
+  getFolders: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  updateFolder: vi.fn(),
+  removeFolder: vi.fn(),
+  removeFeed: vi.fn(),
+}));
+
+vi.mock("@/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn(),
+  reloadFeed: vi.fn(),
+}));
+
+vi.mock("@/core/extractor/prefetch-service.ts", () => ({
+  prefetchStarredArticles: vi.fn(),
+}));
+
+vi.mock("@/core/sync/sync-service", () => ({
+  pushVault: vi.fn(),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+function feed(id: string, title: string, rules: Rule[] = []): Feed {
+  return {
+    id,
+    url: `https://${id}.example.com/feed.xml`,
+    title,
+    description: "",
+    siteUrl: "",
+    createdAt: 0,
+    updatedAt: 0,
+    rules,
+  };
+}
+
+function rule(id: string, name: string, enabled = true): Rule {
+  return {
+    id,
+    name,
+    enabled,
+    condition: { kind: "group", match: "all", children: [] },
+    actions: [{ kind: "mute" }],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("RulesAuditPanel", () => {
+  beforeEach(() => {
+    useFeedStore.setState({
+      feeds: [],
+      folders: [],
+      rulesEditorFeedId: null,
+    });
+  });
+
+  it("renders an empty state when no feed has any rules", () => {
+    render(
+      <MemoryRouter>
+        <RulesAuditPanel />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("rules-audit-empty")).toBeInTheDocument();
+  });
+
+  it("renders one group per feed that has rules, with each rule listed", () => {
+    useFeedStore.setState({
+      feeds: [
+        feed("f1", "Tech Crunchies", [rule("r1", "Mute sponsored")]),
+        feed("f2", "Plain Feed"),
+        feed("f3", "News Mix", [
+          rule("r2", "Star Bret"),
+          rule("r3", "Hide press releases", false),
+        ]),
+      ],
+      folders: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <RulesAuditPanel />
+      </MemoryRouter>,
+    );
+
+    const groups = screen.getAllByTestId("rules-audit-feed-group");
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toHaveTextContent("Tech Crunchies");
+    expect(groups[1]).toHaveTextContent("News Mix");
+
+    const items = screen.getAllByTestId("rules-audit-rule");
+    expect(items).toHaveLength(3);
+    expect(items.map((i) => i.textContent)).toEqual([
+      expect.stringContaining("Mute sponsored"),
+      expect.stringContaining("Star Bret"),
+      expect.stringContaining("Hide press releases"),
+    ]);
+
+    // Disabled rule shows a "paused" marker.
+    const lastRule = items[2];
+    expect(lastRule).toHaveTextContent("paused");
+  });
+
+  it("Edit button calls openRulesEditor with the feed id", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [feed("f1", "Tech Crunchies", [rule("r1", "Mute sponsored")])],
+      folders: [],
+    });
+    render(
+      <MemoryRouter>
+        <RulesAuditPanel />
+      </MemoryRouter>,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Edit rules for Tech Crunchies/i }),
+    );
+    expect(useFeedStore.getState().rulesEditorFeedId).toBe("f1");
+  });
+});

--- a/tests/components/rules/rules-editor-dialog.test.tsx
+++ b/tests/components/rules/rules-editor-dialog.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { RulesEditorDialog } from "@/components/rules/rules-editor-dialog.tsx";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import { useLicenseStore } from "@/stores/license-store.ts";
+import type { Feed, Rule } from "@/types/index.ts";
+
+vi.mock("@/core/storage/db.ts", () => {
+  const feeds = new Map<string, Feed>();
+  return {
+    getFeed: vi.fn(async (id: string) => {
+      const f = feeds.get(id);
+      return f
+        ? { ok: true as const, value: f }
+        : { ok: false as const, error: "not found" };
+    }),
+    getFeeds: vi.fn(async () => ({ ok: true, value: [...feeds.values()] })),
+    updateFeed: vi.fn(async (f: Feed) => {
+      feeds.set(f.id, f);
+      return { ok: true, value: true };
+    }),
+    addFolder: vi.fn(),
+    getFolders: vi.fn(async () => ({ ok: true, value: [] })),
+    updateFolder: vi.fn(),
+    removeFolder: vi.fn(),
+    removeFeed: vi.fn(),
+    _seed: (f: Feed) => feeds.set(f.id, f),
+    _reset: () => feeds.clear(),
+  };
+});
+
+vi.mock("@/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn(),
+  reloadFeed: vi.fn(),
+}));
+
+vi.mock("@/core/extractor/prefetch-service.ts", () => ({
+  prefetchStarredArticles: vi.fn(),
+}));
+
+vi.mock("@/core/sync/sync-service", () => ({
+  pushVault: vi.fn().mockResolvedValue({ ok: true, value: Date.now() }),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+vi.mock("@/core/features/paid-tier-active.ts", () => ({
+  isPaidTierActive: () => true,
+}));
+
+import * as db from "@/core/storage/db.ts";
+const dbMock = db as unknown as {
+  _seed: (f: Feed) => void;
+  _reset: () => void;
+};
+
+function feed(rules: Rule[] = []): Feed {
+  return {
+    id: "f1",
+    url: "https://example.com/feed.xml",
+    title: "Tech Crunchies",
+    description: "",
+    siteUrl: "",
+    createdAt: 0,
+    updatedAt: 0,
+    rules,
+  };
+}
+
+function muteRule(name = "Mute sponsored"): Rule {
+  return {
+    id: "r-1",
+    name,
+    enabled: true,
+    condition: {
+      kind: "group",
+      match: "all",
+      children: [{ kind: "title", op: "contains", value: "sponsored" }],
+    },
+    actions: [{ kind: "mute" }],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function renderDialog() {
+  return render(
+    <MemoryRouter>
+      <RulesEditorDialog />
+    </MemoryRouter>,
+  );
+}
+
+describe("RulesEditorDialog", () => {
+  beforeEach(() => {
+    dbMock._reset();
+    useLicenseStore.setState({ tier: "personal" });
+    useFeedStore.setState({
+      feeds: [],
+      folders: [],
+      rulesEditorFeedId: null,
+    });
+  });
+
+  it("does not render any dialog when rulesEditorFeedId is null", () => {
+    renderDialog();
+    expect(screen.queryByTestId("rules-editor-dialog")).toBeNull();
+  });
+
+  it("opens with the feed's title in the header when rulesEditorFeedId is set", () => {
+    const f = feed();
+    useFeedStore.setState({ feeds: [f], rulesEditorFeedId: "f1" });
+    renderDialog();
+    expect(screen.getByTestId("rules-editor-dialog")).toBeInTheDocument();
+    expect(screen.getByText(/Tech Crunchies/)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the feed has no rules", () => {
+    useFeedStore.setState({ feeds: [feed()], rulesEditorFeedId: "f1" });
+    renderDialog();
+    expect(screen.getByTestId("rules-empty-state")).toBeInTheDocument();
+  });
+
+  it("lists existing rules with their name and a summary of actions", () => {
+    useFeedStore.setState({
+      feeds: [feed([muteRule("Hide sponsored")])],
+      rulesEditorFeedId: "f1",
+    });
+    renderDialog();
+    const items = screen.getAllByTestId("rule-list-item");
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent("Hide sponsored");
+    expect(items[0]).toHaveTextContent("mute");
+  });
+
+  it("enters edit mode when 'Add rule' is clicked", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feeds: [feed()], rulesEditorFeedId: "f1" });
+    renderDialog();
+    await user.click(screen.getByTestId("rule-add"));
+    expect(screen.getByTestId("rule-name-input")).toBeInTheDocument();
+  });
+
+  it("disables Save when the rule has no name or no actions", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feeds: [feed()], rulesEditorFeedId: "f1" });
+    renderDialog();
+    await user.click(screen.getByTestId("rule-add"));
+    const save = screen.getByTestId("rule-save");
+    expect(save).toBeDisabled();
+  });
+
+  it("creates a new rule when Save is clicked with a name + action", async () => {
+    const user = userEvent.setup();
+    const f = feed();
+    dbMock._seed(f);
+    useFeedStore.setState({ feeds: [f], rulesEditorFeedId: "f1" });
+    renderDialog();
+
+    await user.click(screen.getByTestId("rule-add"));
+    await user.type(screen.getByTestId("rule-name-input"), "Mute spam");
+
+    await user.click(screen.getByTestId("rule-action-add"));
+    await user.click(screen.getByText("Mute"));
+
+    const save = screen.getByTestId("rule-save");
+    expect(save).not.toBeDisabled();
+    await user.click(save);
+
+    // After save we return to the list view; the new rule appears.
+    expect(screen.getByTestId("rule-list-item")).toBeInTheDocument();
+    expect(screen.getByText("Mute spam")).toBeInTheDocument();
+  });
+});

--- a/tests/core/features/feature-gates.test.ts
+++ b/tests/core/features/feature-gates.test.ts
@@ -90,10 +90,10 @@ describe("gateState — shipped features (paid tier inactive / pre-launch)", () 
 
   it("coming-soon features stay not-built even when paid tier is inactive", () => {
     // Inactivating the paid tier mustn't pretend that code exists.
-    // `mute-keywords` is still gated coming-soon (per FEATURE_MAP);
-    // `filters` flipped to shipped when the smart-filters feature
-    // landed (slice 5 of that change).
-    const state = gateState("mute-keywords", "free", false, false);
+    // `search` is still gated coming-soon (per FEATURE_MAP). The old
+    // `mute-keywords` entry was subsumed by `rules` when the per-feed
+    // rules engine landed.
+    const state = gateState("search", "free", false, false);
     expect(state.enabled).toBe(false);
     expect(state.reason).toBe("not-built");
   });

--- a/tests/core/features/tier-matrix.test.ts
+++ b/tests/core/features/tier-matrix.test.ts
@@ -84,9 +84,9 @@ describe("tier-matrix — currently shipped gated features", () => {
 });
 
 describe("tier-matrix — coming-soon features", () => {
-  it("mute-keywords is Personal+, coming-soon", () => {
-    expect(getEntry("mute-keywords").status).toBe("coming-soon");
-    expect(getRequiredTier("mute-keywords")).toBe("personal");
+  it("rules is Personal+, shipped (subsumed mute-keywords)", () => {
+    expect(getEntry("rules").status).toBe("shipped");
+    expect(getRequiredTier("rules")).toBe("personal");
   });
 
   it.each([
@@ -141,7 +141,7 @@ describe("tier-matrix — derived helpers", () => {
   it("isGated is true for features with at least one tier denied", () => {
     expect(isGated("auto-organize")).toBe(true);
     expect(isGated("offline-prefetch")).toBe(true);
-    expect(isGated("mute-keywords")).toBe(true);
+    expect(isGated("rules")).toBe(true);
   });
 
   it("isGated is false for always-free features", () => {
@@ -169,7 +169,7 @@ describe("tier-matrix — back-compat with feature-gates.FEATURE_MAP", () => {
       "auto-organize",
       "offline-prefetch",
       "filters",
-      "mute-keywords",
+      "rules",
       "search",
       "ai-signal",
       "authenticated-fetchers",

--- a/tests/core/feeds/refresh-rules.test.ts
+++ b/tests/core/feeds/refresh-rules.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Integration: refreshFeed applies the feed's per-feed rules to each
+ * newly-ingested article before persistence. Mocks the db boundary
+ * only (per CLAUDE.md "mock at the boundary"), exercises the real
+ * rules engine + filter evaluator end to end.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Article, Feed, Rule } from "../../../src/types/index.ts";
+
+const SPONSORED_FEED_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Mixed Feed</title>
+  <link href="https://example.com" rel="alternate"/>
+  <entry>
+    <title>Real article about something</title>
+    <link href="https://example.com/real-1" rel="alternate"/>
+    <id>real-1</id>
+    <published>2024-01-15T12:00:00Z</published>
+    <content type="html">&lt;p&gt;Body&lt;/p&gt;</content>
+    <author><name>Alice</name></author>
+  </entry>
+  <entry>
+    <title>Sponsored: Buy this thing</title>
+    <link href="https://example.com/spam-1" rel="alternate"/>
+    <id>spam-1</id>
+    <published>2024-01-15T13:00:00Z</published>
+    <content type="html">&lt;p&gt;Ad&lt;/p&gt;</content>
+    <author><name>Bob</name></author>
+  </entry>
+</feed>`;
+
+vi.mock("../../../src/core/storage/db.ts", () => {
+  const articles = new Map<string, Article>();
+  return {
+    getArticleByGuid: vi.fn(async () => ({ ok: true, value: null })),
+    addArticles: vi.fn(async (arts: Article[]) => {
+      for (const a of arts) articles.set(a.id, a);
+      return { ok: true, value: true };
+    }),
+    updateArticles: vi.fn(async () => ({ ok: true, value: true })),
+    updateFeed: vi.fn(async () => ({ ok: true, value: true })),
+    _articles: articles,
+    _reset: () => articles.clear(),
+  };
+});
+
+let refreshFeed: typeof import("../../../src/core/feeds/feed-service.ts").refreshFeed;
+let db: typeof import("../../../src/core/storage/db.ts") & {
+  _articles: Map<string, Article>;
+  _reset: () => void;
+};
+
+beforeEach(async () => {
+  db = (await import("../../../src/core/storage/db.ts")) as never;
+  db._reset();
+  vi.clearAllMocks();
+
+  const mod = await import("../../../src/core/feeds/feed-service.ts");
+  refreshFeed = mod.refreshFeed;
+
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(SPONSORED_FEED_XML),
+  });
+});
+
+function feed(rules: Rule[] = []): Feed {
+  return {
+    id: "f-test",
+    url: "https://example.com/feed.xml",
+    title: "Test feed",
+    description: "",
+    siteUrl: "https://example.com",
+    createdAt: 0,
+    updatedAt: 0,
+    rules,
+  };
+}
+
+function muteSponsoredRule(): Rule {
+  return {
+    id: "r-mute",
+    name: "Mute sponsored",
+    enabled: true,
+    condition: {
+      kind: "group",
+      match: "all",
+      children: [{ kind: "title", op: "contains", value: "Sponsored" }],
+    },
+    actions: [{ kind: "mute" }],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("refreshFeed × rules", () => {
+  it("applies a feed's rules to newly-ingested articles", async () => {
+    const result = await refreshFeed(feed([muteSponsoredRule()]));
+    expect(result.ok).toBe(true);
+
+    const persisted = Array.from(db._articles.values());
+    expect(persisted).toHaveLength(2);
+
+    const real = persisted.find((a) => a.title.startsWith("Real"));
+    const sponsored = persisted.find((a) => a.title.startsWith("Sponsored"));
+
+    // Sponsored article muted by the rule
+    expect(sponsored?.muted).toBe(true);
+    // Real article untouched
+    expect(real?.muted).toBeUndefined();
+  });
+
+  it("is a no-op when the feed has no rules", async () => {
+    const result = await refreshFeed(feed([]));
+    expect(result.ok).toBe(true);
+
+    const persisted = Array.from(db._articles.values());
+    expect(persisted).toHaveLength(2);
+    expect(persisted.every((a) => !a.muted)).toBe(true);
+  });
+
+  it("is a no-op when the feed's rules field is undefined (older vault)", async () => {
+    const f = feed();
+    delete (f as Partial<Feed>).rules;
+    const result = await refreshFeed(f);
+    expect(result.ok).toBe(true);
+    expect(Array.from(db._articles.values()).every((a) => !a.muted)).toBe(true);
+  });
+
+  it("applies multiple actions from a single rule (star + mark-read)", async () => {
+    const r: Rule = {
+      ...muteSponsoredRule(),
+      id: "r-multi",
+      name: "Star + read sponsored",
+      actions: [{ kind: "star" }, { kind: "mark-read" }],
+    };
+    await refreshFeed(feed([r]));
+    const sponsored = Array.from(db._articles.values()).find((a) =>
+      a.title.startsWith("Sponsored"),
+    );
+    expect(sponsored?.starred).toBe(true);
+    expect(sponsored?.read).toBe(true);
+  });
+
+  it("does not apply disabled rules", async () => {
+    const r: Rule = { ...muteSponsoredRule(), enabled: false };
+    await refreshFeed(feed([r]));
+    const sponsored = Array.from(db._articles.values()).find((a) =>
+      a.title.startsWith("Sponsored"),
+    );
+    expect(sponsored?.muted).toBeUndefined();
+  });
+
+  it("route-to-folder sets the article-level folderId override", async () => {
+    const r: Rule = {
+      ...muteSponsoredRule(),
+      actions: [{ kind: "route-to-folder", folderId: "folder-spam" }],
+    };
+    await refreshFeed(feed([r]));
+    const sponsored = Array.from(db._articles.values()).find((a) =>
+      a.title.startsWith("Sponsored"),
+    );
+    expect(sponsored?.folderId).toBe("folder-spam");
+  });
+});

--- a/tests/core/rules/engine.test.ts
+++ b/tests/core/rules/engine.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { applyRules } from "../../../src/core/rules/engine.ts";
+import { buildContext } from "../../../src/core/filters/evaluator.ts";
+import type {
+  Article,
+  Feed,
+  Rule,
+  ConditionGroup,
+} from "../../../src/types/index.ts";
+
+function article(overrides: Partial<Article> = {}): Article {
+  return {
+    id: "a-1",
+    feedId: "f-1",
+    guid: "g-1",
+    title: "Hello world",
+    link: "https://example.com/a-1",
+    content: "Body",
+    summary: "Summary",
+    author: "Alice",
+    publishedAt: 1_700_000_000_000,
+    read: false,
+    createdAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function feed(overrides: Partial<Feed> = {}): Feed {
+  return {
+    id: "f-1",
+    url: "https://example.com/feed.xml",
+    title: "Example",
+    description: "",
+    siteUrl: "https://example.com",
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function rule(
+  condition: ConditionGroup,
+  actions: Rule["actions"],
+  overrides: Partial<Rule> = {},
+): Rule {
+  return {
+    id: "r-1",
+    name: "Test rule",
+    enabled: true,
+    condition,
+    actions,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+const titleContains = (value: string): ConditionGroup => ({
+  kind: "group",
+  match: "all",
+  children: [{ kind: "title", op: "contains", value }],
+});
+
+describe("applyRules", () => {
+  const ctx = buildContext({ feeds: [feed()], filters: [] });
+
+  it("returns the article unchanged when no rules are provided", () => {
+    const out = applyRules(article(), [], ctx);
+    expect(out).toEqual(article());
+  });
+
+  it("returns the article unchanged when no rule matches", () => {
+    const r = rule(titleContains("never matches"), [{ kind: "mute" }]);
+    const out = applyRules(article(), [r], ctx);
+    expect(out.muted).toBeUndefined();
+  });
+
+  it("applies mute action when condition matches", () => {
+    const r = rule(titleContains("Hello"), [{ kind: "mute" }]);
+    const out = applyRules(article(), [r], ctx);
+    expect(out.muted).toBe(true);
+  });
+
+  it("applies star action when condition matches", () => {
+    const r = rule(titleContains("Hello"), [{ kind: "star" }]);
+    const out = applyRules(article(), [r], ctx);
+    expect(out.starred).toBe(true);
+    expect(out.starredAt).toBeGreaterThan(0);
+  });
+
+  it("applies mark-read action when condition matches", () => {
+    const r = rule(titleContains("Hello"), [{ kind: "mark-read" }]);
+    const out = applyRules(article(), [r], ctx);
+    expect(out.read).toBe(true);
+  });
+
+  it("applies route-to-folder action when condition matches", () => {
+    const r = rule(titleContains("Hello"), [
+      { kind: "route-to-folder", folderId: "folder-X" },
+    ]);
+    const out = applyRules(article(), [r], ctx);
+    expect(out.folderId).toBe("folder-X");
+  });
+
+  it("applies multiple actions in a single rule (star + mark-read)", () => {
+    const r = rule(titleContains("Hello"), [
+      { kind: "star" },
+      { kind: "mark-read" },
+    ]);
+    const out = applyRules(article(), [r], ctx);
+    expect(out.starred).toBe(true);
+    expect(out.read).toBe(true);
+  });
+
+  it("applies actions across multiple matching rules in order", () => {
+    const rules = [
+      rule(titleContains("Hello"), [{ kind: "star" }], { id: "r-a" }),
+      rule(titleContains("world"), [{ kind: "mark-read" }], { id: "r-b" }),
+    ];
+    const out = applyRules(article(), rules, ctx);
+    expect(out.starred).toBe(true);
+    expect(out.read).toBe(true);
+  });
+
+  it("later route-to-folder rule overrides earlier one (deterministic last-wins)", () => {
+    const rules = [
+      rule(titleContains("Hello"), [{ kind: "route-to-folder", folderId: "first" }], { id: "r-a" }),
+      rule(titleContains("Hello"), [{ kind: "route-to-folder", folderId: "second" }], { id: "r-b" }),
+    ];
+    const out = applyRules(article(), rules, ctx);
+    expect(out.folderId).toBe("second");
+  });
+
+  it("skips disabled rules even when their condition matches", () => {
+    const r = rule(titleContains("Hello"), [{ kind: "mute" }], { enabled: false });
+    const out = applyRules(article(), [r], ctx);
+    expect(out.muted).toBeUndefined();
+  });
+
+  it("does not mutate the input article (pure function)", () => {
+    const input = article();
+    const r = rule(titleContains("Hello"), [{ kind: "mute" }]);
+    applyRules(input, [r], ctx);
+    expect(input.muted).toBeUndefined();
+  });
+
+  it("preserves existing fields not touched by actions", () => {
+    const input = article({ author: "Important", content: "<p>keep</p>" });
+    const r = rule(titleContains("Hello"), [{ kind: "mute" }]);
+    const out = applyRules(input, [r], ctx);
+    expect(out.author).toBe("Important");
+    expect(out.content).toBe("<p>keep</p>");
+    expect(out.muted).toBe(true);
+  });
+
+  it("respects existing read state (mark-read on an already-read article is a no-op-ish)", () => {
+    const input = article({ read: true });
+    const r = rule(titleContains("Hello"), [{ kind: "mark-read" }]);
+    const out = applyRules(input, [r], ctx);
+    expect(out.read).toBe(true);
+  });
+
+  it("supports AND groups (match: 'all')", () => {
+    const cond: ConditionGroup = {
+      kind: "group",
+      match: "all",
+      children: [
+        { kind: "title", op: "contains", value: "Hello" },
+        { kind: "author", op: "contains", value: "Alice" },
+      ],
+    };
+    const r = rule(cond, [{ kind: "mute" }]);
+    const out = applyRules(article(), [r], ctx);
+    expect(out.muted).toBe(true);
+  });
+
+  it("supports OR groups (match: 'any')", () => {
+    const cond: ConditionGroup = {
+      kind: "group",
+      match: "any",
+      children: [
+        { kind: "title", op: "contains", value: "never" },
+        { kind: "author", op: "contains", value: "Alice" },
+      ],
+    };
+    const r = rule(cond, [{ kind: "mute" }]);
+    const out = applyRules(article(), [r], ctx);
+    expect(out.muted).toBe(true);
+  });
+});

--- a/tests/core/storage/rule-schema.test.ts
+++ b/tests/core/storage/rule-schema.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { createRule, validateRule } from "../../../src/core/storage/schema.ts";
+import type { ConditionGroup } from "../../../src/types/index.ts";
+
+const matchAll: ConditionGroup = {
+  kind: "group",
+  match: "all",
+  children: [
+    { kind: "title", op: "contains", value: "sponsored" },
+  ],
+};
+
+describe("createRule", () => {
+  it("fills id + timestamps + defaults a disabled rule to enabled", () => {
+    const before = Date.now();
+    const result = createRule({
+      name: "Mute sponsored",
+      condition: matchAll,
+      actions: [{ kind: "mute" }],
+    });
+    const after = Date.now();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.name).toBe("Mute sponsored");
+    expect(result.value.enabled).toBe(true);
+    expect(result.value.condition).toEqual(matchAll);
+    expect(result.value.actions).toEqual([{ kind: "mute" }]);
+    expect(result.value.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(result.value.createdAt).toBeGreaterThanOrEqual(before);
+    expect(result.value.updatedAt).toBeGreaterThanOrEqual(before);
+    expect(result.value.createdAt).toBeLessThanOrEqual(after);
+  });
+
+  it("rejects empty and whitespace-only names so the rule list never renders an invisible row", () => {
+    expect(createRule({ name: "", condition: matchAll, actions: [{ kind: "mute" }] }).ok).toBe(false);
+    expect(createRule({ name: "   ", condition: matchAll, actions: [{ kind: "mute" }] }).ok).toBe(false);
+  });
+
+  it("rejects rules with no actions — a rule that does nothing is a smart filter, not a rule", () => {
+    const result = createRule({ name: "Empty", condition: matchAll, actions: [] });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects rules with no condition", () => {
+    const result = createRule({
+      name: "No cond",
+      // @ts-expect-error: testing the validation guard at runtime
+      condition: undefined,
+      actions: [{ kind: "mute" }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("supports all four v1 action kinds (mute, star, mark-read, route-to-folder)", () => {
+    const result = createRule({
+      name: "Multi-action",
+      condition: matchAll,
+      actions: [
+        { kind: "mark-read" },
+        { kind: "star" },
+        { kind: "route-to-folder", folderId: "folder-123" },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.actions).toHaveLength(3);
+  });
+
+  it("preserves an explicit enabled: false so a rule can be paused without deleting it", () => {
+    const result = createRule({
+      name: "Paused",
+      condition: matchAll,
+      actions: [{ kind: "mute" }],
+      enabled: false,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.enabled).toBe(false);
+  });
+});
+
+describe("validateRule", () => {
+  it("accepts a well-formed rule", () => {
+    const create = createRule({
+      name: "X",
+      condition: matchAll,
+      actions: [{ kind: "mute" }],
+    });
+    expect(create.ok).toBe(true);
+    if (!create.ok) return;
+    expect(validateRule(create.value).ok).toBe(true);
+  });
+
+  it("rejects a non-object", () => {
+    expect(validateRule(null).ok).toBe(false);
+    expect(validateRule(undefined).ok).toBe(false);
+    expect(validateRule("rule").ok).toBe(false);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(validateRule({}).ok).toBe(false);
+    expect(validateRule({ id: "x" }).ok).toBe(false);
+    expect(validateRule({ id: "x", name: "y", condition: matchAll }).ok).toBe(false);
+  });
+
+  it("rejects a route-to-folder action missing folderId — an older vault must not be a runtime crash", () => {
+    const bad = {
+      id: "id-1",
+      name: "Broken",
+      enabled: true,
+      condition: matchAll,
+      actions: [{ kind: "route-to-folder" }],
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    expect(validateRule(bad).ok).toBe(false);
+  });
+});

--- a/tests/stores/article-store-folder-override.test.ts
+++ b/tests/stores/article-store-folder-override.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Article.folderId is set by the `route-to-folder` rule action. When
+ * present, it overrides the article's feed-level folder for display
+ * purposes — the article appears under the target folder, even if its
+ * feed lives in a different folder (or no folder at all).
+ *
+ * This is what makes `route-to-folder` user-visible. Without
+ * derivation honouring the override, the article would still be
+ * persisted with the override but visually stay under its feed's
+ * folder — the rule would look broken.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  useArticleStore,
+} from "../../src/stores/article-store.ts";
+import { useFeedStore } from "../../src/stores/feed-store.ts";
+import { toFolderFeedId } from "../../src/utils/constants.ts";
+
+vi.mock("../../src/core/storage/db.ts", () => ({
+  getArticles: vi.fn(),
+  getAllArticles: vi.fn(),
+  updateArticle: vi.fn(),
+}));
+
+vi.mock("../../src/core/sync/sync-service", () => ({
+  pushVault: vi.fn().mockResolvedValue({ ok: true, value: Date.now() }),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+import {
+  getArticles,
+  getAllArticles,
+} from "../../src/core/storage/db.ts";
+import type { Article, Feed } from "../../src/types/index.ts";
+
+function article(
+  id: string,
+  feedId: string,
+  extras: Partial<Article> = {},
+): Article {
+  return {
+    id,
+    feedId,
+    guid: id,
+    title: `Article ${id}`,
+    link: `https://example.com/${id}`,
+    content: "",
+    summary: "",
+    author: "",
+    publishedAt: 1_700_000_000_000 - parseInt(id.replace(/\D/g, ""), 10),
+    read: false,
+    createdAt: 0,
+    ...extras,
+  };
+}
+
+function feed(id: string, folderId?: string): Feed {
+  return {
+    id,
+    url: `https://example.com/${id}.xml`,
+    title: id,
+    description: "",
+    siteUrl: "",
+    folderId,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("folder view honours article-level folderId override", () => {
+  beforeEach(() => {
+    useArticleStore.setState({
+      articles: [],
+      articlesByFeedId: {},
+      selectedArticle: null,
+      isLoading: false,
+      articleSortMode: "newest",
+      showMuted: false,
+    });
+    useFeedStore.setState({
+      // f-tech lives in folder-tech; f-news has no folder.
+      feeds: [feed("f-tech", "folder-tech"), feed("f-news")],
+      folders: [],
+    });
+    vi.mocked(getArticles).mockImplementation(async (feedId: string) => ({
+      ok: true,
+      value: useArticleStore.getState().articlesByFeedId[feedId] ?? [],
+    }));
+    vi.mocked(getAllArticles).mockImplementation(async () => ({
+      ok: true,
+      value: Object.values(useArticleStore.getState().articlesByFeedId).flat(),
+    }));
+  });
+
+  it("article from a feed in folder-tech with folderId override to folder-crypto appears in folder-crypto, NOT folder-tech", async () => {
+    useArticleStore.setState({
+      articlesByFeedId: {
+        "f-tech": [
+          article("a1", "f-tech"),
+          article("a2", "f-tech", { folderId: "folder-crypto" }),
+        ],
+      },
+    });
+
+    // Folder-crypto view should include a2 even though f-tech is in folder-tech
+    await useArticleStore.getState().loadArticles(toFolderFeedId("folder-crypto"));
+    expect(useArticleStore.getState().articles.map((a) => a.id)).toEqual(["a2"]);
+
+    // Folder-tech view should NOT include a2 (it's been routed away)
+    await useArticleStore.getState().loadArticles(toFolderFeedId("folder-tech"));
+    expect(useArticleStore.getState().articles.map((a) => a.id)).toEqual(["a1"]);
+  });
+
+  it("article from a folder-less feed with folderId override appears in the target folder", async () => {
+    useArticleStore.setState({
+      articlesByFeedId: {
+        "f-news": [
+          article("a1", "f-news"),
+          article("a2", "f-news", { folderId: "folder-tech" }),
+        ],
+      },
+    });
+
+    await useArticleStore.getState().loadArticles(toFolderFeedId("folder-tech"));
+    expect(useArticleStore.getState().articles.map((a) => a.id)).toEqual(["a2"]);
+  });
+
+  it("specific-feed view always shows ALL of the feed's articles regardless of folder override", async () => {
+    // Routing an article elsewhere shouldn't hide it from the feed it came
+    // from — the user can still find it by clicking the feed.
+    useArticleStore.setState({
+      articlesByFeedId: {
+        "f-tech": [
+          article("a1", "f-tech"),
+          article("a2", "f-tech", { folderId: "folder-crypto" }),
+        ],
+      },
+    });
+    await useArticleStore.getState().loadArticles("f-tech");
+    const ids = useArticleStore.getState().articles.map((a) => a.id).sort();
+    expect(ids).toEqual(["a1", "a2"]);
+  });
+
+  it("article with no override still appears in its feed's folder (unchanged behaviour)", async () => {
+    useArticleStore.setState({
+      articlesByFeedId: {
+        "f-tech": [article("a1", "f-tech")],
+      },
+    });
+    await useArticleStore.getState().loadArticles(toFolderFeedId("folder-tech"));
+    expect(useArticleStore.getState().articles.map((a) => a.id)).toEqual(["a1"]);
+  });
+});

--- a/tests/stores/article-store-muted-view.test.ts
+++ b/tests/stores/article-store-muted-view.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Muted articles are hidden from default views by default. The article
+ * still rides through the vault and exists in storage — only the
+ * default *display* hides it. Users can flip a `showMuted` toggle to
+ * make muted articles reappear (e.g., a "Show muted (N)" affordance).
+ *
+ * Coverage matrix:
+ *   default view       | showMuted=false | showMuted=true
+ *   ──────────────────────────────────────────────────────
+ *   ALL feeds          | hide muted      | show muted
+ *   specific feed      | hide muted      | show muted
+ *   folder feed        | hide muted      | show muted
+ *   starred view       | always show     | always show   (user-explicit signal)
+ *   smart filter view  | always show     | always show   (user-explicit predicate)
+ *
+ * Mute is hidden, not deleted. selectUnreadCount must keep treating
+ * muted articles as part of the feed's unread tally — the badge stays
+ * honest about what's behind the curtain.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  useArticleStore,
+  selectUnreadCount,
+  selectMutedCount,
+} from "../../src/stores/article-store.ts";
+import { useFeedStore } from "../../src/stores/feed-store.ts";
+import {
+  ALL_FEEDS_ID,
+  STARRED_FEED_ID,
+  toFolderFeedId,
+} from "../../src/utils/constants.ts";
+
+vi.mock("../../src/core/storage/db.ts", () => ({
+  getArticles: vi.fn(),
+  getAllArticles: vi.fn(),
+  updateArticle: vi.fn(),
+}));
+
+import {
+  getArticles,
+  getAllArticles,
+} from "../../src/core/storage/db.ts";
+
+vi.mock("../../src/core/sync/sync-service", () => ({
+  pushVault: vi.fn().mockResolvedValue({ ok: true, value: Date.now() }),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+import type { Article, Feed } from "../../src/types/index.ts";
+
+function article(id: string, feedId: string, extras: Partial<Article> = {}): Article {
+  return {
+    id,
+    feedId,
+    guid: id,
+    title: `Article ${id}`,
+    link: `https://example.com/${id}`,
+    content: "",
+    summary: "",
+    author: "",
+    publishedAt: 1_700_000_000_000 - parseInt(id.replace(/\D/g, ""), 10),
+    read: false,
+    createdAt: 0,
+    ...extras,
+  };
+}
+
+function feed(id: string, folderId?: string): Feed {
+  return {
+    id,
+    url: `https://example.com/${id}.xml`,
+    title: id,
+    description: "",
+    siteUrl: "",
+    folderId,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+/**
+ * Seed the article-store's source of truth + the db mocks together
+ * so loadArticles' background fetch doesn't wipe our test data.
+ */
+function seedFeed(feedId: string, articles: Article[]) {
+  useArticleStore.setState({
+    articlesByFeedId: {
+      ...useArticleStore.getState().articlesByFeedId,
+      [feedId]: articles,
+    },
+  });
+}
+
+describe("muted articles are hidden from default views", () => {
+  beforeEach(() => {
+    useArticleStore.setState({
+      articles: [],
+      articlesByFeedId: {},
+      selectedArticle: null,
+      isLoading: false,
+      articleSortMode: "newest",
+      showMuted: false,
+    });
+    useFeedStore.setState({
+      feeds: [feed("f1"), feed("f2", "folder-x")],
+      folders: [],
+    });
+    vi.mocked(getArticles).mockImplementation(async (feedId: string) => ({
+      ok: true,
+      value: useArticleStore.getState().articlesByFeedId[feedId] ?? [],
+    }));
+    vi.mocked(getAllArticles).mockImplementation(async () => ({
+      ok: true,
+      value: Object.values(useArticleStore.getState().articlesByFeedId).flat(),
+    }));
+  });
+
+  it("hides muted articles from a specific feed's view by default", async () => {
+    seedFeed("f1", [
+      article("a1", "f1"),
+      article("a2", "f1", { muted: true }),
+      article("a3", "f1"),
+    ]);
+    await useArticleStore.getState().loadArticles("f1");
+    const visibleIds = useArticleStore.getState().articles.map((a) => a.id);
+    expect(visibleIds).toEqual(["a1", "a3"]);
+  });
+
+  it("hides muted articles from ALL_FEEDS view by default", async () => {
+    seedFeed("f1", [article("a1", "f1"), article("a2", "f1", { muted: true })]);
+    seedFeed("f2", [article("a3", "f2", { muted: true }), article("a4", "f2")]);
+    await useArticleStore.getState().loadArticles(ALL_FEEDS_ID);
+    const ids = useArticleStore.getState().articles.map((a) => a.id).sort();
+    expect(ids).toEqual(["a1", "a4"]);
+  });
+
+  it("hides muted articles from folder view by default", async () => {
+    seedFeed("f2", [
+      article("a1", "f2"),
+      article("a2", "f2", { muted: true }),
+    ]);
+    await useArticleStore.getState().loadArticles(toFolderFeedId("folder-x"));
+    const ids = useArticleStore.getState().articles.map((a) => a.id);
+    expect(ids).toEqual(["a1"]);
+  });
+
+  it("shows muted articles in starred view (user-explicit signal)", async () => {
+    seedFeed("f1", [
+      article("a1", "f1", { starred: true, starredAt: 100 }),
+      article("a2", "f1", { starred: true, starredAt: 200, muted: true }),
+    ]);
+    await useArticleStore.getState().loadArticles(STARRED_FEED_ID);
+    const ids = useArticleStore.getState().articles.map((a) => a.id);
+    expect(ids).toContain("a2");
+  });
+
+  it("setShowMuted(true) makes muted articles reappear in default views", async () => {
+    seedFeed("f1", [
+      article("a1", "f1"),
+      article("a2", "f1", { muted: true }),
+    ]);
+    await useArticleStore.getState().loadArticles("f1");
+    useFeedStore.setState({ selectedFeedId: "f1" });
+    expect(useArticleStore.getState().articles.map((a) => a.id)).toEqual(["a1"]);
+
+    useArticleStore.getState().setShowMuted(true);
+    expect(useArticleStore.getState().articles.map((a) => a.id)).toEqual([
+      "a1",
+      "a2",
+    ]);
+  });
+
+  it("selectMutedCount reports how many muted articles a feed has", () => {
+    useArticleStore.setState({
+      articlesByFeedId: {
+        f1: [
+          article("a1", "f1"),
+          article("a2", "f1", { muted: true }),
+          article("a3", "f1", { muted: true }),
+        ],
+      },
+    });
+    expect(selectMutedCount(useArticleStore.getState(), "f1")).toBe(2);
+  });
+
+  it("muted articles still count toward the unread badge", () => {
+    useArticleStore.setState({
+      articlesByFeedId: {
+        f1: [
+          article("a1", "f1"),
+          article("a2", "f1", { muted: true }),
+          article("a3", "f1", { read: true }),
+        ],
+      },
+    });
+    // Two unread (a1, a2). The fact that a2 is muted doesn't make
+    // it "read" — the badge stays honest about what's behind the curtain.
+    expect(selectUnreadCount(useArticleStore.getState(), "f1")).toBe(2);
+  });
+});

--- a/tests/stores/feed-store-rules.test.ts
+++ b/tests/stores/feed-store-rules.test.ts
@@ -1,0 +1,269 @@
+/**
+ * feed-store rule CRUD: addFeedRule, updateFeedRule, removeFeedRule,
+ * reorderFeedRules. Mirrors the smart-filter-store pattern (load →
+ * mutate via the encrypted db helper → reload → schedule sync push).
+ *
+ * Per CLAUDE.md "mock at the boundary, not the collaborator", these
+ * tests mock the db module (the storage boundary) and the
+ * sync-service module (the network boundary). The real feed-store
+ * mutators, schema factories, and rule shape are exercised end-to-end.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Feed, Rule, RuleAction } from "../../src/types/index.ts";
+
+vi.mock("../../src/core/storage/db.ts", () => {
+  const feeds = new Map<string, Feed>();
+  return {
+    getFeeds: vi.fn(async () => ({ ok: true, value: [...feeds.values()] })),
+    getFeed: vi.fn(async (id: string) => {
+      const f = feeds.get(id);
+      return f
+        ? { ok: true as const, value: f }
+        : { ok: false as const, error: "not found" };
+    }),
+    updateFeed: vi.fn(async (feed: Feed) => {
+      feeds.set(feed.id, feed);
+      return { ok: true, value: true };
+    }),
+    addFolder: vi.fn(),
+    getFolders: vi.fn(async () => ({ ok: true, value: [] })),
+    updateFolder: vi.fn(),
+    removeFolder: vi.fn(),
+    removeFeed: vi.fn(async () => ({ ok: true, value: true })),
+    _feeds: feeds,
+    _seed: (f: Feed) => feeds.set(f.id, f),
+    _reset: () => feeds.clear(),
+  };
+});
+
+vi.mock("../../src/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn(),
+  reloadFeed: vi.fn(),
+}));
+
+vi.mock("../../src/core/extractor/prefetch-service.ts", () => ({
+  prefetchStarredArticles: vi.fn().mockResolvedValue({
+    ok: true,
+    value: { extracted: 0, failed: 0 },
+  }),
+}));
+
+vi.mock("../../src/core/sync/sync-service", () => ({
+  pushVault: vi.fn().mockResolvedValue({ ok: true, value: Date.now() }),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+// Force paid tier active in tests so the gate actually enforces tier
+// requirements; without this VITE_PAID_TIER_VISIBLE is unset and the
+// gate "relaxes" — all shipped Personal features become available to
+// free users with reason: "paid-tier-inactive".
+vi.mock("../../src/core/features/paid-tier-active.ts", () => ({
+  isPaidTierActive: () => true,
+}));
+
+import { useFeedStore } from "../../src/stores/feed-store.ts";
+import { useLicenseStore } from "../../src/stores/license-store.ts";
+import { useSyncStore } from "../../src/stores/sync-store.ts";
+import * as db from "../../src/core/storage/db.ts";
+
+const dbMock = db as unknown as {
+  _feeds: Map<string, Feed>;
+  _seed: (f: Feed) => void;
+  _reset: () => void;
+};
+
+function feed(id: string, rules?: Rule[]): Feed {
+  return {
+    id,
+    url: `https://example.com/${id}.xml`,
+    title: id,
+    description: "",
+    siteUrl: "",
+    createdAt: 0,
+    updatedAt: 0,
+    ...(rules ? { rules } : {}),
+  };
+}
+
+function rule(id: string, name = id, actions: RuleAction[] = [{ kind: "mute" }]): Rule {
+  return {
+    id,
+    name,
+    enabled: true,
+    condition: { kind: "group", match: "all", children: [] },
+    actions,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("feed-store rule CRUD", () => {
+  let schedulePushSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dbMock._reset();
+    vi.clearAllMocks();
+    useLicenseStore.setState({ tier: "personal" });
+    useFeedStore.setState({ feeds: [], folders: [] });
+    schedulePushSpy = vi
+      .spyOn(useSyncStore.getState(), "scheduleSyncPush")
+      .mockImplementation(() => {});
+  });
+
+  describe("addFeedRule", () => {
+    it("appends a rule to a feed that has none", async () => {
+      const f = feed("f1");
+      dbMock._seed(f);
+      useFeedStore.setState({ feeds: [f] });
+
+      const result = await useFeedStore.getState().addFeedRule("f1", {
+        name: "Mute sponsored",
+        condition: { kind: "group", match: "all", children: [] },
+        actions: [{ kind: "mute" }],
+      });
+
+      expect(result.ok).toBe(true);
+      const persisted = dbMock._feeds.get("f1")!;
+      expect(persisted.rules).toHaveLength(1);
+      expect(persisted.rules?.[0].name).toBe("Mute sponsored");
+      expect(persisted.rules?.[0].id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-/,
+      );
+    });
+
+    it("appends to a feed that already has rules without mutating prior entries", async () => {
+      const existing = rule("r-existing", "Existing rule");
+      const f = feed("f1", [existing]);
+      dbMock._seed(f);
+      useFeedStore.setState({ feeds: [f] });
+
+      await useFeedStore.getState().addFeedRule("f1", {
+        name: "Second rule",
+        condition: { kind: "group", match: "all", children: [] },
+        actions: [{ kind: "star" }],
+      });
+
+      const persisted = dbMock._feeds.get("f1")!;
+      expect(persisted.rules).toHaveLength(2);
+      expect(persisted.rules?.[0]).toMatchObject({ id: "r-existing" });
+      expect(persisted.rules?.[1].name).toBe("Second rule");
+    });
+
+    it("schedules a sync push so other devices see the new rule", async () => {
+      dbMock._seed(feed("f1"));
+      await useFeedStore.getState().addFeedRule("f1", {
+        name: "Any",
+        condition: { kind: "group", match: "all", children: [] },
+        actions: [{ kind: "mute" }],
+      });
+      expect(schedulePushSpy).toHaveBeenCalled();
+    });
+
+    it("refuses to add a rule for a free user (gate-locked)", async () => {
+      useLicenseStore.setState({ tier: "free" });
+      dbMock._seed(feed("f1"));
+
+      const result = await useFeedStore.getState().addFeedRule("f1", {
+        name: "Mute sponsored",
+        condition: { kind: "group", match: "all", children: [] },
+        actions: [{ kind: "mute" }],
+      });
+
+      expect(result.ok).toBe(false);
+      expect(dbMock._feeds.get("f1")!.rules).toBeUndefined();
+    });
+
+    it("rejects an input that schema validation rejects (no actions)", async () => {
+      dbMock._seed(feed("f1"));
+      const result = await useFeedStore.getState().addFeedRule("f1", {
+        name: "Empty",
+        condition: { kind: "group", match: "all", children: [] },
+        actions: [],
+      });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("updateFeedRule", () => {
+    it("replaces a rule by id and updates updatedAt", async () => {
+      const original = rule("r-1", "Original");
+      const f = feed("f1", [original]);
+      dbMock._seed(f);
+      useFeedStore.setState({ feeds: [f] });
+
+      const before = Date.now();
+      const result = await useFeedStore.getState().updateFeedRule("f1", {
+        ...original,
+        name: "Updated",
+      });
+
+      expect(result.ok).toBe(true);
+      const persisted = dbMock._feeds.get("f1")!.rules?.[0];
+      expect(persisted?.name).toBe("Updated");
+      expect(persisted?.updatedAt).toBeGreaterThanOrEqual(before);
+    });
+
+    it("is a no-op when the rule id doesn't exist on the feed", async () => {
+      const f = feed("f1", [rule("r-1")]);
+      dbMock._seed(f);
+      const before = dbMock._feeds.get("f1")!.rules?.[0];
+
+      const result = await useFeedStore
+        .getState()
+        .updateFeedRule("f1", { ...rule("r-unknown"), name: "Ghost" });
+
+      expect(result.ok).toBe(false);
+      expect(dbMock._feeds.get("f1")!.rules?.[0]).toEqual(before);
+    });
+  });
+
+  describe("removeFeedRule", () => {
+    it("drops a rule by id", async () => {
+      const r1 = rule("r-1");
+      const r2 = rule("r-2");
+      const f = feed("f1", [r1, r2]);
+      dbMock._seed(f);
+      useFeedStore.setState({ feeds: [f] });
+
+      await useFeedStore.getState().removeFeedRule("f1", "r-1");
+
+      const persisted = dbMock._feeds.get("f1")!;
+      expect(persisted.rules).toHaveLength(1);
+      expect(persisted.rules?.[0].id).toBe("r-2");
+    });
+
+    it("is idempotent on an unknown id", async () => {
+      dbMock._seed(feed("f1", [rule("r-1")]));
+      await useFeedStore.getState().removeFeedRule("f1", "r-unknown");
+      expect(dbMock._feeds.get("f1")!.rules).toHaveLength(1);
+    });
+  });
+
+  describe("reorderFeedRules", () => {
+    it("rewrites the order to match the supplied id list", async () => {
+      const a = rule("r-a");
+      const b = rule("r-b");
+      const c = rule("r-c");
+      dbMock._seed(feed("f1", [a, b, c]));
+
+      await useFeedStore.getState().reorderFeedRules("f1", ["r-c", "r-a", "r-b"]);
+
+      const ids = dbMock._feeds.get("f1")!.rules?.map((r) => r.id);
+      expect(ids).toEqual(["r-c", "r-a", "r-b"]);
+    });
+
+    it("ignores unknown ids in the supplied list (defensive)", async () => {
+      dbMock._seed(feed("f1", [rule("r-a"), rule("r-b")]));
+      await useFeedStore
+        .getState()
+        .reorderFeedRules("f1", ["r-b", "r-ghost", "r-a"]);
+
+      const ids = dbMock._feeds.get("f1")!.rules?.map((r) => r.id);
+      expect(ids).toEqual(["r-b", "r-a"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Per-feed rules. Each feed can carry a list of rules; each rule pairs a `ConditionGroup` predicate (same AST as smart filters) with one or more actions: `mark-read`, `star`, `mute`, `route-to-folder`. Rules evaluate on ingest during `refreshFeed`, so matching articles get every action applied before they're encrypted and written to IndexedDB — the final shape rides through the vault to every device.

Closes the documented capability gap in `docs/strategy/003-playing-to-win.md` (Inoreader's rules engine matched, with the E2E twist nobody else offers — the rules themselves are encrypted and live nowhere but the user's vault). Subsumes the never-shipped `mute-keywords` tier-matrix entry into a single broader engine.

### Why per-feed (not global) in v1

Per-feed scoping makes the editor discoverable from the feed dropdown (one click) and bounds the blast radius of a typo to one feed. The engine takes `Rule[]`; a global-rules slice can be composed in later without changing anything about the v1 design.

### Tier

`rules` is Personal+, shipped. Self-hosters bypass via the standard `VITE_SELF_HOSTED=1` flag. Free users see a toast prompt instead of mutating.

## Commits (10)

1. `feat(rules): rule type + per-feed schema factory` — types + `createRule` + `validateRule`
2. `feat(rules): pure rules engine (applyRules)` — reuses the smart-filter `ConditionGroup` AST + `evaluateGroup`
3. `feat(rules): apply per-feed rules on refreshFeed ingest` — wired into the canonical ingest path
4. `feat(rules): hide muted articles from default views` — `showMuted` toggle + `selectMutedCount` selector
5. `feat(rules): honour article.folderId override in folder view` — `route-to-folder` becomes user-visible
6. `feat(features): tier-matrix entry for rules, drop mute-keywords`
7. `feat(rules): feed-store rule CRUD mutators` — add/update/remove/reorder, gate-locked
8. `feat(rules): per-feed rules editor dialog` — list + edit modes, opened from feed dropdown
9. `feat(rules): all-rules audit view in Settings → Reading`
10. `docs(rules): feature doc for per-feed rules` — `docs/features/017-per-feed-rules.md`

## Test plan

- [x] **Unit/integration** — `npm test` passes (2776 / 14 skipped, no regressions)
- [x] **Type-check** — `npx tsc --noEmit` clean
- [x] **Pure engine** — every action kind, multi-action rules, multi-rule composition, deterministic last-wins for route-to-folder, disabled-rule short-circuit, AND/OR groups, no input mutation
- [x] **Ingest** — `tests/core/feeds/refresh-rules.test.ts` exercises the real engine + evaluator through `refreshFeed` with a mocked db boundary
- [x] **View derivation** — muted hidden by default in ALL/specific/folder views; surfaced in starred + smart filters; `setShowMuted(true)` reveals; unread badge ignores muted state; folderId override routes between folders
- [x] **Store CRUD** — add/update/remove/reorder with gate-locked refusal for free tier
- [x] **Dialog UI** — closed-by-default, opens with feed title, empty state, lists existing rules, edit mode, save-disabled-until-valid, create-rule end-to-end
- [x] **Audit panel** — empty state, grouped-by-feed rendering, paused marker, Edit button opens the right feed
- [ ] Manual smoke against `npm run dev` — recommend before merge
- [ ] E2E — none added this PR (UI changes covered by component tests); follow-up if review wants Playwright coverage

## Out of scope (v1.1 candidates)

- `apply-tag` action — needs tags-as-first-class-concept first
- "Apply rules to existing articles" — single-pass on ingest only today
- Global rules layer — engine ready; just needs a `globalRules` slice
- `notify` action (Browser Notifications API)

See `docs/features/017-per-feed-rules.md` § Limitations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkuzqkyNGYxZsEdXhkPGMr)_