### PR TITLE
feat(ui): floating cog + sort pills replace sidebar dropdowns

### DIFF
--- a/docs/features/019-feed-settings-cog.md
+++ b/docs/features/019-feed-settings-cog.md
@@ -1,0 +1,119 @@
+# Feature 019: Floating settings cog (replaces sidebar dropdowns)
+
+## Status
+Implemented
+
+## Summary
+
+Every per-row three-dot dropdown in the sidebar — for feeds, folders,
+and smart filters — has been replaced by a single **context-aware
+floating cog** at the top-right of the article list, paired with the
+existing **sort selector** (now rebuilt as an expanding-pill).
+
+The cog opens the right settings dialog based on the currently
+selected view:
+
+| Selected view | Cog opens |
+|---|---|
+| Single feed (`f-tech`) | `FeedSettingsDialog` |
+| Folder view (`folder:folder-tech`) | `FolderSettingsDialog` |
+| Smart filter view (`filter:filter-recent`) | existing `SmartFilterEditorDialog` against that filter |
+| `ALL_FEEDS_ID`, `STARRED_FEED_ID`, no selection | Cog is hidden |
+
+The two pills (sort + cog) share the same `ExpandingPill` primitive:
+icon-only circle by default, hover (desktop) or always-on (mobile)
+expands a label rightward via a CSS `max-width` animation. The
+sidebar rows are now select-only — no rename input, no dropdown, no
+swap-on-hover badge logic.
+
+## Behaviour
+
+```gherkin
+Feature: Floating cog over the article list
+
+  Scenario: Open per-feed settings
+    Given I have selected a single feed
+    When I hover the cog at the top of the article list
+    Then the cog expands to "Feed settings"
+    When I click the cog
+    Then the FeedSettingsDialog opens against that feed
+    And it contains Name, Display (Prefer + Prefetch), Folder, Rules, Refresh, Clear cached, Delete
+
+  Scenario: Open folder settings
+    Given I have selected a folder view
+    When I click the cog
+    Then the FolderSettingsDialog opens against that folder
+    And it contains Name, Color picker, Delete
+
+  Scenario: Open smart-filter editor from the cog
+    Given I have selected a smart-filter view
+    When I click the cog
+    Then SmartFilterEditorDialog opens against that filter
+
+  Scenario: Cog hides where no settings apply
+    Given I am on All articles / Starred / no feed selected
+    Then the cog does not render
+
+  Scenario: Cog hides on a broken reference
+    Given the URL points to a folder or smart filter that no longer exists
+    Then the cog does not render (defensive)
+
+  Scenario: Mobile pill behaviour
+    Given I am on a mobile-sized viewport
+    Then the cog and sort pills always show their labels (no hover)
+    And tapping either pill opens its menu / dialog directly
+```
+
+## Architecture
+
+### Flow
+
+1. User selects something in the sidebar — a feed, folder, or smart filter. Feed-store updates `selectedFeedId`.
+2. `<ArticleListControls>` (sticky at the top of the article list) renders two children: `<SettingsPill>` and `<SortPill>`.
+3. `SettingsPill` reads `selectedFeedId` + the various stores. The `resolveTarget` helper classifies the selection into `feed | folder | filter | null` and returns the matching label + dispatcher.
+4. On click, the pill calls `openFeedSettings(id)` / `openFolderSettings(id)` / `openEditor(filter)` — each populates a slice on its store and mounts the corresponding dialog.
+5. Dialogs are mounted at the app root (`src/app.tsx`), controlled entirely by store state — same pattern as `RulesEditorDialog`.
+
+### Files
+
+| File | Role |
+|------|------|
+| `src/components/ui/expanding-pill.tsx` | Reusable circle-to-pill primitive. Animates label `max-width` via CSS only. |
+| `src/components/articles/article-list-controls.tsx` | Sticky-top flex container hosting `SettingsPill` + `SortPill`. Replaces the old `SortMenu` mount site. |
+| `src/components/articles/sort-pill.tsx` | Article-sort selector rebuilt on `ExpandingPill`. Same modes + handler as before; new visual. |
+| `src/components/articles/settings-pill.tsx` | Context-aware cog. Hides on aggregated views and broken refs; dispatches to the right dialog action. |
+| `src/components/feeds/feed-settings-dialog.tsx` | Per-feed dialog (Name, Display, Folder, Rules, Actions). |
+| `src/components/folders/folder-settings-dialog.tsx` | Per-folder dialog (Name, Color, Delete). |
+| `src/components/folders/folder-color-picker.tsx` | Extracted color picker, shared with the (now-removed) sidebar dropdown's visual treatment. |
+| `src/components/smart-filters/smart-filter-editor-dialog.tsx` | Existing dialog, now also hosts Duplicate + Delete in its footer. |
+| `src/components/sidebar/feed-item.tsx`, `folder-item.tsx`, `smart-filter-item.tsx` | Each lost its DropdownMenu and is now select-only. |
+| `src/stores/feed-store.ts` | New state: `feedSettingsDialogId`, `folderSettingsDialogId`, with paired open/close mutators. Mirrors `rulesEditorFeedId`. |
+| `src/app.tsx` | Mounts `<FeedSettingsDialog />` + `<FolderSettingsDialog />` alongside the existing root dialogs. |
+
+### Tests
+
+| File | Coverage |
+|------|----------|
+| `tests/components/ui/expanding-pill.test.tsx` | Primitive renders as button, label in DOM, click + Enter activation, collapsed/expanded class wiring, mobile alwaysExpanded mode, disabled state. |
+| `tests/components/articles/sort-pill.test.tsx` | Shows current mode label, opens menu with every mode, calls onChange. |
+| `tests/components/articles/settings-pill.test.tsx` | Visibility matrix (ALL/STARRED/no-selection/deleted-folder/deleted-filter all return null) and dispatch matrix (feed/folder/filter each call the right store action, label adapts per context). |
+| `tests/stores/feed-store-settings-dialogs.test.ts` | Open/close store actions for both new dialogs, including swap-target-without-close and independence between dialogs. |
+| `tests/components/feeds/feed-settings-dialog.test.tsx` | Every section's write path — rename, prefer toggle, prefetch toggle, folder picker, unfiled, manage rules, refresh, clear, delete with confirm + cancel. |
+| `tests/components/folders/folder-settings-dialog.test.tsx` | Rename, color swatch, click-to-clear, delete confirm + cancel, swatch count. |
+| `tests/components/sidebar/feed-item.test.tsx`, `folder-item.test.tsx` | Rewritten as select-only — every dropdown assertion replaced by "no dropdown exists; settings live in the cog dialog". |
+
+## Design Decisions
+
+- **One cog, multiple dialogs — not one mega-dialog.** Each view's settings have different shapes (feed has six concerns; folder has three; smart filter has predicate + actions). A single dialog with tabs would force every view through the same shell; per-target dialogs keep each focused. The cog is the single entry; the dialogs are the per-type detail.
+- **Hide the cog rather than disable it.** On `ALL_FEEDS` / `STARRED` / no-selection, the cog renders `null` instead of `disabled`. A disabled affordance teases functionality that isn't there.
+- **Settings live where attention is.** Per-feed config was previously hidden behind a hover-only dropdown on a sidebar row. Surfacing the cog above the content the user is actively reading puts the affordance where they look — and removes the "discoverability via hover" problem.
+- **Rename via dialog field, not inline edit.** The inline-input pattern was specific to the sidebar dropdown. Moving rename into the settings dialog costs one click but makes "rename" reachable from a fixed location instead of buried inside a dropdown the user has to discover.
+- **Smart-filter editor absorbs Duplicate + Delete.** To keep the "no three-dot menus" invariant, the smart-filter editor now hosts these actions in its footer. Reviewers see one canonical surface for editing a filter — predicates, sort/limit, *and* lifecycle.
+- **`ExpandingPill` is presentational.** No store reads, no routing, no dialog dispatch — those live in the wrappers (`SortPill`, `SettingsPill`). Future floating pills (per-view bookmarks, mark-all-read, anything) can reuse the same primitive without inheriting any of its consumers' logic.
+- **Folder color picker extracted into `FolderColorPicker`.** Used by the dialog now; if a future surface (e.g. a settings export) needs to render the same swatch grid, it has the same component to import. The original sidebar treatment is the only consumer being deleted in this PR.
+
+## Limitations
+
+- **No bulk actions yet.** Each dialog operates on one target. Multi-select on the sidebar + a bulk operations menu would compose with the cog architecture (the cog could become "Bulk settings…" when multiple things are selected), but that's a separate feature.
+- **No keyboard shortcut for the cog.** The pill is reachable via tab order; a dedicated shortcut (e.g. `,` for settings, mirroring many editors) is a small, additive change that didn't fit this PR's scope.
+- **The smart-filter editor footer is denser than the others.** Duplicate + Delete on the left, Cancel + Save on the right. If the dialog grows another action later, we'll probably move destructive actions into a "danger zone" section like FolderSettingsDialog already has.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,6 +9,7 @@ import { CHANGELOG_FEED_URL } from "@/utils/constants.ts";
 import { Toaster } from "@/components/ui/sonner.tsx";
 import { SmartFilterEditorDialog } from "@/components/smart-filters/smart-filter-editor-dialog.tsx";
 import { RulesEditorDialog } from "@/components/rules/rules-editor-dialog.tsx";
+import { FeedSettingsDialog } from "@/components/feeds/feed-settings-dialog.tsx";
 import { DeviceSetupWizard } from "@/components/billing/device-setup-wizard.tsx";
 import { NavigateWithSearch } from "@/components/routing/navigate-with-search.tsx";
 import { AppLayout } from "@/pages/app-layout.tsx";
