### PR TITLE
fix(gates): close prefetch + rules gating holes for free users

### DIFF
--- a/src/components/feeds/feed-settings-dialog.tsx
+++ b/src/components/feeds/feed-settings-dialog.tsx
@@ -44,6 +44,7 @@ import { Button } from "@/components/ui/button.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
 import { Switch } from "@/components/ui/switch.tsx";
+import { useFeatureGate } from "@/hooks/use-feature-gate.ts";
 import type { Feed } from "@/types/index.ts";
 
 export function FeedSettingsDialog() {
@@ -151,6 +152,7 @@ function NameSection({ feed }: { feed: Feed }) {
 function DisplaySection({ feed }: { feed: Feed }) {
   const setFeedPreferFullText = useFeedStore((s) => s.setFeedPreferFullText);
   const setFeedPrefetchEnabled = useFeedStore((s) => s.setFeedPrefetchEnabled);
+  const prefetchGate = useFeatureGate("offline-prefetch");
 
   return (
     <section className="space-y-3">
@@ -163,15 +165,57 @@ function DisplaySection({ feed }: { feed: Feed }) {
           checked={Boolean(feed.preferFullText)}
           onCheckedChange={(v) => setFeedPreferFullText(feed.id, v)}
         />
-        <ToggleRow
-          id="feed-settings-prefetch"
-          label="Prefetch full text"
-          description="Pre-extract this feed's recent articles on refresh so they read offline."
-          checked={Boolean(feed.prefetchEnabled)}
-          onCheckedChange={(v) => setFeedPrefetchEnabled(feed.id, v)}
-        />
+        {prefetchGate.enabled ? (
+          <ToggleRow
+            id="feed-settings-prefetch"
+            label="Prefetch full text"
+            description="Pre-extract this feed's recent articles on refresh so they read offline."
+            checked={Boolean(feed.prefetchEnabled)}
+            onCheckedChange={(v) => setFeedPrefetchEnabled(feed.id, v)}
+          />
+        ) : (
+          <LockedRow
+            label="Prefetch full text"
+            description="Pre-extract this feed's recent articles on refresh so they read offline."
+            dataTestId="feed-settings-prefetch-locked"
+            onUpgrade={prefetchGate.promptUpgrade}
+          />
+        )}
       </div>
     </section>
+  );
+}
+
+function LockedRow({
+  label,
+  description,
+  dataTestId,
+  onUpgrade,
+}: {
+  label: string;
+  description: string;
+  dataTestId: string;
+  onUpgrade: () => void;
+}) {
+  return (
+    <div
+      className="flex items-start justify-between gap-3"
+      data-testid={dataTestId}
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{label}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onUpgrade}
+        className="shrink-0"
+      >
+        Personal
+      </Button>
+    </div>
   );
 }
 
@@ -235,6 +279,7 @@ function FolderSection({ feed }: { feed: Feed }) {
 
 function RulesSection({ feed }: { feed: Feed }) {
   const openRulesEditor = useFeedStore((s) => s.openRulesEditor);
+  const rulesGate = useFeatureGate("rules");
   const ruleCount = feed.rules?.length ?? 0;
 
   return (
@@ -243,18 +288,31 @@ function RulesSection({ feed }: { feed: Feed }) {
       <div className="flex items-center justify-between rounded-md border bg-card p-3">
         <p className="text-sm text-muted-foreground">
           {ruleCount === 0
-            ? "No rules. Auto-mute, star, or route articles."
+            ? "Auto-mute, star, or route articles by title, author, or content."
             : `${ruleCount} rule${ruleCount === 1 ? "" : "s"} active.`}
         </p>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          data-testid="feed-settings-manage-rules"
-          onClick={() => openRulesEditor(feed.id)}
-        >
-          Manage rules…
-        </Button>
+        {rulesGate.enabled ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="feed-settings-manage-rules"
+            onClick={() => openRulesEditor(feed.id)}
+          >
+            Manage rules…
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="feed-settings-rules-locked"
+            onClick={rulesGate.promptUpgrade}
+            className="shrink-0"
+          >
+            Personal
+          </Button>
+        )}
       </div>
     </section>
   );

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -169,6 +169,16 @@ function sortFoldersByName(folders: Folder[]): Folder[] {
   return [...folders].sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** True when the current session may enable offline-prefetch on a feed. */
+function isPrefetchGateOpen(): boolean {
+  return gateState(
+    "offline-prefetch",
+    useLicenseStore.getState().tier,
+    isSelfHosted(),
+    isPaidTierActive(),
+  ).enabled;
+}
+
 /** True when the current session may mutate per-feed rules. */
 function isRulesGateOpen(): boolean {
   return gateState(
@@ -411,6 +421,16 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
   },
 
   setFeedPrefetchEnabled: async (feedId, value) => {
+    // Defense-in-depth: the dialog UI gates this affordance too. A
+    // free user reaching the mutator via a console/keyboard binding
+    // gets the same toast + no-op as a free user clicking the
+    // (hidden) Switch. Without this, Feed.prefetchEnabled persists
+    // for a free user even though schedulePrefetch never honours
+    // it — visible state would silently contradict actual behaviour.
+    if (!isPrefetchGateOpen()) {
+      toast("Offline prefetch is a Personal feature. Subscribe to unlock.");
+      return;
+    }
     const feedResult = await getFeed(feedId);
     if (!feedResult.ok) return;
     await dbUpdateFeed({

--- a/tests/components/feeds/feed-settings-dialog.test.tsx
+++ b/tests/components/feeds/feed-settings-dialog.test.tsx
@@ -46,6 +46,12 @@ vi.mock("@/core/sync/sync-service", () => ({
   importVault: vi.fn(),
 }));
 
+vi.mock("@/core/features/paid-tier-active.ts", () => ({
+  isPaidTierActive: () => true,
+}));
+
+import { useLicenseStore } from "@/stores/license-store.ts";
+
 function feed(overrides: Partial<Feed> = {}): Feed {
   return {
     id: "f-tech",
@@ -91,6 +97,7 @@ describe("FeedSettingsDialog", () => {
     removeFeed = vi.fn().mockResolvedValue(undefined);
     openRulesEditor = vi.fn();
 
+    useLicenseStore.setState({ tier: "personal" });
     useFeedStore.setState({
       feeds: [feed()],
       folders: [],
@@ -237,5 +244,54 @@ describe("FeedSettingsDialog", () => {
     await user.click(cancel);
 
     expect(removeFeed).not.toHaveBeenCalled();
+  });
+
+  describe("free-tier gating", () => {
+    it("Prefetch full text Switch is not rendered for free users — replaced by an upgrade badge", () => {
+      useLicenseStore.setState({ tier: "free" });
+      useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+      renderDialog();
+
+      expect(screen.queryByTestId("feed-settings-prefetch")).toBeNull();
+      // A locked-state badge replaces the toggle so the user knows
+      // the feature exists but is paid-only.
+      expect(
+        screen.getByTestId("feed-settings-prefetch-locked"),
+      ).toBeInTheDocument();
+    });
+
+    it("Prefer full text Switch stays visible for free users (it's an always-free toggle)", () => {
+      useLicenseStore.setState({ tier: "free" });
+      useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+      renderDialog();
+
+      expect(
+        screen.getByTestId("feed-settings-prefer-full-text"),
+      ).toBeInTheDocument();
+    });
+
+    it("Manage rules button is not rendered for free users — replaced by an upgrade badge", () => {
+      useLicenseStore.setState({ tier: "free" });
+      useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+      renderDialog();
+
+      expect(screen.queryByTestId("feed-settings-manage-rules")).toBeNull();
+      expect(
+        screen.getByTestId("feed-settings-rules-locked"),
+      ).toBeInTheDocument();
+    });
+
+    it("Personal users see both the Prefetch Switch and the Manage rules button as normal", () => {
+      useLicenseStore.setState({ tier: "personal" });
+      useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+      renderDialog();
+
+      expect(
+        screen.getByTestId("feed-settings-prefetch"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("feed-settings-manage-rules"),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/tests/stores/feed-store-prefetch-toggle.test.ts
+++ b/tests/stores/feed-store-prefetch-toggle.test.ts
@@ -53,7 +53,16 @@ vi.mock("../../src/core/sync/sync-service", () => ({
   importVault: vi.fn(),
 }));
 
+// Force paid-tier active so the offline-prefetch gate actually
+// enforces tier requirements; without this, VITE_PAID_TIER_VISIBLE
+// is unset and the gate "relaxes" — all shipped Personal features
+// become available to free users with reason: "paid-tier-inactive".
+vi.mock("../../src/core/features/paid-tier-active.ts", () => ({
+  isPaidTierActive: () => true,
+}));
+
 import { useFeedStore } from "../../src/stores/feed-store.ts";
+import { useLicenseStore } from "../../src/stores/license-store.ts";
 import { useSyncStore } from "../../src/stores/sync-store.ts";
 import * as db from "../../src/core/storage/db.ts";
 
@@ -83,6 +92,7 @@ describe("feed-store setFeedPrefetchEnabled", () => {
     dbMock._reset();
     vi.clearAllMocks();
     useFeedStore.setState({ feeds: [], folders: [] });
+    useLicenseStore.setState({ tier: "personal" });
     pushSpy = vi
       .spyOn(useSyncStore.getState(), "scheduleSyncPush")
       .mockImplementation(() => {});
@@ -119,5 +129,25 @@ describe("feed-store setFeedPrefetchEnabled", () => {
   it("is a no-op for unknown feed ids", async () => {
     await useFeedStore.getState().setFeedPrefetchEnabled("ghost", true);
     expect(dbMock._feeds.size).toBe(0);
+  });
+
+  describe("gate-locked for free tier", () => {
+    it("free user toggling prefetchEnabled = true leaves the feed unchanged", async () => {
+      useLicenseStore.setState({ tier: "free" });
+      dbMock._seed(feed("f1"));
+
+      await useFeedStore.getState().setFeedPrefetchEnabled("f1", true);
+
+      expect(dbMock._feeds.get("f1")?.prefetchEnabled).toBeUndefined();
+    });
+
+    it("free user does not schedule a sync push (no state change to propagate)", async () => {
+      useLicenseStore.setState({ tier: "free" });
+      dbMock._seed(feed("f1"));
+
+      await useFeedStore.getState().setFeedPrefetchEnabled("f1", true);
+
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes two paid-feature gating holes turned up by an audit during the FeedSettingsDialog work.

**The real bug**: a free user could flip the per-feed "Prefetch full text" toggle and `Feed.prefetchEnabled` would persist as `true` in the encrypted vault. `schedulePrefetch` has its own `offline-prefetch` gate so no actual prefetching happened — but the toggle still read as on, and the flag synced to every other device the user signed into. Visible state silently contradicted actual behaviour. This was pre-existing — the toggle in the old sidebar dropdown shared the hole; FeedSettingsDialog inherited it.

**The soft issue**: free users could open "Manage rules…" from FeedSettingsDialog, see the RulesEditorDialog, try to add a rule, and only then hit a toast on save. The smart-filter path handles this better (sidebar entry hidden entirely). This PR brings rules in line.

## Commits (2)

1. **`fix(prefetch): gate setFeedPrefetchEnabled on offline-prefetch`** — store mutator now gates via `isPrefetchGateOpen()` and toasts on locked. Mirrors the smart-filter and rules mutator pattern.
2. **`fix(feed-settings): hide gated affordances behind upgrade prompts`** — the Prefetch Switch and the "Manage rules…" button each render as a small "Personal" button (linking to the upgrade flow) when their gate is closed. Prefer full text stays visible (always-free).

## Stack

Branched from `claude/feed-settings-cog` (PR #139). When that merges into main, this PR's base auto-updates to main and the diff shrinks to just these two commits.

## Test plan

- [x] `npm test` exits 0 (2834 passing, 31 smoke skipped, no regressions, no unhandled errors)
- [x] `npx tsc --noEmit` clean
- [x] pre-push hook passed
- [x] Store gate: 2 new tests — free user's flip leaves `Feed.prefetchEnabled` undefined; no sync push scheduled
- [x] UI gate: 4 new tests — Prefetch Switch hidden for free (locked badge instead), Prefer Switch always visible, Manage rules hidden for free (locked badge), both visible for Personal
- [ ] Manual smoke against `npm run dev` — recommend before merge

## Audit status across all paid features

| Feature | Matrix | Store mutator | UI affordance | Status |
|---|---|---|---|---|
| Smart filters | Personal+ | ✓ (rejectIfGateClosed) | ✓ (sidebar-body) | Solid |
| Rules (per-feed) | Personal+ | ✓ (isRulesGateOpen) | ✓ (this PR) | Solid |
| Mute (rule action) | inherits | inherits | inherits | Fine |
| Per-feed prefetch | Personal+ | ✓ (this PR) | ✓ (this PR) | Solid |
| Auto-organize | Personal+ | ✓ existing | ✓ existing | Solid (pre-existing) |

No other holes found.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkuzqkyNGYxZsEdXhkPGMr)_