### PR TITLE
fix(e2e): retarget feed-management delete tests at the floating cog UI

### DIFF
--- a/tests/e2e/feed-management.spec.ts
+++ b/tests/e2e/feed-management.spec.ts
@@ -44,8 +44,12 @@ test.describe("Feed management", () => {
     await page.getByTestId("feed-settings-delete").click();
 
     // Confirmation dialog should appear with the feed title in the body.
-    await expect(page.getByText("Delete this feed?")).toBeVisible();
-    await expect(page.getByText(/Test Feed.*cached article/)).toBeVisible();
+    // Scope to the AlertDialog so the regex doesn't also match the outer
+    // FeedSettingsDialog (which contains the AlertDialog's text in its subtree).
+    const confirmDialog = page.getByRole("alertdialog");
+    await expect(confirmDialog).toBeVisible();
+    await expect(confirmDialog).toContainText("Delete this feed?");
+    await expect(confirmDialog).toContainText(/Test Feed.*cached article/);
 
     // Confirm removal
     await page.getByTestId("feed-settings-delete-confirm").click();


### PR DESCRIPTION
## Summary

Shard 3/6 of the desktop Playwright project was failing because two
`feed-management.spec.ts` tests still drove the old per-feed three-dot
dropdown (`getByRole("button", { name: "More" })`). That dropdown was
removed in #139 ("floating cog + sort pills replace sidebar dropdowns")
— delete now lives in `FeedSettingsDialog`, opened from the context-aware
floating cog above the article list.

- Select the freshly-added feed in the sidebar (so the context-aware
  pill renders), then drive: `settings-pill` → `feed-settings-delete`
  → `feed-settings-delete-confirm` / `feed-settings-delete-cancel`.
- Match the new copy (`"Delete this feed?"` + `"{title} … cached
  article …"`), scoped to `getByRole("alertdialog")` so the nested
  AlertDialog text doesn't also match the outer FeedSettingsDialog
  (strict-mode violation).
- After Cancel, press Escape so the parent settings dialog stops
  covering the sidebar before we assert the feed is still listed.

## Test plan

- [ ] `npx playwright test --project=desktop --shard=3/6 --max-failures=5` passes locally / in CI
- [ ] Full E2E suite stays green (no other shards regress)
- [ ] Unit/RTL coverage for the delete flow continues to live in `tests/components/feeds/feed-settings-dialog.test.tsx`

https://claude.ai/code/session_014kEme1csGmHj2eiGo56syL

---
_Generated by [Claude Code](https://claude.ai/code/session_014kEme1csGmHj2eiGo56syL)_