### PR TITLE
feat(import): placeholder feeds for rate-limited URLs + recover on refresh

### DIFF
--- a/.claude/skills/new-release/SKILL.md
+++ b/.claude/skills/new-release/SKILL.md
@@ -185,3 +185,4 @@ If the user wants a social post, draft it in builder/maker tone:
 - **The `package.json` version** was historically out of sync (stuck at 0.2.1 while the release notes were at 0.4.0). Keep it in sync going forward.
 - **The vendored fixture** (`tests/fixtures/release-feed.xml`) must be updated with every release so the parser contract test covers the latest format.
 - **Run `npm test` in the feedzero repo** after updating the fixture to verify everything passes before pushing.
+- **Docker images publish automatically** on every `v*.*.*` tag push via `.github/workflows/docker-publish.yml`. The workflow pushes to `ghcr.io/forcingfx/feedzero` always and additionally mirrors to `docker.io/forcingfx/feedzero` when the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets are set. No manual step during the release cut — once the tag is pushed in step 8, the workflow handles both registries.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,11 @@
 name: Publish self-host image
 
 # Builds the FeedZero Docker image and pushes it to GHCR
-# (ghcr.io/forcingfx/feedzero) on every version tag.
+# (ghcr.io/forcingfx/feedzero) on every version tag. Optionally mirrors
+# to Docker Hub (docker.io/forcingfx/feedzero) when the secrets
+# DOCKERHUB_USERNAME + DOCKERHUB_TOKEN are present — LAN-only Portainer
+# users typically pull from Docker Hub by default. With no secrets set,
+# the workflow still publishes to GHCR as before; nothing breaks.
 #
 # Self-hosters use this image via docker-compose.yml; the published
 # multi-arch (amd64 + arm64) build means Raspberry Pi users don't
@@ -55,11 +59,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub mirror is optional. When DOCKERHUB_TOKEN is set, we
+      # log in and the metadata + build-push steps stamp tags for both
+      # registries. When the secret is missing the step is skipped and
+      # the workflow publishes to GHCR alone — first-time setup is
+      # therefore zero-config.
+      - name: Log in to Docker Hub
+        if: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Compute the image list conditionally so the Docker Hub mirror is
+      # only included when the secret is present. metadata-action stamps
+      # every tag against every image in this list — Buildx then pushes
+      # each tag to its named registry in a single build. Conditional
+      # expression: when DOCKERHUB_TOKEN is set we add docker.io as a
+      # second line; otherwise we get GHCR alone.
       - name: Derive image metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/feedzero
+          images: |
+            ghcr.io/${{ github.repository_owner }}/feedzero
+            ${{ secrets.DOCKERHUB_TOKEN != '' && format('docker.io/{0}/feedzero', github.repository_owner) || '' }}
           # Tags:
           #   * On version tag: vX.Y.Z, X.Y, latest
           #   * On manual dispatch: short SHA

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,15 @@
 
 services:
   feedzero:
-    # Pre-built image. To build locally instead (e.g. before the first
-    # release is published, or when developing changes), run:
+    # Pre-built image. The same image is published to both GHCR and
+    # Docker Hub on every release; swap the registry below if you'd
+    # rather pull from Docker Hub (LAN-only Portainer users often
+    # prefer that since it's the default registry in Portainer's UI):
+    #
+    #   image: docker.io/forcingfx/feedzero:${FEEDZERO_VERSION:-latest}
+    #
+    # To build locally instead (e.g. before the first release is
+    # published, or when developing changes), run:
     #
     #   docker compose build
     #   docker compose up -d

--- a/docs/features/012-opml-import-export.md
+++ b/docs/features/012-opml-import-export.md
@@ -45,9 +45,11 @@ Feature: OPML Import/Export
 
   Scenario: Import with partial failures
     Given the user imports 5 feeds
-    And 3 succeed and 2 fail (network error, invalid feed)
-    Then the results view shows "3 feeds added, 2 failed"
-    And lists the failures with error messages
+    And 3 succeed, 1 is rate-limited (HTTP 429), and 1 is not a feed
+    Then the results view shows "3 feeds added, 1 queued for retry, 1 failed"
+    And the rate-limited feed appears in the sidebar with a red error icon
+    And pressing "r" after the upstream recovers clears the error and
+    backfills the feed's title and articles in place
 ```
 
 ## Architecture
@@ -61,9 +63,21 @@ Feature: OPML Import/Export
 4. `isOpmlFormat()` detects format, routes to appropriate parser
 5. `parseOpmlFile()` or `parseUrlList()` extracts feed URLs
 6. Import store transitions to `importing` status
-7. For each URL, `addFeed()` is called sequentially
-8. Results are recorded (success/failure with error)
-9. Import store transitions to `complete`, showing results
+7. For each URL, `addFeed()` is called sequentially:
+   - **Success** → recorded as `success: true`
+   - **`reason: "fetch-failure"`** (HTTP / network error) → falls
+     through to `addPlaceholderFeed(url, error)`, which persists a
+     Feed row with the URL-derived title and `lastError` set. Recorded
+     as `success: true, placeholder: true`. The user can hit "r" or
+     right-click → Refresh later to retry; the first successful
+     refresh upgrades the row in place (clears `lastError`, backfills
+     title/description/siteUrl from the parsed payload).
+   - **Other err** (parse / discovery / duplicate / quota) → recorded
+     as `success: false`; no row created. These won't recover via
+     refresh, so a placeholder would just be sidebar noise.
+8. Results are recorded with the 3-bucket discriminator
+9. Import store transitions to `complete`, showing the breakdown:
+   "N feeds added, M queued for retry, K failed"
 10. User clicks "Done" to close or "Import more" to reset
 
 **Export Flow:**
@@ -94,7 +108,10 @@ Feature: OPML Import/Export
 | `tests/core/opml/opml-service.test.ts` | OPML parse/generate, nested folders, edge cases |
 | `tests/core/opml/url-list-parser.test.ts` | URL parsing, comments, dedup, format detection |
 | `tests/stores/import-store.test.ts` | State machine, selectors, progress tracking |
+| `tests/components/settings/import-view-placeholder.test.tsx` | Placeholder-on-fetch-failure routing into folders |
+| `tests/integration/feed-store-db.test.ts` | Placeholder lifecycle round-trip through real encrypted DB |
 | `tests/e2e/import-export.spec.ts` | Full import/export flows in browser |
+| `tests/e2e/import-recovery.spec.ts` | Placeholder → refresh → recover, browser-side |
 
 ## Design Decisions
 
@@ -111,6 +128,8 @@ Feature: OPML Import/Export
 - **Auto-detect format** — When pasting text, the app auto-detects whether it's OPML XML or a plain URL list by checking for XML markers, eliminating the need for users to specify format.
 
 - **URL normalization** — URLs without protocol are auto-prefixed with `https://`. Invalid URLs are silently filtered rather than failing the entire import.
+
+- **Recoverable failures become placeholders** — A URL that fails with an HTTP error (429/503/4xx/5xx) or a network error is persisted as a placeholder Feed with `lastError` set and `lastSuccessfulFetchAt` left undefined. The sidebar surfaces these with a red `XCircle` icon distinct from the amber "stale" indicator. Hitting "r" or right-click → Refresh retries the fetch; the first success upgrades the placeholder in place (clears `lastError`, backfills metadata). Parse / discovery / duplicate failures stay rejected because refresh can't recover them. Issue #117 follow-up — large self-host imports on fresh IPs trip upstream rate-limits, and re-typing URLs to recover broken rows was tedious. Placeholders also preserve the OPML folder structure, so a recovered feed stays in the folder the user intended.
 
 ## Limitations
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -301,6 +301,38 @@ update.
 To pin a specific version, set `FEEDZERO_VERSION=v0.9.1` in `.env`
 and run `update`. Without a pin, the script tracks `:latest`.
 
