### PR TITLE
test(e2e): remove stale free-tier sync-gate spec

### DIFF
--- a/tests/e2e/sync.spec.ts
+++ b/tests/e2e/sync.spec.ts
@@ -5,19 +5,12 @@ import type { Page } from "@playwright/test";
 /**
  * Navigate to the Settings → Sync & Data tab where the sync controls live.
  *
- * Post-redesign: Settings is a stage page at /settings, the tab is called
- * "Sync & Data", and the primary sync affordance is a <Switch> toggle (not
- * the prior "Enable sync" / "Use existing cloud account" buttons).
- *
- * IMPORTANT: in e2e the default tier is `free` and the build is hosted, so
- * the Cloud sync card mounts with the frosted-glass gate overlay. The
- * gate wraps its content in `aria-hidden=true` so screen readers focus on
- * the upgrade CTA rather than the blurred toggle. That means the
- * "Cloud sync" <h3> is unreachable via Playwright's `getByRole`
- * (which filters out aria-hidden) when this helper runs. We wait on the
- * Danger zone heading instead — it's a sibling card, always rendered,
- * never aria-hidden, so it's a reliable signal that the Sync & Data tab
- * has actually mounted.
+ * Settings is a stage page at /settings, the tab is called "Sync & Data",
+ * and the primary sync affordance is a <Switch> toggle. We anchor on the
+ * Danger zone heading because it's always rendered regardless of hosted /
+ * self-hosted state — the Cloud sync card's heading is aria-hidden in the
+ * self-host-gated path, so anchoring on Danger zone keeps this helper
+ * robust across both modes.
  *
  * On mobile, the sidebar Settings button is inside the bottom drawer which
  * we open first.
@@ -63,23 +56,6 @@ async function addFeedForSync(page: Page) {
 }
 
 test.describe("Sync", () => {
-  test("Sync & Data tab gates the cloud sync toggle for free-tier hosted users", async ({
-    feedPage: page,
-  }) => {
-    await addFeedForSync(page);
-    await goToSyncSection(page);
-    // The Cloud sync card content is aria-hidden behind the frosted-glass
-    // gate; the user-visible state is the overlay's headline. Asserting on
-    // the overlay text (not the hidden heading) matches what the user
-    // actually sees and what they can interact with.
-    await expect(
-      page.getByText(/cloud sync requires a subscription/i),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: /upgrade plan/i }),
-    ).toBeVisible();
-  });
-
   test("clicking the sidebar Settings button navigates to /settings", async ({
     feedPage: page,
   }) => {


### PR DESCRIPTION
What — `Sync & Data tab gates the cloud sync toggle for free-tier hosted
users` fails because the gate it asserts no longer exists. Shard 6/6
fails on `cloud sync requires a subscription` text never appearing.

Why — e179fe1 ("feat(sync): ship cloud sync on Free tier") removed the
hosted-Free sync gate. Cloud sync is now a Free-tier feature; the only
remaining gate is for self-hosters whose `/api/sync` is unreachable.
The unit test in `data-sync-section.test.tsx` was correctly flipped
(`free-tier hosted users see an operable toggle`) — this e2e spec was
missed in that change.

Fix — delete the stale spec; the new behavior is already covered by the
operable-toggle unit test in `data-sync-section.test.tsx:68`. Also
trim the helper docstring which was largely a justification for the
now-removed gate's aria-hidden interaction with the anchor selector.

Prevention — the unit test continues to assert the post-change
behavior, so a regression that re-introduces the gate text would fail
there first.