### PR TITLE
fix(e2e): retarget feed-management delete tests at the floating cog UI

### DIFF
--- a/tests/e2e/feed-management.spec.ts
+++ b/tests/e2e/feed-management.spec.ts
@@ -36,15 +36,19 @@ test.describe("Feed management", () => {
     await mockFeedEndpoint(page, SAMPLE_RSS);
     await addFeedViaUI(page, "https://example.com/feed");
 
-    // Open the dropdown menu for the feed
-    await page.getByRole("button", { name: "More" }).click();
-    await page.getByRole("menuitem", { name: /delete/i }).click();
+    // Ensure the feed is selected so the context-aware settings pill renders.
+    await selectFeedInSidebar(page, "Test Feed");
 
-    // Confirmation dialog should appear
-    await expect(page.getByText(/Remove.*Test Feed/)).toBeVisible();
+    // Open per-feed settings via the floating cog above the article list.
+    await page.getByTestId("settings-pill").click();
+    await page.getByTestId("feed-settings-delete").click();
+
+    // Confirmation dialog should appear with the feed title in the body.
+    await expect(page.getByText("Delete this feed?")).toBeVisible();
+    await expect(page.getByText(/Test Feed.*cached article/)).toBeVisible();
 
     // Confirm removal
-    await page.getByRole("button", { name: "Remove" }).click();
+    await page.getByTestId("feed-settings-delete-confirm").click();
 
     // Feed should be gone
     await expect(
@@ -56,9 +60,14 @@ test.describe("Feed management", () => {
     await mockFeedEndpoint(page, SAMPLE_RSS);
     await addFeedViaUI(page, "https://example.com/feed");
 
-    await page.getByRole("button", { name: "More" }).click();
-    await page.getByRole("menuitem", { name: /delete/i }).click();
-    await page.getByRole("button", { name: "Cancel" }).click();
+    await selectFeedInSidebar(page, "Test Feed");
+
+    await page.getByTestId("settings-pill").click();
+    await page.getByTestId("feed-settings-delete").click();
+    await page.getByTestId("feed-settings-delete-cancel").click();
+
+    // Close the settings dialog so the sidebar is uncovered.
+    await page.keyboard.press("Escape");
 
     // Feed should still be there
     await expect(


### PR DESCRIPTION
**What**
"remove feed with confirmation" and "cancel remove keeps feed" timed out
waiting for a `getByRole("button", { name: "More" })` that no longer
exists in shard 3/6 of the desktop project.

**Why**
Commit 5f39403 ("floating cog + sort pills replace sidebar dropdowns")
removed the per-feed three-dot dropdown from FeedItem. The delete action
now lives in FeedSettingsDialog, opened from the context-aware floating
cog (`data-testid="settings-pill"`) above the article list. The E2E
tests were not updated alongside that UI change.

**Fix**
Select the freshly added feed in the sidebar (so the context-aware pill
renders), open settings via `getByTestId("settings-pill")`, click
`feed-settings-delete`, then confirm/cancel via
`feed-settings-delete-confirm` / `feed-settings-delete-cancel`. Match
the new dialog copy ("Delete this feed?" + "{title} … cached article…").
Press Escape after Cancel so the settings dialog stops covering the
sidebar before we assert the feed is still listed.

**Prevention**
data-testids are now the locators of record for this flow, so a future
copy tweak won't break the test. The unit suite already exercises every
button in FeedSettingsDialog (tests/components/feeds/feed-settings-dialog.test.tsx);
this E2E confirms the cog → dialog → confirm chain end-to-end.