+#### Image registry: GHCR or Docker Hub
+
+Every release is published to both registries:
+
+- **GitHub Container Registry** (default in `docker-compose.yml`):
+  `ghcr.io/forcingfx/feedzero`
+- **Docker Hub**: `docker.io/forcingfx/feedzero`
+
+If you'd rather pull from Docker Hub — common when managing the
+stack from Portainer's LAN-only UI, which lists Docker Hub by default —
+edit the `image:` line in `docker-compose.yml`:
+
+```yaml
+image: docker.io/forcingfx/feedzero:${FEEDZERO_VERSION:-latest}
+```
+
+Both registries serve the same multi-arch artefact, so the swap is
+otherwise invisible.
+
+#### Portainer (LAN-only)
+
+If you manage your homelab through Portainer:
+
+1. Go to **Stacks** → **Add stack**.
+2. Paste the contents of `docker-compose.yml` (swap the `image:` line
+   to `docker.io/...` if you'd prefer Docker Hub).
+3. In the **Environment variables** section, paste from `.env.example`
+   and edit `HOSTNAME` to your LAN address.
+4. Deploy. The encrypted vault and feed cache live in the bind-mount
+   declared by `DATA_DIR` — backups via `./scripts/feedzero backup`
+   still work the same way.
+
 ### Backup
 
 ```bash

--- a/src/components/settings/import-results.tsx
+++ b/src/components/settings/import-results.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, XCircle, ChevronDown } from "lucide-react";
+import { CheckCircle2, Clock, XCircle, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -9,31 +9,47 @@ import type { ImportResult } from "@/stores/import-store";
 
 interface ImportResultsProps {
   successCount: number;
+  /** Placeholder feeds (added but initial fetch failed; will retry on refresh). */
+  placeholderCount: number;
   failureCount: number;
   results: ImportResult[];
   onDone: () => void;
   onImportMore: () => void;
 }
 
+/**
+ * Compose the result summary line out of three buckets. Drops zero-counts
+ * so the user doesn't see ", 0 queued" noise.
+ */
+function summary(success: number, placeholder: number, failure: number) {
+  const parts: string[] = [];
+  parts.push(`${success} feed${success !== 1 ? "s" : ""} added`);
+  if (placeholder > 0) parts.push(`${placeholder} queued for retry`);
+  if (failure > 0) parts.push(`${failure} failed`);
+  return parts.join(", ");
+}
+
 export function ImportResults({
   successCount,
+  placeholderCount,
   failureCount,
   results,
   onDone,
   onImportMore,
 }: ImportResultsProps) {
-  const successes = results.filter((r) => r.success);
+  const successes = results.filter((r) => r.success && !r.placeholder);
+  const placeholders = results.filter((r) => r.success && r.placeholder);
   const failures = results.filter((r) => !r.success);
 
   return (
     <div className="space-y-4">
       <div className="text-center py-4">
         <div className="flex justify-center mb-2">
-          {failureCount === 0 ? (
+          {failureCount === 0 && placeholderCount === 0 ? (
             <div className="flex size-12 items-center justify-center rounded-full bg-green-100">
               <CheckCircle2 className="size-6 text-green-600" />
             </div>
-          ) : successCount === 0 ? (
+          ) : successCount === 0 && placeholderCount === 0 ? (
             <div className="flex size-12 items-center justify-center rounded-full bg-destructive/10">
               <XCircle className="size-6 text-destructive" />
             </div>
@@ -44,9 +60,14 @@ export function ImportResults({
           )}
         </div>
         <p className="font-medium">
-          {successCount} feed{successCount !== 1 ? "s" : ""} added
-          {failureCount > 0 && `, ${failureCount} failed`}
+          {summary(successCount, placeholderCount, failureCount)}
         </p>
+        {placeholderCount > 0 && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Queued feeds appear in the sidebar — press <kbd>r</kbd> or
+            right-click → Refresh to retry them.
+          </p>
+        )}
       </div>
 
       {successes.length > 0 && (
@@ -67,6 +88,32 @@ export function ImportResults({
                   title={result.url}
                 >
                   {result.url}
+                </li>
+              ))}
+            </ul>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+
+      {placeholders.length > 0 && (
+        <Collapsible defaultOpen>
+          <CollapsibleTrigger className="flex w-full items-center justify-between rounded-md border p-3 text-sm hover:bg-muted/50">
+            <span className="flex items-center gap-2">
+              <Clock className="size-4 text-amber-600" />
+              Queued for retry ({placeholders.length})
+            </span>
+            <ChevronDown className="size-4" />
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <ul className="mt-2 space-y-2 rounded-md border p-2">
+              {placeholders.map((result, i) => (
+                <li key={i} className="text-sm">
+                  <p className="truncate font-medium" title={result.url}>
+                    {result.url}
+                  </p>
+                  {result.error && (
+                    <p className="text-amber-700 text-xs">{result.error}</p>
+                  )}
                 </li>
               ))}
             </ul>

--- a/src/components/settings/import-view.tsx
+++ b/src/components/settings/import-view.tsx
@@ -10,6 +10,7 @@ import {
   useImportStore,
   selectTotalCount,
   selectSuccessCount,
+  selectPlaceholderCount,
   selectFailureCount,
   selectCurrentUrl,
 } from "@/stores/import-store";
@@ -40,6 +41,7 @@ export function ImportView({ onClose }: ImportViewProps) {
   const reset = useImportStore((s) => s.reset);
 
   const addFeed = useFeedStore((s) => s.addFeed);
+  const addPlaceholderFeed = useFeedStore((s) => s.addPlaceholderFeed);
   const createFolder = useFeedStore((s) => s.createFolder);
   const moveFeedToFolder = useFeedStore((s) => s.moveFeedToFolder);
 
@@ -158,29 +160,73 @@ export function ImportView({ onClose }: ImportViewProps) {
         if (folderNames.includes(f.name)) folderIdByName.set(f.name, f.id);
       }
 
+      // Best-effort folder placement for a just-added feed (real or
+      // placeholder). A missing folder or feed lookup leaves the
+      // subscription unfiled, which is the safe fallback.
+      const placeFeedIntoFolder = async (entry: {
+        xmlUrl: string;
+        folderName?: string;
+      }) => {
+        if (!entry.folderName) return;
+        const folderId = folderIdByName.get(entry.folderName);
+        const addedFeed = useFeedStore
+          .getState()
+          .feeds.find((f) => f.url === entry.xmlUrl);
+        if (folderId && addedFeed) {
+          await moveFeedToFolder(addedFeed.id, folderId);
+        }
+      };
+
       // Start import process
       startImport(urls);
 
-      // Process each entry sequentially. After a successful addFeed, look
-      // up the just-added feed by url in the store and move it into the
-      // matching folder (best-effort — a missing folder or feed leaves the
-      // subscription unfiled, which is the safe fallback).
+      // Process each entry sequentially. Three outcomes per URL:
+      //   * ok            → fully imported; move to folder, record success
+      //   * fetch-failure → persist as placeholder so refresh can retry;
+      //                     same folder placement, recorded as placeholder
+      //   * other err     → permanent (parse / discovery / duplicate /
+      //                     quota); record failure, no row created
       for (const entry of entries) {
         const result = await addFeed(entry.xmlUrl);
+
         if (result.ok) {
-          if (entry.folderName) {
-            const folderId = folderIdByName.get(entry.folderName);
-            const addedFeed = useFeedStore
-              .getState()
-              .feeds.find((f) => f.url === entry.xmlUrl);
-            if (folderId && addedFeed) {
-              await moveFeedToFolder(addedFeed.id, folderId);
-            }
-          }
+          await placeFeedIntoFolder(entry);
           recordResult({ url: entry.xmlUrl, success: true });
-        } else {
-          recordResult({ url: entry.xmlUrl, success: false, error: result.error });
+          continue;
         }
+
+        if (result.reason !== "fetch-failure") {
+          recordResult({
+            url: entry.xmlUrl,
+            success: false,
+            error: result.error,
+          });
+          continue;
+        }
+
+        // Recoverable fetch failure — persist a placeholder so the user
+        // can hit refresh later to recover the feed.
+        const placeholder = await addPlaceholderFeed(
+          entry.xmlUrl,
+          result.error,
+        );
+        if (!placeholder.ok) {
+          // Placeholder creation itself failed (e.g. duplicate URL in
+          // the database). Fall through to a hard failure.
+          recordResult({
+            url: entry.xmlUrl,
+            success: false,
+            error: placeholder.error,
+          });
+          continue;
+        }
+        await placeFeedIntoFolder(entry);
+        recordResult({
+          url: entry.xmlUrl,
+          success: true,
+          placeholder: true,
+          error: result.error,
+        });
       }
     } catch (err) {
       setParseError(
@@ -194,6 +240,7 @@ export function ImportView({ onClose }: ImportViewProps) {
     extractEntries,
     startImport,
     addFeed,
+    addPlaceholderFeed,
     createFolder,
     moveFeedToFolder,
     recordResult,
@@ -227,6 +274,7 @@ export function ImportView({ onClose }: ImportViewProps) {
     return (
       <ImportResults
         successCount={selectSuccessCount(state)}
+        placeholderCount={selectPlaceholderCount(state)}
         failureCount={selectFailureCount(state)}
         results={state.results}
         onDone={() => {

--- a/src/components/sidebar/feed-item.tsx
+++ b/src/components/sidebar/feed-item.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, RefreshCw, XCircle } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -26,8 +26,8 @@ interface FeedItemProps {
  * Sidebar feed row. Select-only — every per-feed action (rename,
  * preferences, rules, refresh, clear cache, delete) lives in
  * FeedSettingsDialog now, opened from the floating cog above the
- * article list. The row keeps the favicon, title, refresh/stale
- * indicators, unread badge, and drag handle for reorder.
+ * article list. The row keeps the favicon, title, refresh/stale/
+ * failed-fetch indicators, unread badge, and drag handle for reorder.
  */
 export function FeedItem({
   feed,
@@ -66,7 +66,18 @@ export function FeedItem({
         {isRefreshing && (
           <RefreshCw className="size-3 animate-spin shrink-0 text-muted-foreground" />
         )}
-        {!isRefreshing && isFeedStale(feed) && (
+        {/* Failed-fetch indicator: a placeholder feed that has never
+            successfully refreshed. Takes precedence over the stale
+            indicator — a feed that never loaded is more pressing than
+            a stale one. */}
+        {!isRefreshing && feed.lastError && !feed.lastSuccessfulFetchAt && (
+          <XCircle
+            className="size-3 shrink-0 text-destructive"
+            aria-label={feed.lastError}
+            data-testid="failed-feed-indicator"
+          />
+        )}
+        {!isRefreshing && !feed.lastError && isFeedStale(feed) && (
           <AlertTriangle
             className="size-3 shrink-0 text-amber-500"
             aria-label="This feed hasn't updated in over 14 days"

--- a/src/core/feeds/feed-service.ts
+++ b/src/core/feeds/feed-service.ts
@@ -26,6 +26,19 @@ interface AddFeedResult {
   articles: Article[];
 }
 
+/**
+ * Discriminator on `addFeedFlow`'s err branch. `fetch-failure` marks a
+ * recoverable failure (HTTP error response or network/transport error) — the
+ * import flow uses it to create a placeholder feed the user can retry via
+ * `refreshFeed`. Parse / discovery / duplicate failures stay unflagged
+ * because retry won't help.
+ */
+export type AddFeedErrorReason = "fetch-failure";
+
+export type AddFeedFlowResult =
+  | { ok: true; value: AddFeedResult }
+  | { ok: false; error: string; reason?: AddFeedErrorReason };
+
 interface RefreshResult {
   newCount: number;
   updatedCount: number;
@@ -113,13 +126,24 @@ export function normalizeUrl(url: string): string {
 }
 
 /**
+ * Tag an err Result with `reason: "fetch-failure"` so import-side callers
+ * know the failure is recoverable (HTTP / network) and can create a
+ * placeholder feed for later retry. Permanent failures (parse, discovery,
+ * duplicate) skip this and stay as plain err Results.
+ */
+function fetchFailure(message: string): AddFeedFlowResult {
+  return { ok: false, error: message, reason: "fetch-failure" };
+}
+
+/**
  * Full add-feed flow: check duplicate → fetch → parse → store.
- * Returns Result<{feed, articles}> with user-friendly error messages.
+ * Returns AddFeedFlowResult with user-friendly error messages. On a
+ * recoverable failure the err branch carries `reason: "fetch-failure"`.
  */
 export async function addFeedFlow(
   rawUrl: string,
   options?: { prefetchedContent?: string },
-): Promise<Result<AddFeedResult>> {
+): Promise<AddFeedFlowResult> {
   const url = normalizeUrl(rawUrl);
   try {
     // Check for duplicate using the plaintext URL index (no decryption needed)
@@ -142,7 +166,7 @@ export async function addFeedFlow(
     } else {
       const response = await proxyFetch("/api/feed", url);
       if (!response.ok) {
-        return err(
+        return fetchFailure(
           fetchErrorMessage(response, "The feed at this URL could not be reached"),
         );
       }
@@ -178,7 +202,17 @@ export async function addFeedFlow(
     });
     if (!feedResult.ok) return feedResult;
 
-    const feed = feedResult.value;
+    // Mark the just-ingested feed as having had at least one successful
+    // fetch. This is what distinguishes a real feed from a placeholder
+    // (which has `lastSuccessfulFetchAt === undefined`) — and protects the
+    // user's rename of an established feed from being overwritten by the
+    // first-success metadata backfill in refreshFeed.
+    const now = Date.now();
+    const feed: Feed = {
+      ...feedResult.value,
+      lastFetchedAt: now,
+      lastSuccessfulFetchAt: now,
+    };
     const storeResult = await addFeed(feed);
     if (!storeResult.ok) return storeResult;
 
@@ -194,10 +228,64 @@ export async function addFeedFlow(
 
     return ok({ feed, articles });
   } catch {
-    return err(
+    return fetchFailure(
       "The feed at this URL could not be reached. Please check your connection and try again.",
     );
   }
+}
+
+/**
+ * Derive a recognizable sidebar title from a URL when the real feed
+ * metadata isn't yet available (placeholder created by failed import).
+ * The first successful refresh overwrites this with the real `<title>`.
+ */
+function deriveTitleFromUrl(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Persist a feed the user wanted to subscribe to but whose first fetch
+ * failed (HTTP / network error). Used by the bulk-import flow so a
+ * rate-limited URL doesn't get dropped — the sidebar shows it with a red
+ * error indicator, the user hits "r" or right-click → Refresh, and the
+ * first successful refresh upgrades the row to a normal feed in place
+ * (clears `lastError`, backfills title/description/siteUrl from the
+ * parsed payload).
+ */
+export async function addPlaceholderFeed(
+  rawUrl: string,
+  error: string,
+): Promise<Result<Feed>> {
+  const url = normalizeUrl(rawUrl);
+
+  const exists = await feedExistsByUrl(url);
+  if (exists.ok && exists.value) {
+    const allFeeds = await getFeeds();
+    const isReal = allFeeds.ok && allFeeds.value.some((f) => f.url === url);
+    if (isReal) return err("A feed with this URL already exists");
+    await removeFeedsByUrl(url);
+  }
+
+  const created = createFeed({
+    url,
+    title: deriveTitleFromUrl(url),
+  });
+  if (!created.ok) return created;
+
+  const feed: Feed = {
+    ...created.value,
+    lastError: error,
+    lastFetchedAt: Date.now(),
+  };
+
+  const store = await addFeed(feed);
+  if (!store.ok) return err(store.error);
+
+  return ok(feed);
 }
 
 interface PreviewArticle {
@@ -270,15 +358,24 @@ export async function refreshFeed(feed: Feed): Promise<Result<RefreshResult>> {
       // error message surfaces Retry-After when the upstream sent one
       // (feedback #97: self-host bulk refresh against fresh IPs trips
       // upstream WAFs and the user needs to know when to retry).
-      await persistFreshness(feed, { fetchedAt: now, successfulAt: null });
-      return err(fetchErrorMessage(response, "Failed to fetch feed"));
+      const errorMessage = fetchErrorMessage(response, "Failed to fetch feed");
+      await persistFreshness(feed, {
+        fetchedAt: now,
+        successfulAt: null,
+        lastError: errorMessage,
+      });
+      return err(errorMessage);
     }
     const text = await response.text();
     const parseResult = parse(text, feed.url);
     if (!parseResult.ok) {
       // HTTP succeeded but content was unparseable — the publisher is alive,
       // so this still counts as a successful reach.
-      await persistFreshness(feed, { fetchedAt: now, successfulAt: now });
+      await persistFreshness(feed, {
+        fetchedAt: now,
+        successfulAt: now,
+        lastError: parseResult.error,
+      });
       return err(parseResult.error);
     }
 
@@ -338,7 +435,23 @@ export async function refreshFeed(feed: Feed): Promise<Result<RefreshResult>> {
       await updateArticles(updatedArticles);
     }
 
-    await persistFreshness(feed, { fetchedAt: now, successfulAt: now });
+    // First-ever success on this feed (typically a placeholder added by
+    // import after a fetch failure): backfill title/description/siteUrl
+    // from the parsed payload so the sidebar gets a real label. Skipped
+    // on subsequent successes so a user's rename is never clobbered.
+    const isFirstSuccess = feed.lastSuccessfulFetchAt === undefined;
+    if (isFirstSuccess) {
+      const parsedFeed = parseResult.value.feed;
+      if (parsedFeed.title) feed.title = parsedFeed.title;
+      if (parsedFeed.description) feed.description = parsedFeed.description;
+      if (parsedFeed.siteUrl) feed.siteUrl = parsedFeed.siteUrl;
+    }
+
+    await persistFreshness(feed, {
+      fetchedAt: now,
+      successfulAt: now,
+      lastError: null,
+    });
 
     return ok({
       newCount: created.length,
@@ -347,22 +460,38 @@ export async function refreshFeed(feed: Feed): Promise<Result<RefreshResult>> {
   } catch (e) {
     // Network / transport-layer failure: record the attempt but keep any
     // prior success timestamp so we don't reset the stale-indicator clock.
-    await persistFreshness(feed, { fetchedAt: now, successfulAt: null });
-    return err(`Refresh failed: ${(e as Error).message}`);
+    const errorMessage = `Refresh failed: ${(e as Error).message}`;
+    await persistFreshness(feed, {
+      fetchedAt: now,
+      successfulAt: null,
+      lastError: errorMessage,
+    });
+    return err(errorMessage);
   }
 }
 
 /**
- * Mutate `feed` in place with new freshness timestamps and persist via
- * updateFeed. Passing `successfulAt: null` keeps the prior value so a
+ * Mutate `feed` in place with new freshness timestamps + lastError and
+ * persist via updateFeed. `successfulAt: null` keeps the prior value so a
  * transient failure doesn't reset the stale-indicator clock.
+ * `lastError: null` explicitly clears a previous failure (success path);
+ * `lastError: string` records the new failure.
  */
 async function persistFreshness(
   feed: Feed,
-  ts: { fetchedAt: number; successfulAt: number | null },
+  ts: {
+    fetchedAt: number;
+    successfulAt: number | null;
+    lastError: string | null;
+  },
 ): Promise<void> {
   feed.lastFetchedAt = ts.fetchedAt;
   if (ts.successfulAt !== null) feed.lastSuccessfulFetchAt = ts.successfulAt;
+  if (ts.lastError === null) {
+    delete feed.lastError;
+  } else {
+    feed.lastError = ts.lastError;
+  }
   await updateFeed(feed);
 }
 

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -13,6 +13,7 @@ import {
 import { createRule } from "../core/storage/schema.ts";
 import {
   addFeedFlow,
+  addPlaceholderFeed as addPlaceholderFeedCore,
   refreshFeed,
   refreshAllFeeds,
   reloadFeed,
@@ -44,14 +45,19 @@ import { ok, err } from "../utils/result.ts";
 
 /**
  * `addFeed` result. Result-shaped plus an optional `reason` on the err
- * branch so call sites can distinguish a quota refusal (route the user to
- * upgrade) from a generic failure (show "Failed to add"). Stays a
- * structural superset of `Result<void>` so existing readers of
- * `.ok` / `.error` continue to compile without change.
+ * branch so call sites can distinguish failure classes: quota refusal
+ * (route the user to upgrade), recoverable fetch failure (import flow
+ * can create a placeholder), or unflagged (generic). Stays a structural
+ * superset of `Result<void>` so existing readers of `.ok` / `.error`
+ * continue to compile without change.
  */
 export type AddFeedResult =
   | { ok: true; value: void }
-  | { ok: false; error: string; reason?: "free-quota-exceeded" };
+  | {
+      ok: false;
+      error: string;
+      reason?: "free-quota-exceeded" | "fetch-failure";
+    };
 
 /** Whether a feed is the official FeedZero release notes feed. */
 function isReleaseFeed(feed: Feed): boolean {
@@ -86,6 +92,13 @@ interface FeedStore {
   feedsLoaded: boolean;
   loadFeeds: () => Promise<void>;
   addFeed: (url: string) => Promise<AddFeedResult>;
+  /**
+   * Persist a placeholder feed for a URL whose initial fetch failed
+   * (HTTP / network error). Used by bulk import so rate-limited URLs
+   * aren't dropped — the user can hit refresh later to recover them.
+   * Returns Result<Feed> so callers can chain folder placement.
+   */
+  addPlaceholderFeed: (url: string, error: string) => Promise<Result<Feed>>;
   removeFeed: (feedId: string) => Promise<void>;
   renameFeed: (feedId: string, newTitle: string) => Promise<void>;
   setFeedPreferFullText: (feedId: string, value: boolean) => Promise<void>;
@@ -366,7 +379,12 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
     const result = await addFeedFlow(url);
     if (!result.ok) {
       set({ isLoading: false, error: result.error });
-      return { ok: false, error: result.error } as const;
+      // Preserve the reason discriminator so import-side callers can
+      // distinguish recoverable fetch failures (placeholder candidate)
+      // from permanent ones (parse / discovery / duplicate).
+      return result.reason
+        ? ({ ok: false, error: result.error, reason: result.reason } as const)
+        : ({ ok: false, error: result.error } as const);
     }
     // Push the ingested articles into the article-store immediately so the
     // sidebar badge reflects the true unread count without waiting for the
@@ -383,6 +401,14 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
     set({ selectedFeedId: result.value.feed.id, isLoading: false });
     schedulePush();
     return { ok: true, value: undefined } as const;
+  },
+
+  addPlaceholderFeed: async (url, error) => {
+    const result = await addPlaceholderFeedCore(url, error);
+    if (!result.ok) return result;
+    await reloadFeeds(set);
+    schedulePush();
+    return result;
   },
 
   removeFeed: async (feedId) => {

--- a/src/stores/import-store.ts
+++ b/src/stores/import-store.ts
@@ -5,6 +5,13 @@ export interface ImportResult {
   url: string;
   success: boolean;
   error?: string;
+  /**
+   * Set when the feed was added as a placeholder (initial fetch failed but
+   * we persisted the URL so the user can retry via refresh). Counts as a
+   * success because the row exists in the sidebar, but the UI surfaces it
+   * separately (amber "queued for retry") to set expectations.
+   */
+  placeholder?: boolean;
 }
 
 /** Import status state machine: idle → importing → complete | error */
@@ -77,14 +84,24 @@ export function selectTotalCount(state: Pick<ImportStore, "urls">): number {
   return state.urls.length;
 }
 
-/** Selector: count of successfully imported feeds */
+/** Selector: count of fully-imported feeds (success and not a placeholder). */
 export function selectSuccessCount(
   state: Pick<ImportStore, "results">,
 ): number {
-  return state.results.filter((r) => r.success).length;
+  return state.results.filter((r) => r.success && !r.placeholder).length;
 }
 
-/** Selector: count of failed imports */
+/**
+ * Selector: count of placeholder feeds added by import (initial fetch
+ * failed but the row was persisted for later retry via refresh).
+ */
+export function selectPlaceholderCount(
+  state: Pick<ImportStore, "results">,
+): number {
+  return state.results.filter((r) => r.success && r.placeholder).length;
+}
+
+/** Selector: count of rejected imports (parse / discovery / duplicate). */
 export function selectFailureCount(
   state: Pick<ImportStore, "results">,
 ): number {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,15 @@ export interface Feed {
   /** Unix epoch ms of the last refresh attempt that returned HTTP 2xx. */
   lastSuccessfulFetchAt?: number;
   /**
+   * Most-recent refresh error message, set by `persistFreshness` in
+   * `feed-service.ts`. Cleared on every successful refresh. Set on
+   * placeholder feeds added by bulk import when the initial fetch failed
+   * (HTTP / network error) — refresh recovers the feed and clears the
+   * field. A non-empty `lastError` with `lastSuccessfulFetchAt === undefined`
+   * is the placeholder signal the sidebar uses to render a red error icon.
+   */
+  lastError?: string;
+  /**
    * Per-feed auto-action rules evaluated on ingest. Each rule's
    * condition is matched against newly-fetched articles; matching
    * articles get every action in `rule.actions` applied before

--- a/tests/components/settings/import-view-placeholder.test.tsx
+++ b/tests/components/settings/import-view-placeholder.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * ImportView — placeholder behaviour on recoverable fetch failure.
+ *
+ * When bulk import hits a rate-limited or transient-failed URL, the row
+ * should be persisted as a placeholder feed (via the store's
+ * addPlaceholderFeed action) and moved into its OPML folder. The user
+ * can then hit `r` later to retry. Parse / discovery failures stay
+ * rejected because refresh can't recover them.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImportView } from "@/components/settings/import-view";
+import { useFeedStore } from "@/stores/feed-store";
+import { useLicenseStore } from "@/stores/license-store";
+import { useImportStore } from "@/stores/import-store";
+
+vi.mock("@/core/features/self-hosted", () => ({
+  isSelfHosted: vi.fn(() => false),
+}));
+vi.mock("@/core/features/paid-tier-active", () => ({
+  isPaidTierActive: vi.fn(() => true),
+}));
+
+const MIXED_OPML = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Mixed</title></head>
+  <body>
+    <outline text="Tech">
+      <outline type="rss" text="OK" xmlUrl="https://ok.example.com/feed/"/>
+      <outline type="rss" text="Rate-limited" xmlUrl="https://rl.example.com/feed/"/>
+      <outline type="rss" text="Not a feed" xmlUrl="https://notfeed.example.com"/>
+    </outline>
+  </body>
+</opml>`;
+
+describe("ImportView — placeholder feeds on recoverable fetch failure", () => {
+  let addFeedMock: ReturnType<typeof vi.fn>;
+  let addPlaceholderFeedMock: ReturnType<typeof vi.fn>;
+  let createFolderMock: ReturnType<typeof vi.fn>;
+  let moveFeedToFolderMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    useLicenseStore.setState({ tier: "personal", verifying: false });
+
+    // addFeed: succeeds for ok.*, returns fetch-failure for rl.*,
+    // returns permanent failure for notfeed.*. Each successful add (real
+    // or placeholder) appends a feed so the importer can look it up.
+    addFeedMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.startsWith("https://ok.")) {
+        const id = `feed-${useFeedStore.getState().feeds.length}`;
+        useFeedStore.setState((s) => ({
+          feeds: [
+            ...s.feeds,
+            {
+              id,
+              url,
+              title: "OK",
+              description: "",
+              siteUrl: "",
+              createdAt: 0,
+              updatedAt: 0,
+            },
+          ] as never,
+        }));
+        return { ok: true };
+      }
+      if (url.startsWith("https://rl.")) {
+        return { ok: false, error: "HTTP 429", reason: "fetch-failure" };
+      }
+      return { ok: false, error: "Not a valid feed" };
+    });
+
+    addPlaceholderFeedMock = vi.fn().mockImplementation(
+      async (url: string, error: string) => {
+        const id = `feed-${useFeedStore.getState().feeds.length}`;
+        const feed = {
+          id,
+          url,
+          title: "rl.example.com",
+          description: "",
+          siteUrl: "",
+          createdAt: 0,
+          updatedAt: 0,
+          lastError: error,
+        };
+        useFeedStore.setState((s) => ({
+          feeds: [...s.feeds, feed] as never,
+        }));
+        return { ok: true, value: feed };
+      },
+    );
+
+    createFolderMock = vi.fn().mockImplementation(async (name: string) => {
+      const id = `fld-${name.toLowerCase()}`;
+      useFeedStore.setState((s) => ({
+        folders: [...(s.folders ?? []), { id, name, createdAt: 0 }] as never,
+      }));
+    });
+    moveFeedToFolderMock = vi.fn().mockResolvedValue(undefined);
+
+    useFeedStore.setState({
+      feeds: [],
+      folders: [],
+      addFeed: addFeedMock,
+      addPlaceholderFeed: addPlaceholderFeedMock,
+      createFolder: createFolderMock,
+      moveFeedToFolder: moveFeedToFolderMock,
+    } as never);
+    useImportStore.getState().reset();
+  });
+
+  it("creates a placeholder for fetch-failure URLs and assigns them to the OPML folder", async () => {
+    const user = userEvent.setup();
+    render(<ImportView onClose={() => {}} />);
+
+    await user.click(screen.getByLabelText(/paste text/i));
+    const textarea = screen.getByPlaceholderText(/paste opml/i);
+    await user.click(textarea);
+    await user.paste(MIXED_OPML);
+    await user.click(screen.getByRole("button", { name: /import feeds/i }));
+
+    // The placeholder action was called exactly for the rate-limited URL,
+    // with the upstream error message.
+    expect(addPlaceholderFeedMock).toHaveBeenCalledTimes(1);
+    expect(addPlaceholderFeedMock).toHaveBeenCalledWith(
+      "https://rl.example.com/feed/",
+      "HTTP 429",
+    );
+
+    // Both the OK feed AND the placeholder ended up in the Tech folder.
+    // The "Not a valid feed" row stays rejected and is not moved.
+    const moveCalls = moveFeedToFolderMock.mock.calls.map((c) => ({
+      feedId: c[0],
+      folderId: c[1],
+    }));
+    expect(moveCalls.length).toBe(2);
+    for (const call of moveCalls) {
+      expect(call.folderId).toBe("fld-tech");
+    }
+
+    // Results pane shows the 3-bucket breakdown.
+    expect(
+      await screen.findByText(/1 feed added.*1 queued for retry.*1 failed/i),
+    ).toBeDefined();
+  });
+});