@@ -270,6 +271,7 @@ export function App() {
         <DeviceSetupWizard />
         <SmartFilterEditorDialog />
         <RulesEditorDialog />
+        <FeedSettingsDialog />
         <Toaster position="bottom-center" />
       </BrowserRouter>
     </>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -10,6 +10,7 @@ import { Toaster } from "@/components/ui/sonner.tsx";
 import { SmartFilterEditorDialog } from "@/components/smart-filters/smart-filter-editor-dialog.tsx";
 import { RulesEditorDialog } from "@/components/rules/rules-editor-dialog.tsx";
 import { FeedSettingsDialog } from "@/components/feeds/feed-settings-dialog.tsx";
+import { FolderSettingsDialog } from "@/components/folders/folder-settings-dialog.tsx";
 import { DeviceSetupWizard } from "@/components/billing/device-setup-wizard.tsx";
 import { NavigateWithSearch } from "@/components/routing/navigate-with-search.tsx";
 import { AppLayout } from "@/pages/app-layout.tsx";
@@ -272,6 +273,7 @@ export function App() {
         <SmartFilterEditorDialog />
         <RulesEditorDialog />
         <FeedSettingsDialog />
+        <FolderSettingsDialog />
         <Toaster position="bottom-center" />
       </BrowserRouter>
     </>

--- a/src/components/articles/article-list-controls.tsx
+++ b/src/components/articles/article-list-controls.tsx
@@ -1,0 +1,33 @@
+import { SortPill } from "./sort-pill.tsx";
+import type { ArticleSortMode } from "@/types/index.ts";
+
+/**
+ * Sticky header inside the article-list scroll container. Hosts the
+ * floating control pills (sort + settings cog). Right-aligned flex
+ * row with a gap so pills can sit side-by-side without overlapping;
+ * each expands independently on hover.
+ *
+ * The container itself is `pointer-events-none` so the area between
+ * pills stays scroll-friendly; the pills opt back into pointer events.
+ *
+ * SettingsPill is added in a later commit — context-aware (hides on
+ * aggregated views) and routes the cog click to the right dialog.
+ */
+interface ArticleListControlsProps {
+  sortMode: ArticleSortMode;
+  onSortChange: (mode: ArticleSortMode) => void;
+}
+
+export function ArticleListControls({
+  sortMode,
+  onSortChange,
+}: ArticleListControlsProps) {
+  return (
+    <div
+      data-testid="article-list-controls"
+      className="sticky top-0 z-10 flex justify-end items-center gap-2 px-2 py-1 bg-background/80 backdrop-blur-sm pointer-events-none"
+    >
+      <SortPill mode={sortMode} onChange={onSortChange} />
+    </div>
+  );
+}

--- a/src/components/articles/article-list-controls.tsx
+++ b/src/components/articles/article-list-controls.tsx
@@ -1,4 +1,5 @@
 import { SortPill } from "./sort-pill.tsx";
+import { SettingsPill } from "./settings-pill.tsx";
 import type { ArticleSortMode } from "@/types/index.ts";
 
 /**
@@ -27,6 +28,7 @@ export function ArticleListControls({
       data-testid="article-list-controls"
       className="sticky top-0 z-10 flex justify-end items-center gap-2 px-2 py-1 bg-background/80 backdrop-blur-sm pointer-events-none"
     >
+      <SettingsPill />
       <SortPill mode={sortMode} onChange={onSortChange} />
     </div>
   );

--- a/src/components/articles/article-list.tsx
+++ b/src/components/articles/article-list.tsx
@@ -1,28 +1,16 @@
 import { useMemo, useState, useEffect, useRef, useCallback } from "react";
-import { ArrowUpDown, Check, CheckCheck } from "lucide-react";
+import { CheckCheck } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useAppStore } from "@/stores/app-store.ts";
 import { isAggregatedFeedId } from "@/utils/constants.ts";
 import { Button } from "@/components/ui/button.tsx";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu.tsx";
 import { ArticleItem } from "./article-item.tsx";
 import { ArticleGroupSummaryRow } from "./article-group-summary-row.tsx";
+import { ArticleListControls } from "./article-list-controls.tsx";
 import { groupArticles } from "@/lib/group-articles.ts";
-import type { Article, ArticleSortMode } from "@/types/index.ts";
-import { ARTICLE_SORT_MODES } from "@/types/index.ts";
-
-const SORT_LABELS: Record<ArticleSortMode, string> = {
-  "newest": "Newest first",
-  "oldest": "Oldest first",
-  "unread-first": "Unread first",
-};
+import type { Article } from "@/types/index.ts";
 
 /**
  * Flat list-entry shape: every row the virtualizer renders is either a
@@ -257,7 +245,10 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
 
   return (
     <div ref={scrollRef} className="h-full overflow-y-auto relative">
-      <SortMenu mode={articleSortMode} onChange={setArticleSortMode} />
+      <ArticleListControls
+        sortMode={articleSortMode}
+        onSortChange={setArticleSortMode}
+      />
       <ul
         role="listbox"
         aria-label="Articles"
@@ -316,41 +307,6 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
         })}
       </ul>
       <MarkReadPill unreadCount={unreadCount} onMarkAll={markAllAsRead} />
-    </div>
-  );
-}
-
-function SortMenu({
-  mode,
-  onChange,
-}: {
-  mode: ArticleSortMode;
-  onChange: (mode: ArticleSortMode) => void;
-}) {
-  return (
-    <div className="sticky top-0 z-10 flex justify-end px-2 py-1 bg-background/80 backdrop-blur-sm pointer-events-none">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className="pointer-events-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-            aria-label={`Sort: ${SORT_LABELS[mode]}`}
-          >
-            <ArrowUpDown className="size-3" />
-            <span>{SORT_LABELS[mode]}</span>
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="min-w-36">
-          {ARTICLE_SORT_MODES.map((m) => (
-            <DropdownMenuItem key={m} onClick={() => onChange(m)}>
-              <Check
-                className={`size-3.5 mr-1.5 ${mode === m ? "opacity-100" : "opacity-0"}`}
-              />
-              {SORT_LABELS[m]}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
     </div>
   );
 }

--- a/src/components/articles/settings-pill.tsx
+++ b/src/components/articles/settings-pill.tsx
@@ -1,0 +1,111 @@
+import { Settings as SettingsIcon } from "lucide-react";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
+import { ExpandingPill } from "@/components/ui/expanding-pill.tsx";
+import { useIsMobile } from "@/hooks/use-mobile.ts";
+import {
+  ALL_FEEDS_ID,
+  STARRED_FEED_ID,
+  isFolderFeedId,
+  fromFolderFeedId,
+  isFilterFeedId,
+  fromFilterFeedId,
+} from "@/utils/constants.ts";
+
+/**
+ * Floating cog above the article list. Context-aware: clicks
+ * dispatch to the right settings dialog based on the current
+ * selectedFeedId type. Hides itself on aggregated views that have
+ * nothing to configure (ALL_FEEDS, STARRED) and on broken
+ * references (folder/filter whose target was deleted).
+ */
+export function SettingsPill() {
+  const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
+  const feeds = useFeedStore((s) => s.feeds);
+  const folders = useFeedStore((s) => s.folders);
+  const openFeedSettings = useFeedStore((s) => s.openFeedSettings);
+  const openFolderSettings = useFeedStore((s) => s.openFolderSettings);
+  const filters = useSmartFilterStore((s) => s.filters);
+  const openEditor = useSmartFilterStore((s) => s.openEditor);
+  const isMobile = useIsMobile();
+
+  const target = resolveTarget({
+    selectedFeedId,
+    feeds,
+    folders,
+    filters,
+  });
+
+  if (!target) return null;
+
+  function handleClick() {
+    if (!target) return;
+    switch (target.kind) {
+      case "feed":
+        openFeedSettings(target.id);
+        return;
+      case "folder":
+        openFolderSettings(target.id);
+        return;
+      case "filter":
+        openEditor(target.filter);
+        return;
+    }
+  }
+
+  return (
+    <ExpandingPill
+      icon={<SettingsIcon />}
+      label={target.label}
+      aria-label={target.label}
+      alwaysExpanded={isMobile}
+      dataTestId="settings-pill"
+      onClick={handleClick}
+    />
+  );
+}
+
+type Target =
+  | { kind: "feed"; id: string; label: string }
+  | { kind: "folder"; id: string; label: string }
+  | {
+      kind: "filter";
+      filter: import("@/types/index.ts").SmartFilter;
+      label: string;
+    };
+
+function resolveTarget({
+  selectedFeedId,
+  feeds,
+  folders,
+  filters,
+}: {
+  selectedFeedId: string | null;
+  feeds: import("@/types/index.ts").Feed[];
+  folders: import("@/types/index.ts").Folder[];
+  filters: import("@/types/index.ts").SmartFilter[];
+}): Target | null {
+  if (!selectedFeedId) return null;
+  if (selectedFeedId === ALL_FEEDS_ID) return null;
+  if (selectedFeedId === STARRED_FEED_ID) return null;
+
+  if (isFolderFeedId(selectedFeedId)) {
+    const id = fromFolderFeedId(selectedFeedId);
+    if (!id) return null;
+    const folder = folders.find((f) => f.id === id);
+    if (!folder) return null;
+    return { kind: "folder", id, label: "Folder settings" };
+  }
+
+  if (isFilterFeedId(selectedFeedId)) {
+    const id = fromFilterFeedId(selectedFeedId);
+    if (!id) return null;
+    const filter = filters.find((f) => f.id === id);
+    if (!filter) return null;
+    return { kind: "filter", filter, label: "Edit filter" };
+  }
+
+  const feed = feeds.find((f) => f.id === selectedFeedId);
+  if (!feed) return null;
+  return { kind: "feed", id: selectedFeedId, label: "Feed settings" };
+}

--- a/src/components/articles/sort-pill.tsx
+++ b/src/components/articles/sort-pill.tsx
@@ -1,0 +1,57 @@
+import { ArrowUpDown, Check } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu.tsx";
+import { ExpandingPill } from "@/components/ui/expanding-pill.tsx";
+import { useIsMobile } from "@/hooks/use-mobile.ts";
+import type { ArticleSortMode } from "@/types/index.ts";
+import { ARTICLE_SORT_MODES } from "@/types/index.ts";
+
+const SORT_LABELS: Record<ArticleSortMode, string> = {
+  newest: "Newest first",
+  oldest: "Oldest first",
+  "unread-first": "Unread first",
+};
+
+interface SortPillProps {
+  mode: ArticleSortMode;
+  onChange: (mode: ArticleSortMode) => void;
+  dataTestId?: string;
+}
+
+/**
+ * Article-list sort selector built on the ExpandingPill primitive.
+ * Replaces the older compact text+icon SortMenu. Mobile always shows
+ * the label (no hover semantics); desktop expands on hover.
+ */
+export function SortPill({ mode, onChange, dataTestId }: SortPillProps) {
+  const isMobile = useIsMobile();
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <ExpandingPill
+          icon={<ArrowUpDown />}
+          label={SORT_LABELS[mode]}
+          aria-label={`Sort: ${SORT_LABELS[mode]}`}
+          alwaysExpanded={isMobile}
+          dataTestId={dataTestId}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-36">
+        {ARTICLE_SORT_MODES.map((m) => (
+          <DropdownMenuItem key={m} onClick={() => onChange(m)}>
+            <Check
+              className={`size-3.5 mr-1.5 ${
+                mode === m ? "opacity-100" : "opacity-0"
+              }`}
+            />
+            {SORT_LABELS[m]}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/feeds/feed-settings-dialog.tsx
+++ b/src/components/feeds/feed-settings-dialog.tsx
@@ -1,0 +1,333 @@
+/**
+ * Per-feed settings dialog. Opened from the floating cog above the
+ * article list (replaces the per-feed three-dot sidebar dropdown).
+ *
+ * Sections, in order: Name, Display (prefer/prefetch full text),
+ * Folder, Rules (link to RulesEditorDialog), Actions (refresh,
+ * clear cached, delete).
+ *
+ * State: open/close lives on feed-store (feedSettingsDialogId). The
+ * target feed is read from feed-store.feeds. Mutations go straight
+ * to the existing store actions — this component is a controlled
+ * shell around them.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  Settings2,
+  RefreshCw,
+  RotateCcw,
+  Trash2,
+  AlertTriangle,
+} from "lucide-react";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Input } from "@/components/ui/input.tsx";
+import { Label } from "@/components/ui/label.tsx";
+import { Switch } from "@/components/ui/switch.tsx";
+import type { Feed } from "@/types/index.ts";
+
+export function FeedSettingsDialog() {
+  const feedId = useFeedStore((s) => s.feedSettingsDialogId);
+  const close = useFeedStore((s) => s.closeFeedSettings);
+  const feeds = useFeedStore((s) => s.feeds);
+  const feed = feeds.find((f) => f.id === feedId);
+
+  return (
+    <Dialog
+      open={Boolean(feedId)}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      <DialogContent
+        data-testid="feed-settings-dialog"
+        className="max-w-lg max-h-[85vh] overflow-y-auto"
+      >
+        {feed ? <Body feed={feed} onClose={close} /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Body({ feed, onClose }: { feed: Feed; onClose: () => void }) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <Settings2 className="size-4 text-violet-500" />
+          Settings — {feed.title}
+        </DialogTitle>
+        <DialogDescription>
+          Configure how this feed is fetched, displayed, and organised.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-5">
+        <NameSection feed={feed} />
+        <DisplaySection feed={feed} />
+        <FolderSection feed={feed} />
+        <RulesSection feed={feed} />
+        <ActionsSection feed={feed} />
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onClose}>
+          Done
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function NameSection({ feed }: { feed: Feed }) {
+  const renameFeed = useFeedStore((s) => s.renameFeed);
+  const [draft, setDraft] = useState(feed.title);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setDraft(feed.title);
+  }, [feed.title]);
+
+  const dirty = draft.trim().length > 0 && draft.trim() !== feed.title;
+
+  async function save() {
+    if (!dirty) return;
+    setSaving(true);
+    try {
+      await renameFeed(feed.id, draft.trim());
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="space-y-2">
+      <Label htmlFor="feed-settings-name">Name</Label>
+      <div className="flex items-center gap-2">
+        <Input
+          id="feed-settings-name"
+          data-testid="feed-settings-name-input"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") save();
+          }}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={save}
+          disabled={!dirty || saving}
+          data-testid="feed-settings-name-save"
+        >
+          Save
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function DisplaySection({ feed }: { feed: Feed }) {
+  const setFeedPreferFullText = useFeedStore((s) => s.setFeedPreferFullText);
+  const setFeedPrefetchEnabled = useFeedStore((s) => s.setFeedPrefetchEnabled);
+
+  return (
+    <section className="space-y-3">
+      <Label>Display</Label>
+      <div className="space-y-3 rounded-md border bg-card p-3">
+        <ToggleRow
+          id="feed-settings-prefer-full-text"
+          label="Prefer full text"
+          description="Open articles from this feed in extracted-text view by default."
+          checked={Boolean(feed.preferFullText)}
+          onCheckedChange={(v) => setFeedPreferFullText(feed.id, v)}
+        />
+        <ToggleRow
+          id="feed-settings-prefetch"
+          label="Prefetch full text"
+          description="Pre-extract this feed's recent articles on refresh so they read offline."
+          checked={Boolean(feed.prefetchEnabled)}
+          onCheckedChange={(v) => setFeedPrefetchEnabled(feed.id, v)}
+        />
+      </div>
+    </section>
+  );
+}
+
+function ToggleRow({
+  id,
+  label,
+  description,
+  checked,
+  onCheckedChange,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <Label htmlFor={id} className="text-sm font-medium">
+          {label}
+        </Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Switch
+        id={id}
+        data-testid={id}
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+      />
+    </div>
+  );
+}
+
+function FolderSection({ feed }: { feed: Feed }) {
+  const folders = useFeedStore((s) => s.folders);
+  const moveFeedToFolder = useFeedStore((s) => s.moveFeedToFolder);
+
+  return (
+    <section className="space-y-2">
+      <Label htmlFor="feed-settings-folder">Folder</Label>
+      <select
+        id="feed-settings-folder"
+        data-testid="feed-settings-folder"
+        className="h-9 w-full rounded-md border bg-background px-2 text-sm"
+        value={feed.folderId ?? ""}
+        onChange={(e) =>
+          moveFeedToFolder(feed.id, e.target.value === "" ? null : e.target.value)
+        }
+      >
+        <option value="">Unfiled</option>
+        {folders.map((f) => (
+          <option key={f.id} value={f.id}>
+            {f.name}
+          </option>
+        ))}
+      </select>
+    </section>
+  );
+}
+
+function RulesSection({ feed }: { feed: Feed }) {
+  const openRulesEditor = useFeedStore((s) => s.openRulesEditor);
+  const ruleCount = feed.rules?.length ?? 0;
+
+  return (
+    <section className="space-y-2">
+      <Label>Rules</Label>
+      <div className="flex items-center justify-between rounded-md border bg-card p-3">
+        <p className="text-sm text-muted-foreground">
+          {ruleCount === 0
+            ? "No rules. Auto-mute, star, or route articles."
+            : `${ruleCount} rule${ruleCount === 1 ? "" : "s"} active.`}
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="feed-settings-manage-rules"
+          onClick={() => openRulesEditor(feed.id)}
+        >
+          Manage rules…
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function ActionsSection({ feed }: { feed: Feed }) {
+  const refreshSingleFeed = useFeedStore((s) => s.refreshSingleFeed);
+  const reloadSingleFeed = useFeedStore((s) => s.reloadSingleFeed);
+  const removeFeed = useFeedStore((s) => s.removeFeed);
+  const close = useFeedStore((s) => s.closeFeedSettings);
+
+  return (
+    <section className="space-y-2">
+      <Label>Actions</Label>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="feed-settings-refresh"
+          onClick={() => refreshSingleFeed(feed.id)}
+        >
+          <RefreshCw className="size-4" /> Refresh now
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="feed-settings-clear-cache"
+          onClick={() => reloadSingleFeed(feed.id)}
+        >
+          <RotateCcw className="size-4" /> Clear cached articles
+        </Button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              data-testid="feed-settings-delete"
+            >
+              <Trash2 className="size-4" /> Delete feed
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle className="flex items-center gap-2">
+                <AlertTriangle className="size-4 text-destructive" />
+                Delete this feed?
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {feed.title} and every cached article from it will be removed.
+                This cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel data-testid="feed-settings-delete-cancel">
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                data-testid="feed-settings-delete-confirm"
+                onClick={async () => {
+                  await removeFeed(feed.id);
+                  close();
+                }}
+              >
+                Delete feed
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </section>
+  );
+}

--- a/src/components/folders/folder-color-picker.tsx
+++ b/src/components/folders/folder-color-picker.tsx
@@ -1,0 +1,34 @@
+import { FOLDER_COLORS } from "@/lib/folder-colors.ts";
+
+interface FolderColorPickerProps {
+  value: string | undefined;
+  onChange: (color: string | undefined) => void;
+}
+
+/**
+ * 8-swatch color picker for folders. Click toggles — selecting the
+ * current color clears it (back to default). Extracted from the
+ * original sidebar dropdown so it can be reused in the folder
+ * settings dialog without duplication.
+ */
+export function FolderColorPicker({ value, onChange }: FolderColorPickerProps) {
+  return (
+    <div data-testid="folder-color-picker" className="flex gap-1.5 flex-wrap">
+      {FOLDER_COLORS.map((c) => (
+        <button
+          key={c}
+          type="button"
+          className="size-7 rounded-full border-2 transition-transform hover:scale-110 focus-visible:ring-1 focus-visible:ring-offset-1"
+          style={{
+            backgroundColor: c,
+            borderColor: value === c ? "#fff" : "transparent",
+            outline: value === c ? `2px solid ${c}` : undefined,
+          }}
+          aria-label={`Set folder color ${c}`}
+          aria-pressed={value === c}
+          onClick={() => onChange(value === c ? undefined : c)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/folders/folder-settings-dialog.tsx
+++ b/src/components/folders/folder-settings-dialog.tsx
@@ -1,0 +1,215 @@
+/**
+ * Per-folder settings dialog. Opened from the floating cog when the
+ * user is inside a folder view. Replaces the folder's sidebar
+ * three-dot dropdown.
+ *
+ * Sections: Name, Color, Delete. Same shape as FeedSettingsDialog;
+ * mounts at the app root and reads folderSettingsDialogId from
+ * feed-store.
+ */
+
+import { useEffect, useState } from "react";
+import { Folder as FolderIcon, Trash2, AlertTriangle } from "lucide-react";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Input } from "@/components/ui/input.tsx";
+import { Label } from "@/components/ui/label.tsx";
+import { FolderColorPicker } from "./folder-color-picker.tsx";
+import type { Folder } from "@/types/index.ts";
+
+export function FolderSettingsDialog() {
+  const folderId = useFeedStore((s) => s.folderSettingsDialogId);
+  const close = useFeedStore((s) => s.closeFolderSettings);
+  const folders = useFeedStore((s) => s.folders);
+  const folder = folders.find((f) => f.id === folderId);
+
+  return (
+    <Dialog
+      open={Boolean(folderId)}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      <DialogContent
+        data-testid="folder-settings-dialog"
+        className="max-w-lg max-h-[85vh] overflow-y-auto"
+      >
+        {folder ? <Body folder={folder} onClose={close} /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Body({ folder, onClose }: { folder: Folder; onClose: () => void }) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <FolderIcon className="size-4 text-violet-500" />
+          Settings — {folder.name}
+        </DialogTitle>
+        <DialogDescription>
+          Rename, recolor, or delete this folder. Feeds inside the folder
+          stay subscribed; they fall back to Unfiled if the folder is
+          deleted.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-5">
+        <NameSection folder={folder} />
+        <ColorSection folder={folder} />
+        <DeleteSection folder={folder} onClose={onClose} />
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onClose}>
+          Done
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function NameSection({ folder }: { folder: Folder }) {
+  const renameFolder = useFeedStore((s) => s.renameFolder);
+  const [draft, setDraft] = useState(folder.name);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setDraft(folder.name);
+  }, [folder.name]);
+
+  const dirty = draft.trim().length > 0 && draft.trim() !== folder.name;
+
+  async function save() {
+    if (!dirty) return;
+    setSaving(true);
+    try {
+      await renameFolder(folder.id, draft.trim());
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="space-y-2">
+      <Label htmlFor="folder-settings-name">Name</Label>
+      <div className="flex items-center gap-2">
+        <Input
+          id="folder-settings-name"
+          data-testid="folder-settings-name-input"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") save();
+          }}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={save}
+          disabled={!dirty || saving}
+          data-testid="folder-settings-name-save"
+        >
+          Save
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function ColorSection({ folder }: { folder: Folder }) {
+  const updateFolderColor = useFeedStore((s) => s.updateFolderColor);
+
+  return (
+    <section className="space-y-2">
+      <Label>Color</Label>
+      <div className="rounded-md border bg-card p-3">
+        <FolderColorPicker
+          value={folder.color}
+          onChange={(color) => updateFolderColor(folder.id, color)}
+        />
+        <p className="mt-2 text-xs text-muted-foreground">
+          Click a swatch to set the folder's accent. Click again to clear.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function DeleteSection({
+  folder,
+  onClose,
+}: {
+  folder: Folder;
+  onClose: () => void;
+}) {
+  const deleteFolder = useFeedStore((s) => s.deleteFolder);
+
+  return (
+    <section className="space-y-2">
+      <Label>Danger zone</Label>
+      <div className="rounded-md border bg-card p-3">
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              data-testid="folder-settings-delete"
+            >
+              <Trash2 className="size-4" /> Delete folder
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle className="flex items-center gap-2">
+                <AlertTriangle className="size-4 text-destructive" />
+                Delete this folder?
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {folder.name} will be removed. Feeds that were inside it
+                stay subscribed but become Unfiled.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel data-testid="folder-settings-delete-cancel">
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                data-testid="folder-settings-delete-confirm"
+                onClick={async () => {
+                  await deleteFolder(folder.id);
+                  onClose();
+                }}
+              >
+                Delete folder
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sidebar/feed-item.tsx
+++ b/src/components/sidebar/feed-item.tsx
@@ -1,25 +1,16 @@
-import { useState } from "react";
-import { AlertTriangle, Check, MoreHorizontal, Pencil, RefreshCw, RotateCcw, Settings2, Trash2 } from "lucide-react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { cn } from "@/lib/utils.ts";
 import { useArticleStore, selectUnreadCount } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
 import { isFeedStale } from "@/lib/stale-feed.ts";
 import {
-  SidebarMenuAction,
   SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar.tsx";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu.tsx";
 import type { Feed } from "@/types/index.ts";
 
 interface FeedItemProps {
@@ -29,22 +20,24 @@ interface FeedItemProps {
   /** When true, uses @dnd-kit/sortable for reorder-in-place behavior. */
   sortable?: boolean;
   onSelect: () => void;
-  onRemove: () => void;
-  onReload: () => void;
 }
 
-export function FeedItem({ feed, isSelected, inFolder = false, sortable = false, onSelect, onRemove, onReload }: FeedItemProps) {
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [renameValue, setRenameValue] = useState("");
+/**
+ * Sidebar feed row. Select-only — every per-feed action (rename,
+ * preferences, rules, refresh, clear cache, delete) lives in
+ * FeedSettingsDialog now, opened from the floating cog above the
+ * article list. The row keeps the favicon, title, refresh/stale
+ * indicators, unread badge, and drag handle for reorder.
+ */
+export function FeedItem({
+  feed,
+  isSelected,
+  inFolder = false,
+  sortable = false,
+  onSelect,
+}: FeedItemProps) {
   const unreadCount = useArticleStore((s) => selectUnreadCount(s, feed.id));
-  const renameFeed = useFeedStore((s) => s.renameFeed);
-  const setFeedPreferFullText = useFeedStore((s) => s.setFeedPreferFullText);
-  const setFeedPrefetchEnabled = useFeedStore((s) => s.setFeedPrefetchEnabled);
-  const refreshSingleFeed = useFeedStore((s) => s.refreshSingleFeed);
   const refreshingFeedIds = useFeedStore((s) => s.refreshingFeedIds);
-  const folders = useFeedStore((s) => s.folders);
-  const moveFeedToFolder = useFeedStore((s) => s.moveFeedToFolder);
-  const openRulesEditor = useFeedStore((s) => s.openRulesEditor);
   const isRefreshing = refreshingFeedIds.has(feed.id);
 
   // Both hooks are always called (hooks must not be conditional).
@@ -55,20 +48,10 @@ export function FeedItem({ feed, isSelected, inFolder = false, sortable = false,
   const dragRef = sortable ? sortableHook.setNodeRef : draggable.setNodeRef;
   const dragListeners = sortable ? sortableHook.listeners : draggable.listeners;
   const isDragging = sortable ? sortableHook.isDragging : draggable.isDragging;
-  const sortStyle: React.CSSProperties = sortable && sortableHook.transform
-    ? { transform: CSS.Transform.toString(sortableHook.transform), transition: sortableHook.transition }
-    : {};
-
-  function handleStartRename() {
-    setRenameValue(feed.title);
-    setIsRenaming(true);
-  }
-
-  function handleSubmitRename(e: React.FormEvent) {
-    e.preventDefault();
-    if (renameValue.trim()) renameFeed(feed.id, renameValue.trim());
-    setIsRenaming(false);
-  }
+  const sortStyle: React.CSSProperties =
+    sortable && sortableHook.transform
+      ? { transform: CSS.Transform.toString(sortableHook.transform), transition: sortableHook.transition }
+      : {};
 
   return (
     <SidebarMenuItem
@@ -77,100 +60,22 @@ export function FeedItem({ feed, isSelected, inFolder = false, sortable = false,
       className={inFolder ? "pl-4" : ""}
       {...dragListeners}
     >
-      {isRenaming ? (
-        <form className="flex items-center gap-2 px-2 py-1" onSubmit={handleSubmitRename}>
-          <FeedFavicon siteUrl={feed.siteUrl} />
-          <input
-            role="textbox"
-            autoFocus
-            className="flex-1 bg-transparent text-sm outline-none border-b border-primary min-w-0"
-            value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
-            onBlur={() => setIsRenaming(false)}
-            onKeyDown={(e) => { if (e.key === "Escape") setIsRenaming(false); }}
+      <SidebarMenuButton isActive={isSelected} onClick={onSelect}>
+        <FeedFavicon siteUrl={feed.siteUrl} />
+        <span className="truncate">{feed.title}</span>
+        {isRefreshing && (
+          <RefreshCw className="size-3 animate-spin shrink-0 text-muted-foreground" />
+        )}
+        {!isRefreshing && isFeedStale(feed) && (
+          <AlertTriangle
+            className="size-3 shrink-0 text-amber-500"
+            aria-label="This feed hasn't updated in over 14 days"
+            data-testid="stale-feed-indicator"
           />
-        </form>
-      ) : (
-        <SidebarMenuButton isActive={isSelected} onClick={onSelect}>
-          <FeedFavicon siteUrl={feed.siteUrl} />
-          <span className="truncate">{feed.title}</span>
-          {isRefreshing && <RefreshCw className="size-3 animate-spin shrink-0 text-muted-foreground" />}
-          {!isRefreshing && isFeedStale(feed) && (
-            <AlertTriangle
-              className="size-3 shrink-0 text-amber-500"
-              aria-label="This feed hasn't updated in over 14 days"
-              data-testid="stale-feed-indicator"
-            />
-          )}
-        </SidebarMenuButton>
-      )}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <SidebarMenuAction showOnHover className="focus-visible:ring-0">
-            <MoreHorizontal />
-            <span className="sr-only">More</span>
-          </SidebarMenuAction>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent side="right" align="start">
-          <DropdownMenuItem onClick={handleStartRename}>
-            <Pencil className="size-4" /> Rename
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => setFeedPreferFullText(feed.id, !feed.preferFullText)}
-          >
-            <Check
-              className={cn(
-                "size-4",
-                feed.preferFullText ? "opacity-100" : "opacity-0",
-              )}
-            />
-            Prefer full text
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() =>
-              setFeedPrefetchEnabled(feed.id, !feed.prefetchEnabled)
-            }
-            data-testid="feed-item-prefetch-toggle"
-          >
-            <Check
-              className={cn(
-                "size-4",
-                feed.prefetchEnabled ? "opacity-100" : "opacity-0",
-              )}
-            />
-            Prefetch full text
-          </DropdownMenuItem>
-          {folders.length > 0 && (
-            <>
-              <DropdownMenuItem onClick={() => moveFeedToFolder(feed.id, null)} disabled={!feed.folderId}>
-                Unfiled
-              </DropdownMenuItem>
-              {folders.map((f) => (
-                <DropdownMenuItem key={f.id} onClick={() => moveFeedToFolder(feed.id, f.id)} disabled={feed.folderId === f.id}>
-                  → {f.name}
-                </DropdownMenuItem>
-              ))}
-            </>
-          )}
-          <DropdownMenuItem
-            onClick={() => openRulesEditor(feed.id)}
-            data-testid="feed-item-rules"
-          >
-            <Settings2 className="size-4" /> Rules…
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => refreshSingleFeed(feed.id)}>
-            <RefreshCw className="size-4" /> Refresh
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={onReload}>
-            <RotateCcw className="size-4" /> Clear cached articles
-          </DropdownMenuItem>
-          <DropdownMenuItem className="text-destructive focus:text-destructive" onClick={onRemove}>
-            <Trash2 className="size-4" /> Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        )}
+      </SidebarMenuButton>
       {!isRefreshing && unreadCount > 0 && (
-        <SidebarMenuBadge className="rounded-lg bg-primary/10 text-primary text-[10px] font-semibold group-hover/menu-item:opacity-0 group-has-[[data-state=open]]/menu-item:opacity-0 max-md:hidden">
+        <SidebarMenuBadge className="rounded-lg bg-primary/10 text-primary text-[10px] font-semibold max-md:hidden">
           {unreadCount > 99 ? "99+" : unreadCount}
         </SidebarMenuBadge>
       )}

--- a/src/components/sidebar/folder-item.tsx
+++ b/src/components/sidebar/folder-item.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
 import { cn } from "@/lib/utils.ts";
-import { ChevronRight, GripVertical, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { ChevronRight, GripVertical } from "lucide-react";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { useDroppable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
@@ -8,22 +7,13 @@ import { CSS } from "@dnd-kit/utilities";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import {
   SidebarMenu,
-  SidebarMenuAction,
   SidebarMenuButton,
 } from "@/components/ui/sidebar.tsx";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu.tsx";
 import type { Folder } from "@/types/index.ts";
-import { FOLDER_COLORS } from "@/lib/folder-colors.ts";
 
 interface FolderItemProps {
   folder: Folder;
   children: React.ReactNode;
-  onDelete: () => void;
   /** Whether this folder's aggregated feed is the currently selected feed. */
   isSelected: boolean;
   /** Called when the user wants to view the folder's aggregated feed. */
@@ -33,46 +23,37 @@ interface FolderItemProps {
   sortable?: boolean;
 }
 
-export function FolderItem({ folder, children, onDelete, isSelected, onSelect, sortable = false }: FolderItemProps) {
+/**
+ * Sidebar folder row. Select-only — rename / color / delete now live
+ * in FolderSettingsDialog, opened from the floating cog above the
+ * article list. The row keeps the chevron, name, color background,
+ * drag handle for reorder, and the inline grouping of child feeds.
+ */
+export function FolderItem({
+  folder,
+  children,
+  isSelected,
+  onSelect,
+  sortable = false,
+}: FolderItemProps) {
   const open = useFeedStore((s) => s.folderOpenState[folder.id] ?? true);
   const setFolderOpen = useFeedStore((s) => s.setFolderOpen);
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [renameValue, setRenameValue] = useState("");
-  const renameFolder = useFeedStore((s) => s.renameFolder);
-  const updateFolderColor = useFeedStore((s) => s.updateFolderColor);
   const { setNodeRef: setDropRef, isOver } = useDroppable({ id: folder.id });
   const sortableHook = useSortable({ id: folder.id, disabled: !sortable });
-  const sortStyle: React.CSSProperties = sortable && sortableHook.transform
-    ? { transform: CSS.Transform.toString(sortableHook.transform), transition: sortableHook.transition }
-    : {};
+  const sortStyle: React.CSSProperties =
+    sortable && sortableHook.transform
+      ? { transform: CSS.Transform.toString(sortableHook.transform), transition: sortableHook.transition }
+      : {};
 
-  /** Combine the droppable ref (feed→folder drop target) with the sortable
-   *  ref (folder reorder) into a single ref callback for the outer <li>. */
   function setNodeRef(node: HTMLLIElement | null) {
     setDropRef(node);
     if (sortable) sortableHook.setNodeRef(node);
-  }
-
-  function handleStartRename() {
-    setRenameValue(folder.name);
-    setIsRenaming(true);
-  }
-
-  function handleSubmitRename(e: React.FormEvent) {
-    e.preventDefault();
-    if (renameValue.trim()) renameFolder(folder.id, renameValue.trim());
-    setIsRenaming(false);
   }
 
   const colorStyle = folder.color
     ? { backgroundColor: folder.color, color: "#ffffff" }
     : undefined;
 
-  // The outer <li> carries no `group/menu-item` class of its own, so hovering
-  // a child feed (which lives inside an inner <ul>) does NOT trigger hover
-  // state on the folder header's group. The folder header is a nested <div>
-  // that owns its own `group/menu-item` scope for the action-dots swap,
-  // scoped only to the header row — not to child feeds.
   return (
     <li
       ref={setNodeRef}
@@ -84,10 +65,7 @@ export function FolderItem({ folder, children, onDelete, isSelected, onSelect, s
         open={open}
         onOpenChange={(v) => setFolderOpen(folder.id, v)}
       >
-        <div
-          data-sidebar="menu-item"
-          className="group/menu-item relative"
-        >
+        <div data-sidebar="menu-item" className="group/menu-item relative">
           {sortable && (
             <button
               type="button"
@@ -99,94 +77,41 @@ export function FolderItem({ folder, children, onDelete, isSelected, onSelect, s
               <GripVertical className="size-3 text-muted-foreground" />
             </button>
           )}
-          {isRenaming ? (
-            <form className="flex items-center gap-2 px-2 py-1" onSubmit={handleSubmitRename}>
-              <ChevronRight className="size-3.5" />
-              <input
-                autoFocus
-                className="flex-1 bg-transparent text-sm font-medium outline-none border-b border-primary min-w-0"
-                value={renameValue}
-                onChange={(e) => setRenameValue(e.target.value)}
-                onBlur={() => setIsRenaming(false)}
-                onKeyDown={(e) => { if (e.key === "Escape") setIsRenaming(false); }}
-              />
-            </form>
-          ) : (
-            <>
-              {/*
-                Click the folder name → navigate to the folder's aggregated
-                feed only. Click the absolutely-positioned chevron (the
-                Collapsible.Trigger below) → toggle collapse only. The two
-                affordances are intentionally distinct: clicking the name
-                used to also toggle, which surprised users who expected
-                "click name = open that feed" without losing their place
-                in the folder tree. Button padding (pl-7) leaves room for
-                the chevron.
-              */}
-              <SidebarMenuButton
-                isActive={isSelected}
-                onClick={onSelect}
-                className="font-semibold pl-7"
-                style={colorStyle}
-              >
-                <span className="truncate">{folder.name}</span>
-              </SidebarMenuButton>
-              <Collapsible.Trigger asChild>
-                <button
-                  type="button"
-                  aria-label="Toggle folder"
-                  className={cn(
-                    "absolute left-1 top-1 size-6 flex items-center justify-center z-10 transition-colors",
-                    folder.color
-                      ? "text-white/70 hover:text-white"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  <ChevronRight className="size-3.5 transition-transform group-data-[state=open]/folder:rotate-90" />
-                </button>
-              </Collapsible.Trigger>
-            </>
-          )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <SidebarMenuAction showOnHover className="focus-visible:ring-0">
-                <MoreHorizontal />
-                <span className="sr-only">Folder options</span>
-              </SidebarMenuAction>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side="right" align="start">
-              <DropdownMenuItem onClick={handleStartRename}>
-                <Pencil className="size-4" /> Rename folder
-              </DropdownMenuItem>
-              <div data-testid="folder-color-picker" className="px-2 py-1.5">
-                <p className="text-xs text-muted-foreground mb-1.5">Color</p>
-                <div className="flex gap-1 flex-wrap">
-                  {FOLDER_COLORS.map((c) => (
-                    <button
-                      key={c}
-                      type="button"
-                      className="size-5 rounded-full border-2 transition-transform hover:scale-110 focus-visible:ring-1 focus-visible:ring-offset-1"
-                      style={{
-                        backgroundColor: c,
-                        borderColor: folder.color === c ? "#fff" : "transparent",
-                        outline: folder.color === c ? `2px solid ${c}` : undefined,
-                      }}
-                      aria-label={`Set folder color ${c}`}
-                      onClick={() => updateFolderColor(folder.id, folder.color === c ? undefined : c)}
-                    />
-                  ))}
-                </div>
-              </div>
-              <DropdownMenuItem className="text-destructive focus:text-destructive" onClick={onDelete}>
-                <Trash2 className="size-4" /> Delete folder
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {/*
+            Click the folder name → navigate to the folder's aggregated
+            feed only. Click the absolutely-positioned chevron (the
+            Collapsible.Trigger below) → toggle collapse only. The two
+            affordances are intentionally distinct: clicking the name
+            used to also toggle, which surprised users who expected
+            "click name = open that feed" without losing their place
+            in the folder tree. Button padding (pl-7) leaves room for
+            the chevron.
+          */}
+          <SidebarMenuButton
+            isActive={isSelected}
+            onClick={onSelect}
+            className="font-semibold pl-7"
+            style={colorStyle}
+          >
+            <span className="truncate">{folder.name}</span>
+          </SidebarMenuButton>
+          <Collapsible.Trigger asChild>
+            <button
+              type="button"
+              aria-label="Toggle folder"
+              className={cn(
+                "absolute left-1 top-1 size-6 flex items-center justify-center z-10 transition-colors",
+                folder.color
+                  ? "text-white/70 hover:text-white"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <ChevronRight className="size-3.5 transition-transform group-data-[state=open]/folder:rotate-90" />
+            </button>
+          </Collapsible.Trigger>
         </div>
         <Collapsible.Content>
-          <SidebarMenu>
-            {children}
-          </SidebarMenu>
+          <SidebarMenu>{children}</SidebarMenu>
         </Collapsible.Content>
       </Collapsible.Root>
     </li>

--- a/src/components/sidebar/sidebar-feed-list.tsx
+++ b/src/components/sidebar/sidebar-feed-list.tsx
@@ -16,8 +16,6 @@ import {
 import { FeedItem } from "./feed-item.tsx";
 import { FolderItem } from "./folder-item.tsx";
 import { NewFolderInput } from "./new-folder-input.tsx";
-import { FeedRemoveDialog } from "./feed-remove-dialog.tsx";
-import { FeedReloadDialog } from "./feed-reload-dialog.tsx";
 import { FolderDeleteDialog } from "./folder-delete-dialog.tsx";
 import { AutoOrganizePill } from "@/components/folders/auto-organize-pill.tsx";
 import type { Feed, Folder } from "@/types/index.ts";
@@ -76,8 +74,6 @@ export function SidebarFeedList({
   const articlesByFeedId = useArticleStore((s) => s.articlesByFeedId);
 
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
-  const [feedToRemove, setFeedToRemove] = useState<Feed | null>(null);
-  const [feedToReload, setFeedToReload] = useState<Feed | null>(null);
   const [folderToDelete, setFolderToDelete] = useState<Folder | null>(null);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
@@ -182,8 +178,6 @@ export function SidebarFeedList({
     }
   }
 
-  const removeFeed = useFeedStore((s) => s.removeFeed);
-  const reloadSingleFeed = useFeedStore((s) => s.reloadSingleFeed);
   const deleteFolder = useFeedStore((s) => s.deleteFolder);
 
   const isCustomMode = feedSortMode === "custom";
@@ -233,8 +227,6 @@ export function SidebarFeedList({
                 isSelected={feed.id === selectedFeedId}
                 sortable={isCustomMode}
                 onSelect={() => onFeedSelect(feed.id)}
-                onRemove={() => setFeedToRemove(feed)}
-                onReload={() => setFeedToReload(feed)}
               />
             ))}
           </UnfiledDropZone>
@@ -266,8 +258,6 @@ export function SidebarFeedList({
                     isSelected={feed.id === selectedFeedId}
                     inFolder
                     onSelect={() => onFeedSelect(feed.id)}
-                    onRemove={() => setFeedToRemove(feed)}
-                    onReload={() => setFeedToReload(feed)}
                   />
                 ))}
               </FolderItem>
@@ -291,18 +281,6 @@ export function SidebarFeedList({
         </>
       )}
 
-      <FeedRemoveDialog
-        feedTitle={feedToRemove?.title ?? ""}
-        open={feedToRemove !== null}
-        onOpenChange={(open) => { if (!open) setFeedToRemove(null); }}
-        onConfirm={() => { if (feedToRemove) { removeFeed(feedToRemove.id); setFeedToRemove(null); } }}
-      />
-      <FeedReloadDialog
-        feedTitle={feedToReload?.title ?? ""}
-        open={feedToReload !== null}
-        onOpenChange={(open) => { if (!open) setFeedToReload(null); }}
-        onConfirm={() => { if (feedToReload) { reloadSingleFeed(feedToReload.id); setFeedToReload(null); } }}
-      />
       <FolderDeleteDialog
         folderName={folderToDelete?.name ?? ""}
         open={folderToDelete !== null}

--- a/src/components/sidebar/sidebar-feed-list.tsx
+++ b/src/components/sidebar/sidebar-feed-list.tsx
@@ -16,9 +16,8 @@ import {
 import { FeedItem } from "./feed-item.tsx";
 import { FolderItem } from "./folder-item.tsx";
 import { NewFolderInput } from "./new-folder-input.tsx";
-import { FolderDeleteDialog } from "./folder-delete-dialog.tsx";
 import { AutoOrganizePill } from "@/components/folders/auto-organize-pill.tsx";
-import type { Feed, Folder } from "@/types/index.ts";
+import type { Feed } from "@/types/index.ts";
 
 interface SidebarFeedListProps {
   onFeedSelect: (feedId: string) => void;
@@ -74,7 +73,6 @@ export function SidebarFeedList({
   const articlesByFeedId = useArticleStore((s) => s.articlesByFeedId);
 
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
-  const [folderToDelete, setFolderToDelete] = useState<Folder | null>(null);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
@@ -178,7 +176,6 @@ export function SidebarFeedList({
     }
   }
 
-  const deleteFolder = useFeedStore((s) => s.deleteFolder);
 
   const isCustomMode = feedSortMode === "custom";
   const sortableIds = isCustomMode ? sortedUnfiledFeeds.map((f) => f.id) : [];
@@ -249,7 +246,6 @@ export function SidebarFeedList({
                 sortable={isCustomMode}
                 isSelected={selectedFeedId === toFolderFeedId(folder.id)}
                 onSelect={() => onFeedSelect(toFolderFeedId(folder.id))}
-                onDelete={() => setFolderToDelete(folder)}
               >
                 {sortedFolderFeeds.map((feed) => (
                   <FeedItem
@@ -281,12 +277,6 @@ export function SidebarFeedList({
         </>
       )}
 
-      <FolderDeleteDialog
-        folderName={folderToDelete?.name ?? ""}
-        open={folderToDelete !== null}
-        onOpenChange={(open) => { if (!open) setFolderToDelete(null); }}
-        onConfirm={() => { if (folderToDelete) { deleteFolder(folderToDelete.id); setFolderToDelete(null); } }}
-      />
     </>
   );
 }

--- a/src/components/sidebar/smart-filter-item.tsx
+++ b/src/components/sidebar/smart-filter-item.tsx
@@ -1,17 +1,8 @@
-import { Filter, MoreHorizontal, Pencil, Copy, Trash2 } from "lucide-react";
-import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
+import { Filter } from "lucide-react";
 import {
-  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar.tsx";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu.tsx";
 import type { SmartFilter } from "@/types/index.ts";
 
 interface SmartFilterItemProps {
@@ -21,19 +12,16 @@ interface SmartFilterItemProps {
 }
 
 /**
- * Sidebar row for a single smart filter. Click selects the filter view;
- * the "…" menu opens edit / duplicate / delete. The store handles the
- * gate-locked path on its own — every menu action goes through it.
+ * Sidebar row for a single smart filter. Select-only. Edit /
+ * Duplicate / Delete now live in SmartFilterEditorDialog, opened
+ * from the floating cog above the article list when the user is on
+ * the filter's view.
  */
 export function SmartFilterItem({
   filter,
   isSelected,
   onSelect,
 }: SmartFilterItemProps) {
-  const openEditor = useSmartFilterStore((s) => s.openEditor);
-  const duplicateFilter = useSmartFilterStore((s) => s.duplicateFilter);
-  const removeFilter = useSmartFilterStore((s) => s.removeFilter);
-
   return (
     <SidebarMenuItem data-testid="sidebar-smart-filter-item">
       <SidebarMenuButton
@@ -44,34 +32,6 @@ export function SmartFilterItem({
         <Filter className="size-4 text-violet-500" />
         <span className="truncate">{filter.name}</span>
       </SidebarMenuButton>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <SidebarMenuAction
-            data-testid={`smart-filter-menu-${filter.id}`}
-            aria-label="Filter actions"
-          >
-            <MoreHorizontal className="size-3.5" />
-          </SidebarMenuAction>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="min-w-36">
-          <DropdownMenuItem onClick={() => openEditor(filter)}>
-            <Pencil className="size-3.5 mr-2" />
-            Edit
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => duplicateFilter(filter.id)}>
-            <Copy className="size-3.5 mr-2" />
-            Duplicate
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={() => removeFilter(filter.id)}
-            className="text-destructive focus:text-destructive"
-          >
-            <Trash2 className="size-3.5 mr-2" />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
     </SidebarMenuItem>
   );
 }

--- a/src/components/smart-filters/smart-filter-editor-dialog.tsx
+++ b/src/components/smart-filters/smart-filter-editor-dialog.tsx
@@ -47,6 +47,8 @@ export function SmartFilterEditorDialog() {
   const closeEditor = useSmartFilterStore((s) => s.closeEditor);
   const createFilter = useSmartFilterStore((s) => s.createFilter);
   const updateFilter = useSmartFilterStore((s) => s.updateFilter);
+  const duplicateFilter = useSmartFilterStore((s) => s.duplicateFilter);
+  const removeFilter = useSmartFilterStore((s) => s.removeFilter);
 
   const allArticles = useArticleStore((s) => s.articlesByFeedId);
   const feeds = useFeedStore((s) => s.feeds);
@@ -231,23 +233,58 @@ export function SmartFilterEditorDialog() {
           )}
         </div>
 
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={closeEditor}
-            disabled={saving}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            data-testid="smart-filter-save"
-            onClick={handleSave}
-            disabled={saveDisabled}
-          >
-            {editorTarget ? "Save changes" : "Create filter"}
-          </Button>
+        <DialogFooter className="sm:justify-between">
+          <div className="flex gap-2">
+            {editorTarget && (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  data-testid="smart-filter-duplicate"
+                  onClick={async () => {
+                    await duplicateFilter(editorTarget.id);
+                    closeEditor();
+                  }}
+                  disabled={saving}
+                >
+                  Duplicate
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  data-testid="smart-filter-delete"
+                  onClick={async () => {
+                    await removeFilter(editorTarget.id);
+                    closeEditor();
+                  }}
+                  disabled={saving}
+                >
+                  Delete
+                </Button>
+              </>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeEditor}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              data-testid="smart-filter-save"
+              onClick={handleSave}
+              disabled={saveDisabled}
+            >
+              {editorTarget ? "Save changes" : "Create filter"}
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/ui/expanding-pill.tsx
+++ b/src/components/ui/expanding-pill.tsx
@@ -1,0 +1,80 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Circle-to-pill button. Default state is a circular icon-only button;
+ * hover (desktop) or keyboard focus-visible expands the label slot via
+ * a CSS `max-width` animation, growing the pill rightward without
+ * shifting the icon. Set `alwaysExpanded` for the mobile path where
+ * hover doesn't apply.
+ *
+ * Pattern is new for this codebase — see the cog/sort floating pills
+ * at the top of the article list for the primary consumers. Keep the
+ * primitive presentational; routing, store reads, and dialog dispatch
+ * happen in the wrapper component (SortPill, SettingsPill).
+ *
+ * Accessibility:
+ * - Always renders as a real <button>, so keyboard activation works
+ *   out of the box.
+ * - aria-label is forwarded; pass a description (e.g. "Open feed
+ *   settings") that makes sense even when the label is collapsed.
+ * - The label text stays in the DOM at all times so screen readers
+ *   announce it; only its visual width is animated.
+ */
+export interface ExpandingPillProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+  icon: React.ReactNode;
+  label: string;
+  /**
+   * When true, the label is visible at its full width without needing
+   * a hover. Use on mobile (no hover semantics) and any always-on
+   * affordance.
+   */
+  alwaysExpanded?: boolean;
+  dataTestId?: string;
+}
+
+export const ExpandingPill = React.forwardRef<
+  HTMLButtonElement,
+  ExpandingPillProps
+>(function ExpandingPill(
+  { icon, label, alwaysExpanded = false, dataTestId, className, ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      data-testid={dataTestId}
+      className={cn(
+        // Base shape: circle that grows into a pill as the label expands.
+        "group inline-flex items-center justify-center gap-0 h-9 rounded-full px-2 shrink-0",
+        "bg-background/80 backdrop-blur-sm border border-border shadow-sm",
+        "text-muted-foreground hover:text-foreground transition-colors",
+        // Pointer-events keep the surrounding sticky container scroll-friendly.
+        "pointer-events-auto",
+        // Focus-visible ring matches the rest of the UI primitives.
+        "outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2",
+        "disabled:opacity-50 disabled:pointer-events-none",
+        "[&_svg]:size-4 [&_svg]:shrink-0",
+        className,
+      )}
+      {...rest}
+    >
+      <span className="flex items-center justify-center">{icon}</span>
+      <span
+        className={cn(
+          "overflow-hidden whitespace-nowrap text-xs font-medium",
+          "transition-[max-width,padding] duration-200 ease-out",
+          alwaysExpanded
+            ? "max-w-[160px] pl-2"
+            : // Collapsed by default; expand on group-hover (desktop) or
+              // when the button itself becomes focus-visible (keyboard).
+              "max-w-0 group-hover:max-w-[160px] group-hover:pl-2 group-focus-visible:max-w-[160px] group-focus-visible:pl-2",
+        )}
+      >
+        {label}
+      </span>
+    </button>
+  );
+});

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -135,6 +135,18 @@ interface FeedStore {
   rulesEditorFeedId: string | null;
   openRulesEditor: (feedId: string) => void;
   closeRulesEditor: () => void;
+  /**
+   * Open/close state for the per-feed settings dialog. Dialog mounts
+   * at the app root and reads this slice; non-null id = open against
+   * that feed. Mirrors rulesEditorFeedId for shape.
+   */
+  feedSettingsDialogId: string | null;
+  openFeedSettings: (feedId: string) => void;
+  closeFeedSettings: () => void;
+  /** Same shape, for the per-folder settings dialog (rename + color + delete). */
+  folderSettingsDialogId: string | null;
+  openFolderSettings: (folderId: string) => void;
+  closeFolderSettings: () => void;
 }
 
 function readSortMode(): FeedSortMode {
@@ -313,6 +325,12 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
   rulesEditorFeedId: null,
   openRulesEditor: (feedId) => set({ rulesEditorFeedId: feedId }),
   closeRulesEditor: () => set({ rulesEditorFeedId: null }),
+  feedSettingsDialogId: null,
+  openFeedSettings: (feedId) => set({ feedSettingsDialogId: feedId }),
+  closeFeedSettings: () => set({ feedSettingsDialogId: null }),
+  folderSettingsDialogId: null,
+  openFolderSettings: (folderId) => set({ folderSettingsDialogId: folderId }),
+  closeFolderSettings: () => set({ folderSettingsDialogId: null }),
 
   loadFeeds: async () => {
     const [feedsResult, foldersResult] = await Promise.all([getFeeds(), dbGetFolders()]);

--- a/tests/components/articles/settings-pill.test.tsx
+++ b/tests/components/articles/settings-pill.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * SettingsPill — the floating cog. Context-aware: clicks dispatch to
+ * the right settings dialog based on selectedFeedId type, and the
+ * pill hides itself entirely on aggregated views that have nothing
+ * to configure (ALL_FEEDS, STARRED).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingsPill } from "@/components/articles/settings-pill.tsx";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
+import {
+  ALL_FEEDS_ID,
+  STARRED_FEED_ID,
+  toFolderFeedId,
+  toFilterFeedId,
+} from "@/utils/constants.ts";
+import type { Feed, Folder, SmartFilter } from "@/types/index.ts";
+
+vi.mock("@/core/storage/db.ts", () => ({
+  getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getFeed: vi.fn(),
+  updateFeed: vi.fn(),
+  getFolders: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  updateFolder: vi.fn(),
+  removeFolder: vi.fn(),
+  removeFeed: vi.fn(),
+  addFolder: vi.fn(),
+  getSmartFilters: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  addSmartFilter: vi.fn(),
+  updateSmartFilter: vi.fn(),
+  removeSmartFilter: vi.fn(),
+}));
+
+vi.mock("@/core/sync/sync-service", () => ({
+  pushVault: vi.fn(),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+function feed(id: string, title: string): Feed {
+  return {
+    id,
+    url: `https://${id}.example.com/feed.xml`,
+    title,
+    description: "",
+    siteUrl: "",
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function folder(id: string, name: string): Folder {
+  return { id, name, createdAt: 0 };
+}
+
+function smartFilter(id: string, name: string): SmartFilter {
+  return {
+    id,
+    name,
+    rule: { kind: "group", match: "all", children: [] },
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("SettingsPill", () => {
+  let openFeedSettings: ReturnType<typeof vi.fn>;
+  let openFolderSettings: ReturnType<typeof vi.fn>;
+  let openEditor: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    openFeedSettings = vi.fn();
+    openFolderSettings = vi.fn();
+    openEditor = vi.fn();
+    useFeedStore.setState({
+      feeds: [feed("f-tech", "Tech Crunchies")],
+      folders: [folder("folder-tech", "Tech")],
+      selectedFeedId: null,
+      openFeedSettings,
+      openFolderSettings,
+    });
+    useSmartFilterStore.setState({
+      filters: [smartFilter("filter-recent", "Recent")],
+      openEditor,
+    });
+  });
+
+  it("hides on ALL_FEEDS view", () => {
+    useFeedStore.setState({ selectedFeedId: ALL_FEEDS_ID });
+    const { container } = render(<SettingsPill />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("hides on STARRED view", () => {
+    useFeedStore.setState({ selectedFeedId: STARRED_FEED_ID });
+    const { container } = render(<SettingsPill />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("hides when no feed is selected", () => {
+    useFeedStore.setState({ selectedFeedId: null });
+    const { container } = render(<SettingsPill />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("on a single feed, clicking opens the feed settings dialog", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ selectedFeedId: "f-tech" });
+    render(<SettingsPill />);
+    await user.click(screen.getByTestId("settings-pill"));
+    expect(openFeedSettings).toHaveBeenCalledWith("f-tech");
+  });
+
+  it("on a folder view, clicking opens the folder settings dialog with that folder id", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ selectedFeedId: toFolderFeedId("folder-tech") });
+    render(<SettingsPill />);
+    await user.click(screen.getByTestId("settings-pill"));
+    expect(openFolderSettings).toHaveBeenCalledWith("folder-tech");
+  });
+
+  it("on a smart filter view, clicking opens the smart-filter editor with that filter", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      selectedFeedId: toFilterFeedId("filter-recent"),
+    });
+    render(<SettingsPill />);
+    await user.click(screen.getByTestId("settings-pill"));
+    expect(openEditor).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "filter-recent" }),
+    );
+  });
+
+  it("the label adapts to the context (Feed settings / Folder / Filter)", () => {
+    useFeedStore.setState({ selectedFeedId: "f-tech" });
+    const { rerender } = render(<SettingsPill />);
+    expect(screen.getByText(/feed settings/i)).toBeInTheDocument();
+
+    useFeedStore.setState({ selectedFeedId: toFolderFeedId("folder-tech") });
+    rerender(<SettingsPill />);
+    expect(screen.getByText(/folder settings/i)).toBeInTheDocument();
+
+    useFeedStore.setState({
+      selectedFeedId: toFilterFeedId("filter-recent"),
+    });
+    rerender(<SettingsPill />);
+    expect(screen.getByText(/edit filter/i)).toBeInTheDocument();
+  });
+
+  it("hides on a folder view whose folder no longer exists (defensive)", () => {
+    useFeedStore.setState({
+      selectedFeedId: toFolderFeedId("folder-ghost"),
+      folders: [],
+    });
+    const { container } = render(<SettingsPill />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("hides on a smart-filter view whose filter no longer exists (defensive)", () => {
+    useFeedStore.setState({
+      selectedFeedId: toFilterFeedId("filter-ghost"),
+    });
+    useSmartFilterStore.setState({ filters: [] });
+    const { container } = render(<SettingsPill />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/tests/components/articles/sort-pill.test.tsx
+++ b/tests/components/articles/sort-pill.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * SortPill — the article-sort control rebuilt on ExpandingPill.
+ * Replaces the previous SortMenu (text+icon button). Same modes,
+ * same handler, new visual.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SortPill } from "@/components/articles/sort-pill.tsx";
+import type { ArticleSortMode } from "@/types/index.ts";
+
+describe("SortPill", () => {
+  let onChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onChange = vi.fn();
+  });
+
+  function renderPill(mode: ArticleSortMode = "newest") {
+    return render(<SortPill mode={mode} onChange={onChange} />);
+  }
+
+  it("shows the current mode label", () => {
+    renderPill("unread-first");
+    expect(screen.getByText("Unread first")).toBeInTheDocument();
+  });
+
+  it("opens a menu with every sort mode when clicked", async () => {
+    const user = userEvent.setup();
+    renderPill("newest");
+    await user.click(screen.getByRole("button", { name: /sort/i }));
+    expect(
+      await screen.findByRole("menuitem", { name: /newest first/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /oldest first/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /unread first/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange with the chosen mode", async () => {
+    const user = userEvent.setup();
+    renderPill("newest");
+    await user.click(screen.getByRole("button", { name: /sort/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /unread first/i }),
+    );
+    expect(onChange).toHaveBeenCalledWith("unread-first");
+  });
+
+  it("aria-label describes the current sort mode for screen readers", () => {
+    renderPill("oldest");
+    const btn = screen.getByRole("button", { name: /sort.*oldest first/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("forwards data-testid for downstream queries", () => {
+    render(<SortPill mode="newest" onChange={onChange} dataTestId="sort-pill" />);
+    expect(screen.getByTestId("sort-pill")).toBeInTheDocument();
+  });
+});

--- a/tests/components/feeds/app-sidebar-states.test.tsx
+++ b/tests/components/feeds/app-sidebar-states.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import userEvent from "@testing-library/user-event";
 import { AppSidebar } from "@/components/layout/app-sidebar.tsx";
 import { SidebarProvider } from "@/components/ui/sidebar.tsx";
 import { useFeedStore } from "@/stores/feed-store.ts";
@@ -76,55 +75,19 @@ describe("AppSidebar states", () => {
   });
 
 
-  it("delete triggers confirmation dialog", async () => {
-    const user = userEvent.setup();
+  // Delete-confirmation flow used to live in the sidebar (dropdown
+  // → AlertDialog mounted by sidebar-feed-list). It moved to
+  // FeedSettingsDialog when the per-feed dropdown was removed. The
+  // sidebar no longer renders a More button or any confirmation
+  // dialog of its own — both responsibilities now live behind the
+  // floating cog above the article list. Coverage moves to
+  // tests/components/feeds/feed-settings-dialog.test.tsx.
+  it("sidebar no longer renders a per-feed More dropdown trigger", () => {
     useFeedStore.setState({
       feeds: [mockFeed("a", "Alpha Feed")],
     });
     renderSidebar();
-
-    // Open the dropdown menu for the feed
-    const moreButton = screen.getByRole("button", { name: "More" });
-    await user.click(moreButton);
-
-    // Click Delete in dropdown
-    const deleteItem = screen.getByRole("menuitem", { name: /delete/i });
-    await user.click(deleteItem);
-
-    // Confirmation dialog should appear
-    expect(screen.getByText(/Remove.*Alpha Feed/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
-  });
-
-  it("cancel delete closes dialog", async () => {
-    const user = userEvent.setup();
-    useFeedStore.setState({
-      feeds: [mockFeed("a", "Alpha Feed")],
-    });
-    renderSidebar();
-
-    await user.click(screen.getByRole("button", { name: "More" }));
-    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
-
-    expect(screen.queryByText(/Remove.*Alpha Feed/)).not.toBeInTheDocument();
-  });
-
-  it("confirm delete calls removeFeed", async () => {
-    const user = userEvent.setup();
-    const removeFeed = vi.fn();
-    useFeedStore.setState({
-      feeds: [mockFeed("a", "Alpha Feed")],
-      removeFeed,
-    });
-    renderSidebar();
-
-    await user.click(screen.getByRole("button", { name: "More" }));
-    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
-    await user.click(screen.getByRole("button", { name: "Remove" }));
-
-    expect(removeFeed).toHaveBeenCalledWith("a");
+    expect(screen.queryByRole("button", { name: "More" })).toBeNull();
   });
 
   it("active feed has accent background (sidebar defaults)", () => {

--- a/tests/components/feeds/feed-settings-dialog.test.tsx
+++ b/tests/components/feeds/feed-settings-dialog.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * FeedSettingsDialog — the unified per-feed settings surface, opened
+ * by the floating cog pill above the article list. Replaces the
+ * scattered three-dot dropdown entries on every sidebar feed row.
+ *
+ * Coverage focus: dialog opens against the right feed; each section
+ * writes through to the right store action; destructive actions
+ * confirm.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { FeedSettingsDialog } from "@/components/feeds/feed-settings-dialog.tsx";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import type { Feed, Folder } from "@/types/index.ts";
+
+vi.mock("@/core/storage/db.ts", () => ({
+  getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getFeed: vi.fn(),
+  updateFeed: vi.fn(),
+  addFolder: vi.fn(),
+  getFolders: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  updateFolder: vi.fn(),
+  removeFolder: vi.fn(),
+  removeFeed: vi.fn(),
+}));
+
+vi.mock("@/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn(),
+  reloadFeed: vi.fn(),
+}));
+
+vi.mock("@/core/extractor/prefetch-service.ts", () => ({
+  prefetchStarredArticles: vi.fn(),
+  prefetchFeedArticles: vi.fn(),
+  selectFrequentFeeds: vi.fn(() => []),
+}));
+
+vi.mock("@/core/sync/sync-service", () => ({
+  pushVault: vi.fn(),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+function feed(overrides: Partial<Feed> = {}): Feed {
+  return {
+    id: "f-tech",
+    url: "https://example.com/feed.xml",
+    title: "Tech Crunchies",
+    description: "",
+    siteUrl: "https://example.com",
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function folder(id: string, name: string): Folder {
+  return { id, name, createdAt: 0 };
+}
+
+function renderDialog() {
+  return render(
+    <MemoryRouter>
+      <FeedSettingsDialog />
+    </MemoryRouter>,
+  );
+}
+
+describe("FeedSettingsDialog", () => {
+  let renameFeed: ReturnType<typeof vi.fn>;
+  let setFeedPreferFullText: ReturnType<typeof vi.fn>;
+  let setFeedPrefetchEnabled: ReturnType<typeof vi.fn>;
+  let moveFeedToFolder: ReturnType<typeof vi.fn>;
+  let refreshSingleFeed: ReturnType<typeof vi.fn>;
+  let reloadSingleFeed: ReturnType<typeof vi.fn>;
+  let removeFeed: ReturnType<typeof vi.fn>;
+  let openRulesEditor: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    renameFeed = vi.fn().mockResolvedValue(undefined);
+    setFeedPreferFullText = vi.fn().mockResolvedValue(undefined);
+    setFeedPrefetchEnabled = vi.fn().mockResolvedValue(undefined);
+    moveFeedToFolder = vi.fn().mockResolvedValue(undefined);
+    refreshSingleFeed = vi.fn().mockResolvedValue(undefined);
+    reloadSingleFeed = vi.fn().mockResolvedValue(undefined);
+    removeFeed = vi.fn().mockResolvedValue(undefined);
+    openRulesEditor = vi.fn();
+
+    useFeedStore.setState({
+      feeds: [feed()],
+      folders: [],
+      feedSettingsDialogId: null,
+      renameFeed,
+      setFeedPreferFullText,
+      setFeedPrefetchEnabled,
+      moveFeedToFolder,
+      refreshSingleFeed,
+      reloadSingleFeed,
+      removeFeed,
+      openRulesEditor,
+    });
+  });
+
+  it("does not render when feedSettingsDialogId is null", () => {
+    renderDialog();
+    expect(screen.queryByTestId("feed-settings-dialog")).toBeNull();
+  });
+
+  it("opens with the target feed's title in the header", () => {
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+    expect(screen.getByTestId("feed-settings-dialog")).toBeInTheDocument();
+    expect(screen.getByText(/Tech Crunchies/)).toBeInTheDocument();
+  });
+
+  it("Name field saves via renameFeed when Save is clicked", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+
+    const input = screen.getByTestId("feed-settings-name-input");
+    await user.clear(input);
+    await user.type(input, "Tech (renamed)");
+    await user.click(screen.getByTestId("feed-settings-name-save"));
+
+    expect(renameFeed).toHaveBeenCalledWith("f-tech", "Tech (renamed)");
+  });
+
+  it("Prefer full text switch reflects feed state and toggles via setFeedPreferFullText", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [feed({ preferFullText: true })],
+      feedSettingsDialogId: "f-tech",
+    });
+    renderDialog();
+
+    const switchEl = screen.getByTestId("feed-settings-prefer-full-text");
+    expect(switchEl).toHaveAttribute("data-state", "checked");
+
+    await user.click(switchEl);
+    expect(setFeedPreferFullText).toHaveBeenCalledWith("f-tech", false);
+  });
+
+  it("Prefetch full text switch reflects feed state and toggles via setFeedPrefetchEnabled", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [feed({ prefetchEnabled: false })],
+      feedSettingsDialogId: "f-tech",
+    });
+    renderDialog();
+
+    const switchEl = screen.getByTestId("feed-settings-prefetch");
+    expect(switchEl).toHaveAttribute("data-state", "unchecked");
+
+    await user.click(switchEl);
+    expect(setFeedPrefetchEnabled).toHaveBeenCalledWith("f-tech", true);
+  });
+
+  it("Folder picker calls moveFeedToFolder with the selected folder id", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [feed({ folderId: undefined })],
+      folders: [folder("folder-tech", "Tech"), folder("folder-news", "News")],
+      feedSettingsDialogId: "f-tech",
+    });
+    renderDialog();
+
+    const select = screen.getByTestId("feed-settings-folder");
+    await user.selectOptions(select, "folder-tech");
+    expect(moveFeedToFolder).toHaveBeenCalledWith("f-tech", "folder-tech");
+  });
+
+  it("Folder picker can move to Unfiled (null)", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [feed({ folderId: "folder-tech" })],
+      folders: [folder("folder-tech", "Tech")],
+      feedSettingsDialogId: "f-tech",
+    });
+    renderDialog();
+
+    const select = screen.getByTestId("feed-settings-folder");
+    await user.selectOptions(select, "");
+    expect(moveFeedToFolder).toHaveBeenCalledWith("f-tech", null);
+  });
+
+  it("Manage rules button calls openRulesEditor with the feed id", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+
+    await user.click(screen.getByTestId("feed-settings-manage-rules"));
+    expect(openRulesEditor).toHaveBeenCalledWith("f-tech");
+  });
+
+  it("Refresh button calls refreshSingleFeed", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+    await user.click(screen.getByTestId("feed-settings-refresh"));
+    expect(refreshSingleFeed).toHaveBeenCalledWith("f-tech");
+  });
+
+  it("Clear cached articles button calls reloadSingleFeed", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+    await user.click(screen.getByTestId("feed-settings-clear-cache"));
+    expect(reloadSingleFeed).toHaveBeenCalledWith("f-tech");
+  });
+
+  it("Delete button shows a confirmation, then calls removeFeed when confirmed", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+
+    await user.click(screen.getByTestId("feed-settings-delete"));
+    // AlertDialog renders the confirm in a portal
+    const confirm = await screen.findByTestId("feed-settings-delete-confirm");
+    await user.click(confirm);
+
+    expect(removeFeed).toHaveBeenCalledWith("f-tech");
+  });
+
+  it("Delete confirmation can be cancelled (removeFeed not called)", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+
+    await user.click(screen.getByTestId("feed-settings-delete"));
+    const cancel = await screen.findByTestId("feed-settings-delete-cancel");
+    await user.click(cancel);
+
+    expect(removeFeed).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/folders/folder-settings-dialog.test.tsx
+++ b/tests/components/folders/folder-settings-dialog.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * FolderSettingsDialog — opened by the floating cog when the user is
+ * inside a folder view. Replaces the folder's sidebar three-dot
+ * dropdown (rename + color + delete).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { FolderSettingsDialog } from "@/components/folders/folder-settings-dialog.tsx";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import type { Folder } from "@/types/index.ts";
+
+vi.mock("@/core/storage/db.ts", () => ({
+  getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getFeed: vi.fn(),
+  updateFeed: vi.fn(),
+  addFolder: vi.fn(),
+  getFolders: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  updateFolder: vi.fn(),
+  removeFolder: vi.fn(),
+  removeFeed: vi.fn(),
+}));
+
+vi.mock("@/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn(),
+  reloadFeed: vi.fn(),
+}));
+
+vi.mock("@/core/extractor/prefetch-service.ts", () => ({
+  prefetchStarredArticles: vi.fn(),
+  prefetchFeedArticles: vi.fn(),
+  selectFrequentFeeds: vi.fn(() => []),
+}));
+
+vi.mock("@/core/sync/sync-service", () => ({
+  pushVault: vi.fn(),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+function folder(overrides: Partial<Folder> = {}): Folder {
+  return {
+    id: "folder-tech",
+    name: "Tech",
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+function renderDialog() {
+  return render(
+    <MemoryRouter>
+      <FolderSettingsDialog />
+    </MemoryRouter>,
+  );
+}
+
+describe("FolderSettingsDialog", () => {
+  let renameFolder: ReturnType<typeof vi.fn>;
+  let updateFolderColor: ReturnType<typeof vi.fn>;
+  let deleteFolder: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    renameFolder = vi.fn().mockResolvedValue(undefined);
+    updateFolderColor = vi.fn().mockResolvedValue(undefined);
+    deleteFolder = vi.fn().mockResolvedValue(undefined);
+
+    useFeedStore.setState({
+      folders: [folder()],
+      folderSettingsDialogId: null,
+      renameFolder,
+      updateFolderColor,
+      deleteFolder,
+    });
+  });
+
+  it("does not render when folderSettingsDialogId is null", () => {
+    renderDialog();
+    expect(screen.queryByTestId("folder-settings-dialog")).toBeNull();
+  });
+
+  it("opens with the target folder's name in the header", () => {
+    useFeedStore.setState({ folderSettingsDialogId: "folder-tech" });
+    renderDialog();
+    expect(screen.getByTestId("folder-settings-dialog")).toBeInTheDocument();
+    expect(screen.getByText(/Tech/)).toBeInTheDocument();
+  });
+
+  it("Name field saves via renameFolder when Save is clicked", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ folderSettingsDialogId: "folder-tech" });
+    renderDialog();
+
+    const input = screen.getByTestId("folder-settings-name-input");
+    await user.clear(input);
+    await user.type(input, "Engineering");
+    await user.click(screen.getByTestId("folder-settings-name-save"));
+
+    expect(renameFolder).toHaveBeenCalledWith("folder-tech", "Engineering");
+  });
+
+  it("color picker renders one swatch per folder color", () => {
+    useFeedStore.setState({ folderSettingsDialogId: "folder-tech" });
+    renderDialog();
+    const picker = screen.getByTestId("folder-color-picker");
+    const swatches = picker.querySelectorAll("button");
+    expect(swatches.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("selecting a color writes through updateFolderColor", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ folderSettingsDialogId: "folder-tech" });
+    renderDialog();
+
+    const violet = screen.getByLabelText(/Set folder color #7c3aed/i);
+    await user.click(violet);
+
+    expect(updateFolderColor).toHaveBeenCalledWith(
+      "folder-tech",
+      "#7c3aed",
+    );
+  });
+
+  it("clicking the current color clears it (toggle off)", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      folders: [folder({ color: "#7c3aed" })],
+      folderSettingsDialogId: "folder-tech",
+    });
+    renderDialog();
+
+    const violet = screen.getByLabelText(/Set folder color #7c3aed/i);
+    await user.click(violet);
+
+    expect(updateFolderColor).toHaveBeenCalledWith("folder-tech", undefined);
+  });
+
+  it("Delete button shows a confirmation, then calls deleteFolder when confirmed", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ folderSettingsDialogId: "folder-tech" });
+    renderDialog();
+
+    await user.click(screen.getByTestId("folder-settings-delete"));
+    const confirm = await screen.findByTestId(
+      "folder-settings-delete-confirm",
+    );
+    await user.click(confirm);
+
+    expect(deleteFolder).toHaveBeenCalledWith("folder-tech");
+  });
+
+  it("Delete confirmation can be cancelled", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ folderSettingsDialogId: "folder-tech" });
+    renderDialog();
+
+    await user.click(screen.getByTestId("folder-settings-delete"));
+    const cancel = await screen.findByTestId(
+      "folder-settings-delete-cancel",
+    );
+    await user.click(cancel);
+
+    expect(deleteFolder).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/sidebar/feed-item.test.tsx
+++ b/tests/components/sidebar/feed-item.test.tsx
@@ -13,8 +13,6 @@ function renderFeedItem(props: Partial<React.ComponentProps<typeof FeedItem>> = 
         feed={mockFeed}
         isSelected={false}
         onSelect={vi.fn()}
-        onRemove={vi.fn()}
-        onReload={vi.fn()}
         {...props}
       />
     </SidebarProvider>
@@ -61,18 +59,30 @@ function articleFixture(id: string, read: boolean, feedId = "f1") {
   };
 }
 
+/**
+ * FeedItem is now select-only — its dropdown was removed in favour
+ * of the floating cog above the article list, which dispatches to
+ * FeedSettingsDialog. Tests below verify the row's remaining
+ * responsibilities: title + favicon + unread badge derivation +
+ * click-to-select + drag-handle attachment.
+ *
+ * Per-feed configuration (rename / prefer / prefetch / rules /
+ * refresh / delete) is covered in:
+ *  - tests/components/feeds/feed-settings-dialog.test.tsx
+ *  - tests/components/articles/settings-pill.test.tsx
+ */
 describe("FeedItem", () => {
   beforeEach(() => {
     useArticleStore.setState({ articlesByFeedId: {}, articles: [] });
     useFeedStore.setState({ feeds: [mockFeed], folders: [], selectedFeedId: null });
   });
 
+  it("renders the feed title", () => {
+    renderFeedItem();
+    expect(screen.getByText("Example Feed")).toBeInTheDocument();
+  });
+
   it("derives unread count from articlesByFeedId, not a stored counter", () => {
-    // This is the architectural invariant: there is a single source of
-    // truth for unread-ness (the article set), and the badge reads it.
-    // Proving this at the component level prevents the regression class
-    // where a writer mutates the source and forgets to update a separate
-    // counter field.
     useArticleStore.setState({
       articlesByFeedId: {
         f1: [
@@ -84,11 +94,6 @@ describe("FeedItem", () => {
     });
     renderFeedItem();
     expect(screen.getByText("2")).toBeInTheDocument();
-  });
-
-  it("renders the feed title", () => {
-    renderFeedItem();
-    expect(screen.getByText("Example Feed")).toBeInTheDocument();
   });
 
   it("shows unread badge when count > 0", () => {
@@ -111,28 +116,7 @@ describe("FeedItem", () => {
     expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 
-  it.skip("enters rename mode and saves on Enter — Radix dropdown portal issue in happy-dom", async () => {
-    const user = userEvent.setup();
-    const renameFeed = vi.fn();
-    useFeedStore.setState({ renameFeed });
-
-    renderFeedItem();
-
-    await user.click(screen.getByRole("button", { name: /more/i }));
-    await user.click(screen.getByText("Rename"));
-
-    // Input should appear with current title
-    const input = document.querySelector("input");
-    expect(input).not.toBeNull();
-    expect(input!.value).toBe("Example Feed");
-
-    await user.clear(input!);
-    await user.type(input!, "New Name{Enter}");
-
-    expect(renameFeed).toHaveBeenCalledWith("f1", "New Name");
-  });
-
-  it("unfiled feed renders unread count as SidebarMenuBadge that swaps with the action dots", () => {
+  it("renders unread count as SidebarMenuBadge (single-source-of-truth, not inline span)", () => {
     useArticleStore.setState({
       articlesByFeedId: {
         f1: Array.from({ length: 5 }, (_, i) => articleFixture(`a${i}`, false)),
@@ -141,27 +125,19 @@ describe("FeedItem", () => {
     renderFeedItem();
     const badge = screen.getByText("5").closest("[data-sidebar='menu-badge']");
     expect(badge).not.toBeNull();
-    // Badge should hide on group hover (when action dots appear)
-    expect(badge!.className).toContain("group-hover/menu-item:opacity-0");
-    // Badge should also hide when dropdown menu is open (data-state=open)
-    expect(badge!.className).toContain("group-has-[[data-state=open]]/menu-item:opacity-0");
   });
 
-  it("in-folder feed renders unread count as SidebarMenuBadge with identical swap behavior", () => {
+  it("in-folder feed renders the same badge component (consistency across contexts)", () => {
     useArticleStore.setState({
       articlesByFeedId: {
         f1: Array.from({ length: 5 }, (_, i) => articleFixture(`a${i}`, false)),
       },
     });
     renderFeedItem({ inFolder: true });
-    // Badge should use the shadcn SidebarMenuBadge, not an inline span inside the button
     const feedButton = screen.getByText("Example Feed").closest("[data-sidebar='menu-button']");
     expect(feedButton!.textContent).not.toContain("5");
     const badge = screen.getByText("5").closest("[data-sidebar='menu-badge']");
     expect(badge).not.toBeNull();
-    // Same swap behavior as unfiled feeds — consistency across both contexts.
-    expect(badge!.className).toContain("group-hover/menu-item:opacity-0");
-    expect(badge!.className).toContain("group-has-[[data-state=open]]/menu-item:opacity-0");
   });
 
   it("calls onSelect when clicked", async () => {
@@ -172,11 +148,7 @@ describe("FeedItem", () => {
     expect(onSelect).toHaveBeenCalled();
   });
 
-  it("unread badge is hidden on mobile (max-md:hidden) to avoid simultaneous badge + action dots", () => {
-    // On mobile, SidebarMenuAction showOnHover defaults to visible (md:opacity-0 only
-    // applies ≥768px). Without hiding the badge on mobile, both the count and the
-    // three-dots trigger are permanently visible at the same time. Since the badge
-    // is informational and the action is interactive, we hide the badge on mobile.
+  it("unread badge is hidden on mobile (max-md:hidden) to keep the row compact", () => {
     useArticleStore.setState({
       articlesByFeedId: {
         f1: Array.from({ length: 3 }, (_, i) => articleFixture(`a${i}`, false)),
@@ -188,71 +160,8 @@ describe("FeedItem", () => {
     expect(badge!.className).toContain("max-md:hidden");
   });
 
-  it("dropdown shows a 'Prefer full text' toggle that calls setFeedPreferFullText", async () => {
-    const setFeedPreferFullText = vi.fn().mockResolvedValue(undefined);
-    useFeedStore.setState({ setFeedPreferFullText });
-    const user = userEvent.setup();
+  it("no longer renders any three-dot dropdown trigger (cog at top of article list owns settings now)", () => {
     renderFeedItem();
-    await user.click(screen.getByRole("button", { name: /more/i }));
-    const item = await screen.findByRole("menuitem", { name: /prefer full text/i });
-    await user.click(item);
-    expect(setFeedPreferFullText).toHaveBeenCalledWith("f1", true);
-  });
-
-  it("Prefer full text menu item shows a check when the feed already opts in", async () => {
-    const user = userEvent.setup();
-    renderFeedItem({ feed: { ...mockFeed, preferFullText: true } });
-    await user.click(screen.getByRole("button", { name: /more/i }));
-    const item = await screen.findByRole("menuitem", { name: /prefer full text/i });
-    // The Check icon is opacity-100 when on, opacity-0 when off.
-    const icon = item.querySelector("svg");
-    expect(icon?.getAttribute("class") ?? "").toContain("opacity-100");
-  });
-
-  it("dropdown shows a 'Prefetch full text' toggle that calls setFeedPrefetchEnabled", async () => {
-    const setFeedPrefetchEnabled = vi.fn().mockResolvedValue(undefined);
-    useFeedStore.setState({ setFeedPrefetchEnabled });
-    const user = userEvent.setup();
-    renderFeedItem();
-    await user.click(screen.getByRole("button", { name: /more/i }));
-    const item = await screen.findByRole("menuitem", { name: /prefetch full text/i });
-    await user.click(item);
-    expect(setFeedPrefetchEnabled).toHaveBeenCalledWith("f1", true);
-  });
-
-  it("Prefetch full text menu item shows a check when the feed is opted in", async () => {
-    const user = userEvent.setup();
-    renderFeedItem({ feed: { ...mockFeed, prefetchEnabled: true } });
-    await user.click(screen.getByRole("button", { name: /more/i }));
-    const item = await screen.findByRole("menuitem", { name: /prefetch full text/i });
-    const icon = item.querySelector("svg");
-    expect(icon?.getAttribute("class") ?? "").toContain("opacity-100");
-  });
-
-  it("action dots do not appear on click-focus, only on hover or keyboard focus-visible", () => {
-    // Bug: clicking a feed puts the button into :focus state (click focus).
-    // The shadcn SidebarMenuAction's showOnHover variant used
-    // `group-focus-within/menu-item:opacity-100`, which matches ANY focus —
-    // including click focus — so after clicking the action dots became
-    // visible alongside the unread badge, overlapping it.
-    //
-    // The fix is to use `group-has-[:focus-visible]` instead, which only
-    // matches when the focused element has :focus-visible (keyboard focus,
-    // not mouse click). This test enforces the class substitution at the
-    // source, so a regression in the shadcn wrapper is caught immediately.
-    useArticleStore.setState({
-      articlesByFeedId: {
-        f1: Array.from({ length: 5 }, (_, i) => articleFixture(`a${i}`, false)),
-      },
-    });
-    const { container } = renderFeedItem({ isSelected: true });
-    const action = container.querySelector("[data-sidebar='menu-action']");
-    expect(action).not.toBeNull();
-    // Negative: must not reveal the action on any focus (including click).
-    expect(action!.className).not.toContain(
-      "group-focus-within/menu-item:opacity-100",
-    );
-    // Positive: hover-based reveal must still work.
-    expect(action!.className).toContain("group-hover/menu-item:opacity-100");
+    expect(screen.queryByRole("button", { name: /more/i })).toBeNull();
   });
 });

--- a/tests/components/sidebar/folder-item.test.tsx
+++ b/tests/components/sidebar/folder-item.test.tsx
@@ -84,8 +84,6 @@ function renderFolderWithFeed(folderProps: Partial<React.ComponentProps<typeof F
             isSelected={false}
             inFolder
             onSelect={vi.fn()}
-            onRemove={vi.fn()}
-            onReload={vi.fn()}
           />
         </FolderItem>
       </ul>
@@ -214,11 +212,15 @@ describe("FolderItem", () => {
     expect(badge!.textContent).toContain("24");
   });
 
-  it("shows settings action on feeds inside folders", () => {
+  it("the folder row has its own settings affordance (More menu) — feeds inside are select-only", () => {
+    // FeedItem's dropdown was removed in favour of the floating cog
+    // above the article list. The folder's own dropdown still
+    // exists in this commit (removed in a later commit).
     renderFolderWithFeed();
-    // There should be at least 2 "More" buttons: one for the folder, one for the feed
-    const moreButtons = screen.getAllByRole("button", { name: /more|folder options/i });
-    expect(moreButtons.length).toBeGreaterThanOrEqual(2);
+    const moreButtons = screen.getAllByRole("button", {
+      name: /more|folder options/i,
+    });
+    expect(moreButtons.length).toBeGreaterThanOrEqual(1);
   });
 
   it("folder's root element is a <li> so it nests validly under SidebarMenu's <ul>", () => {

--- a/tests/components/sidebar/folder-item.test.tsx
+++ b/tests/components/sidebar/folder-item.test.tsx
@@ -55,7 +55,7 @@ function renderFolder(props: Partial<React.ComponentProps<typeof FolderItem>> = 
     <SidebarProvider>
       <FolderItem
         folder={mockFolder}
-        onDelete={vi.fn()}
+        
         isSelected={false}
         onSelect={vi.fn()}
         {...props}
@@ -74,7 +74,7 @@ function renderFolderWithFeed(folderProps: Partial<React.ComponentProps<typeof F
       <ul data-testid="folder-parent-list">
         <FolderItem
           folder={mockFolder}
-          onDelete={vi.fn()}
+          
           isSelected={false}
           onSelect={vi.fn()}
           {...folderProps}
@@ -150,7 +150,7 @@ describe("FolderItem", () => {
     const coloredFolder = { ...mockFolder, color: "#7c3aed" };
     render(
       <SidebarProvider>
-        <FolderItem folder={coloredFolder} onDelete={vi.fn()} isSelected={false} onSelect={vi.fn()}>
+        <FolderItem folder={coloredFolder}  isSelected={false} onSelect={vi.fn()}>
           <div />
         </FolderItem>
       </SidebarProvider>
@@ -212,15 +212,12 @@ describe("FolderItem", () => {
     expect(badge!.textContent).toContain("24");
   });
 
-  it("the folder row has its own settings affordance (More menu) — feeds inside are select-only", () => {
-    // FeedItem's dropdown was removed in favour of the floating cog
-    // above the article list. The folder's own dropdown still
-    // exists in this commit (removed in a later commit).
+  it("renders neither a folder dropdown nor a per-feed dropdown — cog above article list owns settings", () => {
     renderFolderWithFeed();
-    const moreButtons = screen.getAllByRole("button", {
+    const moreButtons = screen.queryAllByRole("button", {
       name: /more|folder options/i,
     });
-    expect(moreButtons.length).toBeGreaterThanOrEqual(1);
+    expect(moreButtons.length).toBe(0);
   });
 
   it("folder's root element is a <li> so it nests validly under SidebarMenu's <ul>", () => {
@@ -244,7 +241,7 @@ describe("FolderItem", () => {
       const coloredFolder = { ...mockFolder, color: "#7c3aed" };
       render(
         <SidebarProvider>
-          <FolderItem folder={coloredFolder} onDelete={vi.fn()} isSelected={false} onSelect={vi.fn()}>
+          <FolderItem folder={coloredFolder}  isSelected={false} onSelect={vi.fn()}>
             <div />
           </FolderItem>
         </SidebarProvider>
@@ -258,7 +255,7 @@ describe("FolderItem", () => {
       const coloredFolder = { ...mockFolder, color: "#7c3aed" };
       render(
         <SidebarProvider>
-          <FolderItem folder={coloredFolder} onDelete={vi.fn()} isSelected={false} onSelect={vi.fn()}>
+          <FolderItem folder={coloredFolder}  isSelected={false} onSelect={vi.fn()}>
             <div />
           </FolderItem>
         </SidebarProvider>
@@ -268,22 +265,12 @@ describe("FolderItem", () => {
       expect(style).toContain("color");
     });
 
-    it("shows a color picker option in the dropdown", async () => {
-      const user = userEvent.setup();
-      renderFolder();
-      const moreBtn = screen.getByRole("button", { name: /folder options/i });
-      await user.click(moreBtn);
-      expect(screen.getByTestId("folder-color-picker")).toBeInTheDocument();
-    });
+    // The color picker lived in the dropdown; it now lives in
+    // FolderSettingsDialog. Coverage moves to that test file.
   });
 
-  it("feed inside folder is not a DOM descendant of folder's menu-item (hover scope isolation)", () => {
+  it("folder header and feed rows live in distinct menu-items (DOM structure invariant)", () => {
     renderFolderWithFeed();
-    // If the feed <li data-sidebar='menu-item'> is nested inside the folder's
-    // <li data-sidebar='menu-item'>, CSS `group-hover/menu-item` leaks: hovering
-    // the child feed also triggers hover on the folder's group, making the
-    // folder's action dots appear at the same time. Each menu-item must own
-    // its own hover scope.
     const folderMenuItem = screen
       .getByText("Tech News")
       .closest("[data-sidebar='menu-item']");

--- a/tests/components/sidebar/sidebar-feed-list.test.tsx
+++ b/tests/components/sidebar/sidebar-feed-list.test.tsx
@@ -260,23 +260,19 @@ describe("SidebarFeedList", () => {
     });
 
     /**
-     * Invariant 3: every feed's unread badge uses the same swap-on-hover
-     * classes (shadcn SidebarMenuBadge), so action dots replace the badge
-     * consistently for both unfiled and in-folder feeds.
+     * Invariant 3: every feed has exactly one unread badge rendered
+     * with the shadcn SidebarMenuBadge component. The "swap on hover"
+     * behaviour was tied to the now-removed per-feed dropdown — the
+     * cog above the article list owns settings now, so badges no
+     * longer need to vanish on hover.
      */
-    it("every feed's badge is a SidebarMenuBadge with hover-swap classes", () => {
+    it("every feed renders exactly one SidebarMenuBadge", () => {
       renderList();
       const badges = document.querySelectorAll(
         "[data-sidebar='menu-badge']",
       );
       // Four feeds, four badges.
       expect(badges.length).toBe(4);
-      for (const badge of Array.from(badges)) {
-        expect(badge.className).toContain("group-hover/menu-item:opacity-0");
-        expect(badge.className).toContain(
-          "group-has-[[data-state=open]]/menu-item:opacity-0",
-        );
-      }
     });
   });
 

--- a/tests/components/ui/expanding-pill.test.tsx
+++ b/tests/components/ui/expanding-pill.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * ExpandingPill — circle-to-pill primitive. Default state shows the
+ * icon only at a circular size; hover (desktop) or always-on (mobile)
+ * expands a label slot horizontally via CSS max-width animation.
+ *
+ * Behaviour tests focus on:
+ *  - The label is present in the DOM but visually constrained when collapsed
+ *    (so assistive tech can still read it, and CSS transitions have a target)
+ *  - aria-label is forwarded for screen-reader fallback
+ *  - onClick fires regardless of expansion state
+ *  - The component renders as a button by default (keyboard accessible)
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Settings as SettingsIcon } from "lucide-react";
+import { ExpandingPill } from "@/components/ui/expanding-pill.tsx";
+
+describe("ExpandingPill", () => {
+  it("renders as a button element with the supplied aria-label", () => {
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        aria-label="Open feed settings"
+        onClick={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Open feed settings" });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("renders the label text in the DOM (for hover-expand + a11y)", () => {
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Feed settings")).toBeInTheDocument();
+  });
+
+  it("fires onClick when activated", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        aria-label="Open feed settings"
+        onClick={onClick}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Open feed settings" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports keyboard activation (Enter)", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        aria-label="Open feed settings"
+        onClick={onClick}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Open feed settings" });
+    btn.focus();
+    await user.keyboard("{Enter}");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapsed state: label slot has max-w-0 + overflow-hidden so the icon-only width is the default", () => {
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        onClick={vi.fn()}
+      />,
+    );
+    const label = screen.getByText("Feed settings");
+    expect(label.className).toMatch(/max-w-0/);
+    expect(label.className).toMatch(/overflow-hidden/);
+  });
+
+  it("expand-on-hover: label uses group-hover:max-w- to reveal on parent hover", () => {
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        onClick={vi.fn()}
+      />,
+    );
+    const label = screen.getByText("Feed settings");
+    // Group + group-hover:max-w-* is the desktop expand pattern. Don't
+    // pin the exact width — just confirm the mechanism is wired.
+    expect(label.className).toMatch(/group-hover:max-w-/);
+    expect(label.className).toMatch(/group-focus-visible:max-w-/);
+  });
+
+  it("when alwaysExpanded is true, the label has no max-w-0 constraint (mobile-always-visible mode)", () => {
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        alwaysExpanded
+        onClick={vi.fn()}
+      />,
+    );
+    const label = screen.getByText("Feed settings");
+    expect(label.className).not.toMatch(/max-w-0/);
+  });
+
+  it("forwards a data-testid for downstream queries", () => {
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        dataTestId="settings-pill"
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("settings-pill")).toBeInTheDocument();
+  });
+
+  it("does not fire onClick when disabled", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <ExpandingPill
+        icon={<SettingsIcon />}
+        label="Feed settings"
+        aria-label="Open feed settings"
+        disabled
+        onClick={onClick}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Open feed settings" }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/tests/stores/feed-store-settings-dialogs.test.ts
+++ b/tests/stores/feed-store-settings-dialogs.test.ts
@@ -1,0 +1,103 @@
+/**
+ * feed-store gains open/close state for two new dialogs:
+ *  - FeedSettingsDialog (controlled by feedSettingsDialogId)
+ *  - FolderSettingsDialog (controlled by folderSettingsDialogId)
+ *
+ * Pattern mirrors the rulesEditorFeedId + openRulesEditor/closeRulesEditor
+ * triplet that already lives on feed-store. Each id is null when the
+ * dialog is closed; setting it opens the dialog against that target.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../src/core/storage/db.ts", () => ({
+  getFeeds: vi.fn(async () => ({ ok: true, value: [] })),
+  getFeed: vi.fn(),
+  updateFeed: vi.fn(),
+  addFolder: vi.fn(),
+  getFolders: vi.fn(async () => ({ ok: true, value: [] })),
+  updateFolder: vi.fn(),
+  removeFolder: vi.fn(),
+  removeFeed: vi.fn(),
+}));
+
+vi.mock("../../src/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn(),
+  reloadFeed: vi.fn(),
+}));
+
+vi.mock("../../src/core/extractor/prefetch-service.ts", () => ({
+  prefetchStarredArticles: vi.fn(),
+  prefetchFeedArticles: vi.fn(),
+  selectFrequentFeeds: vi.fn(() => []),
+}));
+
+vi.mock("../../src/core/sync/sync-service", () => ({
+  pushVault: vi.fn(),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+import { useFeedStore } from "../../src/stores/feed-store.ts";
+
+describe("feed-store dialog open/close state", () => {
+  beforeEach(() => {
+    useFeedStore.setState({
+      feedSettingsDialogId: null,
+      folderSettingsDialogId: null,
+    });
+  });
+
+  describe("feed settings dialog", () => {
+    it("starts closed", () => {
+      expect(useFeedStore.getState().feedSettingsDialogId).toBeNull();
+    });
+
+    it("openFeedSettings(id) sets the dialog id", () => {
+      useFeedStore.getState().openFeedSettings("f-tech");
+      expect(useFeedStore.getState().feedSettingsDialogId).toBe("f-tech");
+    });
+
+    it("closeFeedSettings clears the dialog id", () => {
+      useFeedStore.getState().openFeedSettings("f-tech");
+      useFeedStore.getState().closeFeedSettings();
+      expect(useFeedStore.getState().feedSettingsDialogId).toBeNull();
+    });
+
+    it("opening a different feed swaps the target without an intermediate close", () => {
+      useFeedStore.getState().openFeedSettings("f-tech");
+      useFeedStore.getState().openFeedSettings("f-news");
+      expect(useFeedStore.getState().feedSettingsDialogId).toBe("f-news");
+    });
+  });
+
+  describe("folder settings dialog", () => {
+    it("starts closed", () => {
+      expect(useFeedStore.getState().folderSettingsDialogId).toBeNull();
+    });
+
+    it("openFolderSettings(id) sets the dialog id", () => {
+      useFeedStore.getState().openFolderSettings("folder-crypto");
+      expect(useFeedStore.getState().folderSettingsDialogId).toBe(
+        "folder-crypto",
+      );
+    });
+
+    it("closeFolderSettings clears the dialog id", () => {
+      useFeedStore.getState().openFolderSettings("folder-crypto");
+      useFeedStore.getState().closeFolderSettings();
+      expect(useFeedStore.getState().folderSettingsDialogId).toBeNull();
+    });
+  });
+
+  it("the two dialogs are independent — opening one does not close the other", () => {
+    useFeedStore.getState().openFeedSettings("f-tech");
+    useFeedStore.getState().openFolderSettings("folder-crypto");
+    expect(useFeedStore.getState().feedSettingsDialogId).toBe("f-tech");
+    expect(useFeedStore.getState().folderSettingsDialogId).toBe(
+      "folder-crypto",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Replaces every three-dot dropdown in the sidebar (feeds, folders, smart filters) with a single **context-aware floating cog** at the top-right of the article list, paired with the **sort selector** rebuilt as an expanding-pill. The sidebar becomes select-only; settings live where the user's attention already is.

Closes the UX direction set in the [maybe-we-can-move-lazy-pizza plan](https://github.com/forcingfx/feedzero/blob/claude/feed-settings-cog/docs/features/019-feed-settings-cog.md). Builds on the rules engine (PR #136) and prefetch toggle (PR #137) — both are now reachable through the unified `FeedSettingsDialog` rather than three separate dropdown entries.

## Context-aware behaviour

| Selected view | Cog opens |
|---|---|
| Single feed | `FeedSettingsDialog` (rename, prefer/prefetch toggles, folder, rules link, refresh, clear cached, delete) |
| Folder view | `FolderSettingsDialog` (rename, color picker, delete) |
| Smart filter view | Existing `SmartFilterEditorDialog` against that filter (now hosts Duplicate + Delete in its footer too) |
| `ALL_FEEDS` / `STARRED` / nothing selected | Cog hidden |
| Broken reference (deleted folder/filter) | Cog hidden (defensive) |

Both pills are circles by default; hover (desktop) or always-on (mobile) expands the label rightward via a CSS `max-width` animation. No layout shift on the icon; sidebar rows are now select-only.

## Commits (11)

1. `feat(ui): expanding-pill primitive` — circle-to-pill, hover/focus-visible/alwaysExpanded modes
2. `feat(articles): sort pill replaces sort menu` — same modes, new visual
3. `feat(feeds): feed-store dialog open/close state for settings dialogs` — `feedSettingsDialogId`, `folderSettingsDialogId` mirrors `rulesEditorFeedId`
4. `feat(feeds): feed settings dialog` — Name, Display toggles, Folder, Rules link, Refresh, Clear, Delete with confirmation
5. `feat(folders): folder settings dialog` — Name, Color, Delete + extracted `FolderColorPicker`
6. `feat(articles): settings pill (context-aware)` — visibility + dispatch matrix for feed/folder/filter; hides on aggregated views
7. `refactor(sidebar): remove feed-item dropdown` — row is now select-only
8. `refactor(sidebar): remove folder-item dropdown` — same
9. `refactor(sidebar): remove smart-filter-item dropdown` — same; smart-filter editor footer absorbs Duplicate + Delete
10. `docs(cog): feature doc for the floating settings cog` — `docs/features/019-feed-settings-cog.md`
11. `test(sidebar): drop dead app-sidebar-states delete-confirm tests` — coverage moved to FeedSettingsDialog tests

## Test plan

- [x] **Unit/integration** — `npm test` exits 0 (2828 / 31 skipped, no regressions, no unhandled errors)
- [x] **Type-check** — `npx tsc --noEmit` clean
- [x] **Pre-push hook** — passes (this PR was pushed through it)
- [x] **Primitive** — `ExpandingPill`: button render, label in DOM for a11y, click + Enter activation, collapsed/expanded class wiring, `alwaysExpanded` mobile mode, disabled state
- [x] **Sort pill** — current-mode label, opens menu, calls `onChange`
- [x] **Settings pill** — visibility matrix (ALL/STARRED/no-selection/deleted-folder/deleted-filter all return null) + dispatch matrix (feed/folder/filter each call the right store action with the right id; label adapts per context)
- [x] **Feed settings** — every section's write path: rename, prefer toggle, prefetch toggle, folder picker, unfiled, manage rules, refresh, clear, delete with confirm + cancel
- [x] **Folder settings** — rename, color swatch select, click-to-clear, delete confirm + cancel
- [x] **Sidebar rows** — rewritten as select-only; the dropdown-content assertions are replaced by negative assertions ("no More button exists; settings live in the cog dialog")
- [ ] Manual smoke against `npm run dev` — recommend before merge
- [ ] E2E — none added this PR (component tests cover the dispatch + flows); follow-up if review wants Playwright coverage of the hover-expand interaction

## Notes for review

- **Rename UX** moves from inline-input-on-sidebar to a text field inside the settings dialog. One extra click; explicitly traded off in the feature doc.
- **Smart filter editor** now hosts Duplicate + Delete in its footer — the only way to keep "no sidebar dropdowns" while still surfacing those actions.
- **Aggressive cleanup**: `FeedRemoveDialog`, `FeedReloadDialog`, and the sidebar's `folderToDelete` / `feedToRemove` / `feedToReload` state are deleted. The dialogs themselves still exist as files (unused exports) — happy to delete those in a follow-up if the reviewer prefers a clean tree, but they're cheap to keep around in case any other surface wants to reuse them.

See `docs/features/019-feed-settings-cog.md` for the full architecture, design decisions, and `## Limitations`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkuzqkyNGYxZsEdXhkPGMr)_