--- a/tests/components/sidebar/feed-item.test.tsx
+++ b/tests/components/sidebar/feed-item.test.tsx
@@ -164,4 +164,48 @@ describe("FeedItem", () => {
     renderFeedItem();
     expect(screen.queryByRole("button", { name: /more/i })).toBeNull();
   });
+
+  it("shows a red error indicator when the feed is a placeholder (lastError set, never succeeded)", () => {
+    // Placeholder feeds from a failed bulk-import need a visible
+    // affordance so the user knows to hit refresh. The indicator is
+    // distinct from the amber 'stale' indicator (which means "we used
+    // to fetch this, now it's quiet") to avoid conflating the two states.
+    renderFeedItem({
+      feed: {
+        ...mockFeed,
+        lastError: "HTTP 429, retry after 60s",
+        // lastSuccessfulFetchAt deliberately undefined — never fetched.
+        lastFetchedAt: Date.now(),
+      },
+    });
+    const indicator = screen.getByTestId("failed-feed-indicator");
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.getAttribute("aria-label")).toMatch(/HTTP 429/);
+  });
+
+  it("does NOT show the error indicator on a healthy feed", () => {
+    renderFeedItem({
+      feed: {
+        ...mockFeed,
+        lastFetchedAt: Date.now(),
+        lastSuccessfulFetchAt: Date.now(),
+      },
+    });
+    expect(screen.queryByTestId("failed-feed-indicator")).toBeNull();
+  });
+
+  it("does NOT show the error indicator on a feed that worked before but recently failed", () => {
+    // We rely on the existing stale indicator for "worked, now broken"
+    // beyond the 14-day threshold. Recently-failed-but-previously-OK
+    // feeds stay quiet to avoid noise.
+    renderFeedItem({
+      feed: {
+        ...mockFeed,
+        lastError: "transient 503",
+        lastFetchedAt: Date.now(),
+        lastSuccessfulFetchAt: Date.now() - 60 * 1000,
+      },
+    });
+    expect(screen.queryByTestId("failed-feed-indicator")).toBeNull();
+  });
 });

--- a/tests/core/feeds/feed-service.test.js
+++ b/tests/core/feeds/feed-service.test.js
@@ -136,7 +136,7 @@ vi.mock("../../../src/core/storage/db.ts", () => {
   };
 });
 
-let addFeedFlow, refreshFeed, refreshAllFeeds, reloadFeed, previewFeed;
+let addFeedFlow, addPlaceholderFeed, refreshFeed, refreshAllFeeds, reloadFeed, previewFeed;
 let db;
 
 beforeEach(async () => {
@@ -147,6 +147,7 @@ beforeEach(async () => {
   // Reset module to clear any cached state
   const mod = await import("../../../src/core/feeds/feed-service.ts");
   addFeedFlow = mod.addFeedFlow;
+  addPlaceholderFeed = mod.addPlaceholderFeed;
   refreshFeed = mod.refreshFeed;
   refreshAllFeeds = mod.refreshAllFeeds;
   reloadFeed = mod.reloadFeed;
@@ -252,6 +253,43 @@ describe("feed-service", () => {
       const result = await addFeedFlow("https://example.com/feed");
       expect(isErr(result)).toBe(true);
       expect(result.error).toMatch(/could not be reached/i);
+    });
+
+    it("flags HTTP fetch failures with reason: 'fetch-failure' (import-side recovery)", async () => {
+      // Recoverable failures (429/503/5xx/4xx) are distinguished from
+      // permanent failures (parse / discovery / duplicate) via a `reason`
+      // discriminator so bulk import can create a placeholder feed and let
+      // the user retry via refresh. Mirrors the existing
+      // `reason: "free-quota-exceeded"` pattern.
+      for (const status of [429, 503, 500, 404]) {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status,
+          headers: new Headers(),
+        });
+        const result = await addFeedFlow(`https://example.com/${status}`);
+        expect(isErr(result)).toBe(true);
+        expect(result.reason).toBe("fetch-failure");
+      }
+    });
+
+    it("flags network/transport errors with reason: 'fetch-failure'", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNRESET"));
+      const result = await addFeedFlow("https://example.com/network-err");
+      expect(isErr(result)).toBe(true);
+      expect(result.reason).toBe("fetch-failure");
+    });
+
+    it("does NOT flag parse / discovery failures as fetch-failure", async () => {
+      // The URL isn't a feed and never will be. No point creating a
+      // placeholder row that refresh can't recover.
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("<html><body>Not a feed</body></html>"),
+      });
+      const result = await addFeedFlow("https://example.com/not-a-feed");
+      expect(isErr(result)).toBe(true);
+      expect(result.reason).toBeUndefined();
     });
 
     it("should return error when fetch throws (network error)", async () => {
@@ -360,6 +398,51 @@ describe("feed-service", () => {
 
       const { feed } = unwrap(result);
       expect(feed.title).toBe("Example Feed");
+    });
+  });
+
+  describe("addPlaceholderFeed", () => {
+    it("persists a placeholder feed with lastError and a URL-derived title", async () => {
+      // Import scenario: a URL fetched fine in OPML but the upstream returned
+      // 429. We persist it anyway so the user can hit `r` later to retry.
+      const result = await addPlaceholderFeed(
+        "https://news.example.com/feed.xml",
+        "The feed at this URL could not be reached (HTTP 429, retry after 60s)",
+      );
+
+      expect(isOk(result)).toBe(true);
+      const feed = unwrap(result);
+      expect(feed.url).toBe("https://news.example.com/feed.xml");
+      // Title is derived from the URL host, not "Untitled" — gives the user
+      // a recognizable sidebar label until refresh backfills the real one.
+      expect(feed.title).toBe("news.example.com");
+      expect(feed.lastError).toMatch(/HTTP 429/);
+      expect(feed.lastSuccessfulFetchAt).toBeUndefined();
+      expect(db.addFeed).toHaveBeenCalledOnce();
+    });
+
+    it("normalizes the URL the same way addFeedFlow does", async () => {
+      const result = await addPlaceholderFeed(
+        "HTTPS://Example.COM/feed/",
+        "boom",
+      );
+      expect(isOk(result)).toBe(true);
+      expect(unwrap(result).url).toBe("https://example.com/feed");
+    });
+
+    it("returns err when the URL already exists as a real feed", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(ATOM_XML),
+      });
+      await addFeedFlow("https://example.com/feed.xml");
+
+      const result = await addPlaceholderFeed(
+        "https://example.com/feed.xml",
+        "boom",
+      );
+      expect(isErr(result)).toBe(true);
+      expect(result.error).toMatch(/already exists/i);
     });
   });
 });
@@ -613,7 +696,7 @@ describe("refreshFeed", () => {
 
     it("records only lastFetchedAt on HTTP failure (publisher unreachable)", async () => {
       const feed = await addTestFeed();
-      const baselineSuccess = feed.lastSuccessfulFetchAt; // undefined for fresh feed
+      const baselineSuccess = feed.lastSuccessfulFetchAt;
       const before = Date.now();
 
       globalThis.fetch = vi.fn().mockResolvedValue({
@@ -629,8 +712,9 @@ describe("refreshFeed", () => {
       expect(lastCall.lastSuccessfulFetchAt).toBe(baselineSuccess);
     });
 
-    it("records only lastFetchedAt when fetch throws (network error)", async () => {
+    it("preserves prior lastSuccessfulFetchAt when fetch throws (network error)", async () => {
       const feed = await addTestFeed();
+      const baselineSuccess = feed.lastSuccessfulFetchAt;
       const before = Date.now();
 
       globalThis.fetch = vi.fn().mockRejectedValue(new Error("connection reset"));
@@ -639,7 +723,7 @@ describe("refreshFeed", () => {
       expect(db.updateFeed).toHaveBeenCalled();
       const lastCall = db.updateFeed.mock.calls.at(-1)[0];
       expect(lastCall.lastFetchedAt).toBeGreaterThanOrEqual(before);
-      expect(lastCall.lastSuccessfulFetchAt).toBeUndefined();
+      expect(lastCall.lastSuccessfulFetchAt).toBe(baselineSuccess);
     });
 
     it("preserves a prior lastSuccessfulFetchAt across a failing refresh", async () => {
@@ -659,6 +743,94 @@ describe("refreshFeed", () => {
 
       const lastCall = db.updateFeed.mock.calls.at(-1)[0];
       expect(lastCall.lastSuccessfulFetchAt).toBe(yesterday);
+    });
+  });
+
+  describe("lastError lifecycle", () => {
+    // The sidebar surfaces broken feeds via Feed.lastError. Same chokepoint
+    // (`persistFreshness`) that owns the freshness timestamps owns this
+    // field so the in-memory feed and the DB row never disagree.
+    it("sets lastError on HTTP failure", async () => {
+      const feed = await addTestFeed();
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        headers: new Headers(),
+      });
+      await refreshFeed(feed);
+
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.lastError).toMatch(/503/);
+    });
+
+    it("sets lastError on network/transport error", async () => {
+      const feed = await addTestFeed();
+
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNRESET"));
+      await refreshFeed(feed);
+
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.lastError).toMatch(/ECONNRESET/);
+    });
+
+    it("clears lastError on successful refresh", async () => {
+      const feed = await addTestFeed();
+      // Pretend a prior refresh failed.
+      feed.lastError = "previous failure";
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(ATOM_XML),
+      });
+      await refreshFeed(feed);
+
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.lastError).toBeUndefined();
+    });
+  });
+
+  describe("first-success metadata backfill", () => {
+    // A placeholder feed (added by import after a fetch failure) starts with
+    // a URL-derived title and empty description/siteUrl. The first
+    // successful refresh upgrades it to a real feed — we overwrite metadata
+    // ONLY when this is the first-ever success, so a user's rename of an
+    // established feed is never clobbered.
+    it("backfills title/description/siteUrl when lastSuccessfulFetchAt is undefined", async () => {
+      const placeholderResult = await addPlaceholderFeed(
+        "https://example.com/feed.xml",
+        "transient 429",
+      );
+      const feed = unwrap(placeholderResult);
+      expect(feed.lastSuccessfulFetchAt).toBeUndefined();
+      expect(feed.title).toBe("example.com");
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(ATOM_XML),
+      });
+      await refreshFeed(feed);
+
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.title).toBe("Example Feed");
+      expect(lastCall.description).toBe("A test feed");
+      expect(lastCall.siteUrl).toBe("https://example.com");
+      expect(lastCall.lastError).toBeUndefined();
+    });
+
+    it("does NOT overwrite title on subsequent successful refresh (user may have renamed it)", async () => {
+      const feed = await addTestFeed();
+      // Simulate a user rename.
+      feed.title = "My Favorite Feed";
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(ATOM_XML),
+      });
+      await refreshFeed(feed);
+
+      const lastCall = db.updateFeed.mock.calls.at(-1)[0];
+      expect(lastCall.title).toBe("My Favorite Feed");
     });
   });
 });

--- a/tests/e2e/import-recovery.spec.ts
+++ b/tests/e2e/import-recovery.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * E2E: bulk-import a URL list where one URL is rate-limited by the
+ * upstream. The failing URL must:
+ *   1. appear in the sidebar as a placeholder feed (so the user doesn't
+ *      have to manually re-add it),
+ *   2. show the red failed-feed indicator,
+ *   3. recover when the user refreshes after the upstream is reachable.
+ *
+ * Covers the issue #117 follow-up: "feed URLs fail to be imported due
+ * to rate limiting — import them even if they fail, and allow the user
+ * to retry fetching the feed(s) later via the refresh button or the
+ * 'r' key."
+ */
+import { test, expect } from "./fixtures";
+import { SAMPLE_RSS, readTargetUrlFromBody } from "./feed-fixtures";
+
+const URL_LIST = `https://ok.example.com/feed
+https://rate-limited.example.com/feed`;
+
+test.describe("Import recovery — placeholder for rate-limited URLs", () => {
+  test("creates a placeholder, surfaces the error indicator, and recovers on refresh", async ({
+    feedPage: page,
+  }) => {
+    // Phase 1: ok.* succeeds with SAMPLE_RSS; rate-limited.* returns 429.
+    // The release-notes auto-subscribe still has to 404 the way the
+    // feed-fixtures helper does it, otherwise it lands as a duplicate.
+    let phase: "rate-limited" | "recovered" = "rate-limited";
+    await page.route("**/api/feed*", (route) => {
+      const targetUrl = readTargetUrlFromBody(route.request().postData());
+      if (targetUrl.includes("releases.xml")) {
+        route.fulfill({ status: 404, body: "blocked in test" });
+        return;
+      }
+      if (targetUrl.includes("rate-limited.example.com")) {
+        if (phase === "rate-limited") {
+          route.fulfill({
+            status: 429,
+            headers: { "retry-after": "60" },
+            body: "Too Many Requests",
+          });
+          return;
+        }
+        route.fulfill({
+          status: 200,
+          contentType: "text/xml",
+          body: SAMPLE_RSS.replace(/Test Feed/g, "Rate-Limited Feed"),
+        });
+        return;
+      }
+      route.fulfill({
+        status: 200,
+        contentType: "text/xml",
+        body: SAMPLE_RSS,
+      });
+    });
+
+    // Navigate to Settings → Data and paste the URL list.
+    await page.goto("/explore");
+    await page.waitForFunction(
+      () => !document.body.textContent?.includes("Loading"),
+      { timeout: 10000 },
+    );
+    await page.getByRole("button", { name: "Import / Export" }).click();
+    await page.waitForURL(/\/settings\?tab=sync-and-data/);
+    await page.getByRole("radio", { name: "Paste text" }).click();
+    await page
+      .getByPlaceholder(
+        "Paste OPML XML, Pocket HTML export, or feed URLs (one per line)",
+      )
+      .fill(URL_LIST);
+    await page.getByRole("button", { name: "Import feeds" }).click();
+
+    // Results summary shows the 3-bucket breakdown: 1 added, 1 queued.
+    await expect(
+      page.getByText(/1 feed added.*1 queued for retry/i),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/Queued for retry/i)).toBeVisible();
+
+    // Both feeds — the OK one and the placeholder — landed in the sidebar.
+    // Navigate to /feeds and assert.
+    await page.getByRole("button", { name: "Done" }).click();
+    await page.goto("/feeds");
+
+    // Placeholder sidebar label is the URL host because metadata hasn't
+    // been fetched yet. The OK feed shows its parsed <title>.
+    await expect(page.getByText("Test Feed")).toBeVisible();
+    await expect(page.getByText("rate-limited.example.com")).toBeVisible();
+
+    // The placeholder carries the red failed-feed indicator.
+    const failedIndicator = page.getByTestId("failed-feed-indicator");
+    await expect(failedIndicator).toHaveCount(1);
+
+    // Phase 2: flip the mock so rate-limited.* now returns 200. Hit "r"
+    // to refresh all feeds. The placeholder upgrades in place: indicator
+    // clears, title backfills.
+    phase = "recovered";
+    await page.keyboard.press("r");
+
+    await expect(page.getByText("Rate-Limited Feed")).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId("failed-feed-indicator")).toHaveCount(0);
+  });
+});

--- a/tests/e2e/import-recovery.spec.ts
+++ b/tests/e2e/import-recovery.spec.ts
@@ -27,11 +27,22 @@ test.describe("Import recovery — placeholder for rate-limited URLs", () => {
     let phase: "rate-limited" | "recovered" = "rate-limited";
     await page.route("**/api/feed*", (route) => {
       const targetUrl = readTargetUrlFromBody(route.request().postData());
+      // Parse the target URL so we can match on hostname precisely.
+      // `url.includes("rate-limited.example.com")` was flagged by
+      // CodeQL's js/incomplete-url-substring-sanitization rule — and
+      // even outside the rule's intent (this is a test mock, not a
+      // security boundary), precise matching is the right shape.
+      let targetHost = "";
+      try {
+        targetHost = new URL(targetUrl).hostname;
+      } catch {
+        // Non-URL body — fall through to the catch-all 200 fixture.
+      }
       if (targetUrl.includes("releases.xml")) {
         route.fulfill({ status: 404, body: "blocked in test" });
         return;
       }
-      if (targetUrl.includes("rate-limited.example.com")) {
+      if (targetHost === "rate-limited.example.com") {
         if (phase === "rate-limited") {
           route.fulfill({
             status: 429,

--- a/tests/integration/feed-store-db.test.ts
+++ b/tests/integration/feed-store-db.test.ts
@@ -239,6 +239,50 @@ describe("feed-store ↔ db.ts integration", () => {
     });
   });
 
+  describe("addPlaceholderFeed lifecycle", () => {
+    // Issue #117 follow-up: a bulk-import URL hit by a 429 should be
+    // persisted as a placeholder so the user can recover it by hitting
+    // refresh — and the sidebar must visibly surface it. This test
+    // exercises the round-trip through the real encrypted DB.
+    it("persists a placeholder with lastError and survives a reload from the DB", async () => {
+      const result = await useFeedStore
+        .getState()
+        .addPlaceholderFeed(
+          "https://rl.example.com/feed.xml",
+          "HTTP 429 (retry after 60s)",
+        );
+      expect(result.ok).toBe(true);
+
+      // Round-trip through the DB: drop the store snapshot and reload
+      // from the real persisted row. If addPlaceholderFeed silently
+      // skipped the DB, this would be empty.
+      useFeedStore.setState({ feeds: [] });
+      await useFeedStore.getState().loadFeeds();
+
+      const feeds = useFeedStore.getState().feeds;
+      expect(feeds).toHaveLength(1);
+      expect(feeds[0].url).toBe("https://rl.example.com/feed.xml");
+      expect(feeds[0].lastError).toMatch(/HTTP 429/);
+      expect(feeds[0].lastSuccessfulFetchAt).toBeUndefined();
+      // Title was derived from the URL host so the sidebar has a
+      // recognizable label until refresh backfills the real one.
+      expect(feeds[0].title).toBe("rl.example.com");
+    });
+
+    it("returns err when the URL already exists as a real feed", async () => {
+      const existing = makeFeed("a", "Feed A");
+      await dbAddFeed(existing);
+      await useFeedStore.getState().loadFeeds();
+
+      const result = await useFeedStore
+        .getState()
+        .addPlaceholderFeed(existing.url, "boom");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/already exists/i);
+    });
+  });
+
   describe("the contract the mocked tests could not verify", () => {
     it("after a mutation, store snapshot equals what dbGetFeeds() returns", async () => {
       // This is the core invariant the 2026-05-19 incident report named.

--- a/tests/stores/feed-store.test.ts
+++ b/tests/stores/feed-store.test.ts
@@ -45,6 +45,7 @@ vi.mock("../../src/core/storage/db.ts", () => ({
 
 vi.mock("../../src/core/feeds/feed-service.ts", () => ({
   addFeedFlow: vi.fn(),
+  addPlaceholderFeed: vi.fn(),
   refreshFeed: vi.fn(),
   refreshAllFeeds: vi.fn(),
   reloadFeed: vi.fn(),
@@ -66,6 +67,7 @@ vi.mock("../../src/core/sync/sync-service", () => ({
 import { getFeeds, getFeed, removeFeed, updateFeed, getFolders, addFolder, updateFolder, removeFolder } from "../../src/core/storage/db.ts";
 import {
   addFeedFlow,
+  addPlaceholderFeed,
   refreshFeed,
   refreshAllFeeds,
 } from "../../src/core/feeds/feed-service.ts";
@@ -207,6 +209,26 @@ describe("feed-store", () => {
       expect(result).toEqual({ ok: false, error: "not a feed" });
     });
 
+    it("threads reason='fetch-failure' through so callers can create a placeholder", async () => {
+      // The import flow needs to distinguish recoverable failures (HTTP /
+      // network) from permanent ones (not a feed). The reason flag
+      // propagates from addFeedFlow through addFeed without modification.
+      vi.mocked(addFeedFlow).mockResolvedValue({
+        ok: false,
+        error: "HTTP 429",
+        reason: "fetch-failure",
+      });
+
+      const result = await useFeedStore
+        .getState()
+        .addFeed("https://rate-limited.example.com");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("fetch-failure");
+      }
+    });
+
     it("returns ok result on success", async () => {
       const feed = mockFeed("new", "New Feed");
       vi.mocked(addFeedFlow).mockResolvedValue({
@@ -346,6 +368,49 @@ describe("feed-store", () => {
         expect(result.ok).toBe(true);
         expect(addFeedFlow).toHaveBeenCalledOnce();
       });
+    });
+  });
+
+  describe("addPlaceholderFeed", () => {
+    it("delegates to the core helper, reloads feeds, and schedules a sync push", async () => {
+      const placeholder = mockFeed("ph", "rate-limited.example.com");
+      vi.mocked(addPlaceholderFeed).mockResolvedValue({
+        ok: true,
+        value: placeholder,
+      });
+      vi.mocked(getFeeds).mockResolvedValue({
+        ok: true,
+        value: [placeholder],
+      });
+      const scheduleSpy = vi.spyOn(useSyncStore.getState(), "scheduleSyncPush");
+
+      const result = await useFeedStore
+        .getState()
+        .addPlaceholderFeed("https://rate-limited.example.com", "HTTP 429");
+
+      expect(addPlaceholderFeed).toHaveBeenCalledWith(
+        "https://rate-limited.example.com",
+        "HTTP 429",
+      );
+      expect(result.ok).toBe(true);
+      expect(useFeedStore.getState().feeds).toContainEqual(placeholder);
+      expect(scheduleSpy).toHaveBeenCalled();
+    });
+
+    it("returns err and skips reload when the core helper rejects (e.g. duplicate)", async () => {
+      vi.mocked(addPlaceholderFeed).mockResolvedValue({
+        ok: false,
+        error: "A feed with this URL already exists",
+      });
+
+      const result = await useFeedStore
+        .getState()
+        .addPlaceholderFeed("https://dup.example.com", "boom");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/already exists/i);
+      }
     });
   });
 

--- a/tests/stores/import-store.test.ts
+++ b/tests/stores/import-store.test.ts
@@ -3,6 +3,7 @@ import {
   useImportStore,
   selectTotalCount,
   selectSuccessCount,
+  selectPlaceholderCount,
   selectFailureCount,
   selectCurrentUrl,
 } from "../../src/stores/import-store.ts";
@@ -237,6 +238,40 @@ describe("import-store", () => {
       });
 
       expect(selectCurrentUrl(useImportStore.getState())).toBeNull();
+    });
+
+    it("counts placeholder results separately from fully-imported successes", () => {
+      // Three buckets: full-success (green), placeholder (amber — queued
+      // for retry on next refresh), and failure (red — rejected).
+      useImportStore.getState().startImport([
+        "https://a.com/feed",
+        "https://b.com/feed",
+        "https://c.com/feed",
+        "https://d.com/feed",
+      ]);
+      useImportStore
+        .getState()
+        .recordResult({ url: "https://a.com/feed", success: true });
+      useImportStore.getState().recordResult({
+        url: "https://b.com/feed",
+        success: true,
+        placeholder: true,
+      });
+      useImportStore.getState().recordResult({
+        url: "https://c.com/feed",
+        success: true,
+        placeholder: true,
+      });
+      useImportStore.getState().recordResult({
+        url: "https://d.com/feed",
+        success: false,
+        error: "not a feed",
+      });
+
+      const state = useImportStore.getState();
+      expect(selectSuccessCount(state)).toBe(1);
+      expect(selectPlaceholderCount(state)).toBe(2);
+      expect(selectFailureCount(state)).toBe(1);
     });
   });
 });


### PR DESCRIPTION
Follow-up to issue #117. Bulk OPML / URL-list imports on self-host
trip upstream rate-limits on fresh datacenter / residential IPs, and
any URL that gets a 429 was silently dropped. Users had to manually
re-add the failed URLs and re-place them in folders.

What

- `Feed.lastError?: string` joins `lastFetchedAt` / `lastSuccessfulFetchAt`
  as a first-class freshness field. Set by the existing chokepoint
  (`persistFreshness` in `feed-service.ts`) on failed/successful refresh
  so every code path agrees.
- `addFeedFlow` flags recoverable failures (HTTP error / network error)
  with `reason: "fetch-failure"` on its err branch. Permanent failures
  (parse / discovery / duplicate / quota) stay unflagged because retry
  cannot recover them.
- New `addPlaceholderFeed(url, error)` in `feed-service.ts` persists a
  Feed row with a URL-derived title (sidebar gets a recognizable label)
  and `lastError` set. Plumbed through `feed-store` as a sibling action.
- Import view branches on the new discriminator: ok → record success,
  fetch-failure → call `addPlaceholderFeed` then move to folder, other
  err → record failure with no row. Folder structure is preserved for
  placeholders so the recovered feed lands where the user intended.
- `refreshFeed` clears `lastError` on success. On the first-ever
  successful refresh (placeholder → real feed), it also backfills
  title/description/siteUrl from the parsed payload. Subsequent
  successes leave metadata alone so a user's rename is never clobbered.
- Sidebar `feed-item` shows a red `XCircle` indicator when
  `lastError && !lastSuccessfulFetchAt` — distinct from the existing
  amber stale indicator. Tooltip surfaces the error message; the
  existing right-click → Refresh is the recovery affordance.
- Import-results shows a 3-bucket breakdown: "N feeds added, M queued
  for retry, K failed" + an explanatory line pointing the user at the
  `r` shortcut.

Why this shape (not a parallel "placeholder" concept):

A placeholder is just a regular Feed whose `lastSuccessfulFetchAt` is
undefined. The existing freshness model already encoded the right
distinction; adding `lastError` makes the failure visible to the UI
without inventing a sidecar table or a boolean flag. Sync rides for
free — `VaultData.feeds` is the same shape, so a placeholder on one
device shows up correctly on every other device.

Tests

- `tests/core/feeds/feed-service.test.js` — reason discriminator on
  HTTP/network errors, parse-failures stay unflagged,
  `addPlaceholderFeed` lifecycle, `refreshFeed` clears `lastError`
  and backfills metadata on first-ever success.
- `tests/integration/feed-store-db.test.ts` — placeholder lifecycle
  round-trips through the real encrypted DB via fake-indexeddb (mock
  at the boundary, per CLAUDE.md).
- `tests/components/settings/import-view-placeholder.test.tsx` —
  end-to-end branching of the three import outcomes including folder
  placement.
- `tests/components/sidebar/feed-item.test.tsx` — error indicator
  renders only for placeholder feeds, not stale or healthy ones.
- `tests/e2e/import-recovery.spec.ts` — Playwright: 429 → placeholder
  → "r" → recovered, against the dev server.