### PR TITLE
feat(ui): cog + sort pills in feed title bar, icon-only with tap-expand

### DIFF
--- a/src/components/articles/article-list-controls.tsx
+++ b/src/components/articles/article-list-controls.tsx
@@ -1,35 +1,149 @@
+import { Layers, Star, Filter, Folder as FolderIcon } from "lucide-react";
+import { useArticleStore } from "@/stores/article-store.ts";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
+import { useIsMobile } from "@/hooks/use-mobile.ts";
+import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
 import { SortPill } from "./sort-pill.tsx";
 import { SettingsPill } from "./settings-pill.tsx";
+import {
+  ALL_FEEDS_ID,
+  STARRED_FEED_ID,
+  isFolderFeedId,
+  fromFolderFeedId,
+  isFilterFeedId,
+  fromFilterFeedId,
+} from "@/utils/constants.ts";
 import type { ArticleSortMode } from "@/types/index.ts";
 
-/**
- * Sticky header inside the article-list scroll container. Hosts the
- * floating control pills (sort + settings cog). Right-aligned flex
- * row with a gap so pills can sit side-by-side without overlapping;
- * each expands independently on hover.
- *
- * The container itself is `pointer-events-none` so the area between
- * pills stays scroll-friendly; the pills opt back into pointer events.
- *
- * SettingsPill is added in a later commit — context-aware (hides on
- * aggregated views) and routes the cog click to the right dialog.
- */
 interface ArticleListControlsProps {
   sortMode: ArticleSortMode;
   onSortChange: (mode: ArticleSortMode) => void;
 }
 
+/**
+ * Sticky title bar at the top of the article-list panel. Shows the
+ * current feed indicator on the left and the floating control pills
+ * (cog + sort) on the right. Pills are icon-only at rest and expand
+ * on hover / focus / tap; the flex layout keeps them from
+ * overlapping when one expands (the rightmost stays anchored at the
+ * right edge, the leftmost shifts).
+ *
+ * Hidden on mobile — the global header in `app-layout.tsx` carries
+ * the breadcrumb + pills there, so there's nothing left to show here.
+ */
 export function ArticleListControls({
   sortMode,
   onSortChange,
 }: ArticleListControlsProps) {
+  const isMobile = useIsMobile();
+  if (isMobile) return null;
+
   return (
     <div
       data-testid="article-list-controls"
-      className="sticky top-0 z-10 flex justify-end items-center gap-2 px-2 py-1 bg-background/80 backdrop-blur-sm pointer-events-none"
+      className="sticky top-0 z-10 flex items-center gap-2 px-3 h-12 border-b bg-background/80 backdrop-blur-sm"
+    >
+      <FeedIndicator />
+      <div className="ml-auto flex items-center gap-2 pointer-events-auto">
+        <SettingsPill />
+        <SortPill mode={sortMode} onChange={onSortChange} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Inline feed indicator — icon + truncated name for whichever view
+ * is selected. Mirrors HeaderBreadcrumbs's virtual-feed resolution
+ * but drops the article slot (the article-list view is already
+ * showing the articles; surfacing one in a breadcrumb here would
+ * duplicate context with the reader panel).
+ */
+function FeedIndicator() {
+  const feeds = useFeedStore((s) => s.feeds);
+  const folders = useFeedStore((s) => s.folders);
+  const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
+  const smartFilters = useSmartFilterStore((s) => s.filters);
+
+  if (!selectedFeedId) return <span className="text-sm font-medium" />;
+
+  if (selectedFeedId === ALL_FEEDS_ID) {
+    return (
+      <Label icon={<Layers className="size-4 shrink-0" />}>All items</Label>
+    );
+  }
+  if (selectedFeedId === STARRED_FEED_ID) {
+    return (
+      <Label
+        icon={<Star className="size-4 shrink-0 text-amber-500" />}
+      >
+        Starred
+      </Label>
+    );
+  }
+  if (isFolderFeedId(selectedFeedId)) {
+    const id = fromFolderFeedId(selectedFeedId);
+    const folder = folders.find((f) => f.id === id);
+    return (
+      <Label
+        icon={<FolderIcon className="size-4 shrink-0 text-violet-500" />}
+      >
+        {folder?.name ?? "Folder"}
+      </Label>
+    );
+  }
+  if (isFilterFeedId(selectedFeedId)) {
+    const id = fromFilterFeedId(selectedFeedId);
+    const filter = smartFilters.find((f) => f.id === id);
+    return (
+      <Label icon={<Filter className="size-4 shrink-0 text-violet-500" />}>
+        {filter?.name ?? "Filter"}
+      </Label>
+    );
+  }
+
+  const feed = feeds.find((f) => f.id === selectedFeedId);
+  if (!feed) return <span className="text-sm font-medium" />;
+  return (
+    <Label icon={<FeedFavicon siteUrl={feed.siteUrl} className="size-4 shrink-0" />}>
+      {feed.title}
+    </Label>
+  );
+}
+
+function Label({
+  icon,
+  children,
+}: {
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+      {icon}
+      <span className="truncate">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * Bare pair of pills (cog + sort), no title, no sticky positioning.
+ * Mounted in the mobile global header alongside HeaderBreadcrumbs so
+ * the user reaches feed/folder/filter settings from the same bar that
+ * shows where they are. The full title-bar shape
+ * (ArticleListControls) is desktop-only.
+ */
+export function MobileHeaderPills() {
+  const articleSortMode = useArticleStore((s) => s.articleSortMode);
+  const setArticleSortMode = useArticleStore((s) => s.setArticleSortMode);
+  return (
+    <div
+      data-testid="mobile-header-pills"
+      className="flex items-center gap-2"
     >
       <SettingsPill />
-      <SortPill mode={sortMode} onChange={onSortChange} />
+      <SortPill mode={articleSortMode} onChange={setArticleSortMode} />
     </div>
   );
 }

--- a/src/components/articles/settings-pill.tsx
+++ b/src/components/articles/settings-pill.tsx
@@ -2,7 +2,6 @@ import { Settings as SettingsIcon } from "lucide-react";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
 import { ExpandingPill } from "@/components/ui/expanding-pill.tsx";
-import { useIsMobile } from "@/hooks/use-mobile.ts";
 import {
   ALL_FEEDS_ID,
   STARRED_FEED_ID,
@@ -27,7 +26,6 @@ export function SettingsPill() {
   const openFolderSettings = useFeedStore((s) => s.openFolderSettings);
   const filters = useSmartFilterStore((s) => s.filters);
   const openEditor = useSmartFilterStore((s) => s.openEditor);
-  const isMobile = useIsMobile();
 
   const target = resolveTarget({
     selectedFeedId,
@@ -58,7 +56,6 @@ export function SettingsPill() {
       icon={<SettingsIcon />}
       label={target.label}
       aria-label={target.label}
-      alwaysExpanded={isMobile}
       dataTestId="settings-pill"
       onClick={handleClick}
     />

--- a/src/components/articles/sort-pill.tsx
+++ b/src/components/articles/sort-pill.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.tsx";
 import { ExpandingPill } from "@/components/ui/expanding-pill.tsx";
-import { useIsMobile } from "@/hooks/use-mobile.ts";
 import type { ArticleSortMode } from "@/types/index.ts";
 import { ARTICLE_SORT_MODES } from "@/types/index.ts";
 
@@ -24,11 +23,10 @@ interface SortPillProps {
 
 /**
  * Article-list sort selector built on the ExpandingPill primitive.
- * Replaces the older compact text+icon SortMenu. Mobile always shows
- * the label (no hover semantics); desktop expands on hover.
+ * Icon-only on every viewport; expands on hover (desktop), focus
+ * (keyboard), or press (mobile tap).
  */
 export function SortPill({ mode, onChange, dataTestId }: SortPillProps) {
-  const isMobile = useIsMobile();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -36,7 +34,6 @@ export function SortPill({ mode, onChange, dataTestId }: SortPillProps) {
           icon={<ArrowUpDown />}
           label={SORT_LABELS[mode]}
           aria-label={`Sort: ${SORT_LABELS[mode]}`}
-          alwaysExpanded={isMobile}
           dataTestId={dataTestId}
         />
       </DropdownMenuTrigger>

--- a/src/components/ui/expanding-pill.tsx
+++ b/src/components/ui/expanding-pill.tsx
@@ -3,10 +3,11 @@ import { cn } from "@/lib/utils";
 
 /**
  * Circle-to-pill button. Default state is a circular icon-only button;
- * hover (desktop) or keyboard focus-visible expands the label slot via
- * a CSS `max-width` animation, growing the pill rightward without
- * shifting the icon. Set `alwaysExpanded` for the mobile path where
- * hover doesn't apply.
+ * hover (desktop), keyboard focus-visible, or pointer press (mobile
+ * tap) expands the label slot via a CSS `max-width` animation,
+ * growing the pill rightward without shifting the icon. The
+ * `alwaysExpanded` prop forces the visible state — mostly an escape
+ * hatch for tests; the new default works on every viewport.
  *
  * Pattern is new for this codebase — see the cog/sort floating pills
  * at the top of the article list for the primary consumers. Keep the
@@ -68,9 +69,11 @@ export const ExpandingPill = React.forwardRef<
           "transition-[max-width,padding] duration-200 ease-out",
           alwaysExpanded
             ? "max-w-[160px] pl-2"
-            : // Collapsed by default; expand on group-hover (desktop) or
-              // when the button itself becomes focus-visible (keyboard).
-              "max-w-0 group-hover:max-w-[160px] group-hover:pl-2 group-focus-visible:max-w-[160px] group-focus-visible:pl-2",
+            : // Collapsed by default. Expand on:
+              //  - group-hover (desktop pointer)
+              //  - group-focus-visible (keyboard focus)
+              //  - group-active (mobile tap, while the press is held)
+              "max-w-0 group-hover:max-w-[160px] group-hover:pl-2 group-focus-visible:max-w-[160px] group-focus-visible:pl-2 group-active:max-w-[160px] group-active:pl-2",
         )}
       >
         {label}

--- a/src/pages/app-layout.tsx
+++ b/src/pages/app-layout.tsx
@@ -15,6 +15,7 @@ import { SidebarProvider } from "@/components/ui/sidebar.tsx";
 import { AppSidebar } from "@/components/layout/app-sidebar.tsx";
 import { HeaderBreadcrumbs } from "@/components/layout/header-breadcrumbs.tsx";
 import { MobileNavDrawer } from "@/components/layout/mobile-nav-drawer.tsx";
+import { MobileHeaderPills } from "@/components/articles/article-list-controls.tsx";
 
 /**
  * Listens for the feedzero:toggle-sidebar event and toggles the sidebar.
@@ -99,6 +100,7 @@ export function AppLayout() {
       <div className="flex flex-col h-dvh overflow-hidden bg-background">
         <header className="flex h-12 shrink-0 items-center gap-2 border-b px-3 z-10 bg-background">
           <HeaderBreadcrumbs fallback={feedId ? "Articles" : "Feeds"} />
+          <MobileHeaderPills />
         </header>
         <Outlet />
         <MobileNavDrawer onFeedSelect={handleFeedSelect} />

--- a/tests/components/articles/article-list-controls.test.tsx
+++ b/tests/components/articles/article-list-controls.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * ArticleListControls is the desktop title bar at the top of the
+ * article-list panel. Shows the current feed indicator on the left
+ * and the cog + sort pills on the right. Hidden on mobile — the
+ * global header in app-layout carries the breadcrumb + pills there.
+ *
+ * MobileHeaderPills is the bare pills-only wrapper mounted in the
+ * mobile global header.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import {
+  ArticleListControls,
+  MobileHeaderPills,
+} from "@/components/articles/article-list-controls.tsx";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import { useArticleStore } from "@/stores/article-store.ts";
+import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
+import {
+  ALL_FEEDS_ID,
+  STARRED_FEED_ID,
+  toFolderFeedId,
+  toFilterFeedId,
+} from "@/utils/constants.ts";
+import type { Feed, Folder, SmartFilter } from "@/types/index.ts";
+
+vi.mock("@/core/storage/db.ts", () => ({
+  getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getFeed: vi.fn(),
+  updateFeed: vi.fn(),
+  getFolders: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  updateFolder: vi.fn(),
+  removeFolder: vi.fn(),
+  removeFeed: vi.fn(),
+  addFolder: vi.fn(),
+  getSmartFilters: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+}));
+
+vi.mock("@/core/sync/sync-service", () => ({
+  pushVault: vi.fn(),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+const { useIsMobileSpy } = vi.hoisted(() => ({
+  useIsMobileSpy: vi.fn(() => false),
+}));
+
+vi.mock("@/hooks/use-mobile.ts", () => ({
+  useIsMobile: () => useIsMobileSpy(),
+}));
+
+function feed(id: string, title: string): Feed {
+  return {
+    id,
+    url: `https://${id}.example.com/feed.xml`,
+    title,
+    description: "",
+    siteUrl: `https://${id}.example.com`,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function folder(id: string, name: string): Folder {
+  return { id, name, createdAt: 0 };
+}
+
+function smartFilter(id: string, name: string): SmartFilter {
+  return {
+    id,
+    name,
+    rule: { kind: "group", match: "all", children: [] },
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function renderControls() {
+  return render(
+    <MemoryRouter>
+      <ArticleListControls sortMode="newest" onSortChange={vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ArticleListControls (desktop title bar)", () => {
+  beforeEach(() => {
+    useIsMobileSpy.mockReturnValue(false);
+    useFeedStore.setState({
+      feeds: [feed("f-tech", "Tech Crunchies")],
+      folders: [folder("folder-tech", "Tech")],
+      selectedFeedId: null,
+    });
+    useSmartFilterStore.setState({
+      filters: [smartFilter("filter-recent", "Recent")],
+    });
+    useArticleStore.setState({ articleSortMode: "newest" });
+  });
+
+  it("renders on desktop with both pills", () => {
+    useFeedStore.setState({ selectedFeedId: "f-tech" });
+    renderControls();
+    expect(screen.getByTestId("article-list-controls")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-pill")).toBeInTheDocument();
+    expect(screen.getByLabelText(/sort/i)).toBeInTheDocument();
+  });
+
+  it("hides entirely on mobile (returns null)", () => {
+    useIsMobileSpy.mockReturnValue(true);
+    useFeedStore.setState({ selectedFeedId: "f-tech" });
+    renderControls();
+    expect(screen.queryByTestId("article-list-controls")).toBeNull();
+  });
+
+  it("shows the feed title on a single feed view", () => {
+    useFeedStore.setState({ selectedFeedId: "f-tech" });
+    renderControls();
+    expect(screen.getByText("Tech Crunchies")).toBeInTheDocument();
+  });
+
+  it("shows 'All items' on ALL_FEEDS view", () => {
+    useFeedStore.setState({ selectedFeedId: ALL_FEEDS_ID });
+    renderControls();
+    expect(screen.getByText(/All items/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Starred' on STARRED view", () => {
+    useFeedStore.setState({ selectedFeedId: STARRED_FEED_ID });
+    renderControls();
+    expect(screen.getByText(/Starred/i)).toBeInTheDocument();
+  });
+
+  it("shows the folder name on a folder view", () => {
+    useFeedStore.setState({ selectedFeedId: toFolderFeedId("folder-tech") });
+    renderControls();
+    expect(screen.getByText("Tech")).toBeInTheDocument();
+  });
+
+  it("shows the smart filter name on a filter view", () => {
+    useFeedStore.setState({ selectedFeedId: toFilterFeedId("filter-recent") });
+    renderControls();
+    expect(screen.getByText("Recent")).toBeInTheDocument();
+  });
+
+  it("settings pill hides on ALL_FEEDS but sort pill stays (no settings on aggregated)", () => {
+    useFeedStore.setState({ selectedFeedId: ALL_FEEDS_ID });
+    renderControls();
+    expect(screen.queryByTestId("settings-pill")).toBeNull();
+    expect(screen.getByLabelText(/sort/i)).toBeInTheDocument();
+  });
+});
+
+describe("MobileHeaderPills", () => {
+  beforeEach(() => {
+    useFeedStore.setState({
+      feeds: [feed("f-tech", "Tech Crunchies")],
+      folders: [],
+      selectedFeedId: "f-tech",
+    });
+    useSmartFilterStore.setState({ filters: [] });
+    useArticleStore.setState({ articleSortMode: "newest" });
+  });
+
+  it("renders the two pills without a title or sticky positioning", () => {
+    render(
+      <MemoryRouter>
+        <MobileHeaderPills />
+      </MemoryRouter>,
+    );
+    const wrapper = screen.getByTestId("mobile-header-pills");
+    expect(wrapper).toBeInTheDocument();
+    // Bare wrapper — no sticky / border / title slot.
+    expect(wrapper.className).not.toMatch(/sticky/);
+    expect(wrapper.className).not.toMatch(/border-b/);
+    expect(screen.getByTestId("settings-pill")).toBeInTheDocument();
+    expect(screen.getByLabelText(/sort/i)).toBeInTheDocument();
+  });
+
+  it("hides the settings pill on ALL_FEEDS view (sort still renders)", () => {
+    useFeedStore.setState({ selectedFeedId: ALL_FEEDS_ID });
+    render(
+      <MemoryRouter>
+        <MobileHeaderPills />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("settings-pill")).toBeNull();
+    expect(screen.getByLabelText(/sort/i)).toBeInTheDocument();
+  });
+});

--- a/tests/components/articles/article-list.test.tsx
+++ b/tests/components/articles/article-list.test.tsx
@@ -364,7 +364,12 @@ describe("ArticleList", () => {
       expect(screen.getByText(/Gaming Daily/)).toBeInTheDocument();
     });
 
-    it("does not show feed title when not in global view", () => {
+    it("does not show feed title on each article when not in global view", () => {
+      // The article-list title bar shows the current feed name once at
+      // the top (introduced when the cog + sort pills moved into a
+      // proper title bar). Per-article feed labels still only appear
+      // in aggregated views — this test now scopes to the per-article
+      // labels via the title bar's exclusion.
       useFeedStore.setState({
         feeds: [mockFeed("f1", "Tech News")],
         selectedFeedId: "f1",
@@ -377,9 +382,21 @@ describe("ArticleList", () => {
         isLoading: false,
       });
 
-      render(<ArticleList />);
+      const { container } = render(<ArticleList />);
 
-      expect(screen.queryByText(/Tech News/)).not.toBeInTheDocument();
+      // Title bar should contain "Tech News" once; the article rows
+      // beneath it should not repeat the feed name.
+      const titleBar = container.querySelector(
+        "[data-testid='article-list-controls']",
+      );
+      expect(titleBar?.textContent).toContain("Tech News");
+
+      const articleRows = container.querySelectorAll(
+        "[data-testid='article-item']",
+      );
+      for (const row of Array.from(articleRows)) {
+        expect(row.textContent).not.toContain("Tech News");
+      }
     });
 
     it("shows feed favicon for each article when in global view", () => {
@@ -410,7 +427,10 @@ describe("ArticleList", () => {
       );
     });
 
-    it("does not show feed favicon when not in global view", () => {
+    it("does not show feed favicon per article when not in global view", () => {
+      // The title bar shows the current feed's favicon once at the top.
+      // The per-article favicon is only for aggregated views — this
+      // test scopes to the article rows specifically.
       useFeedStore.setState({
         feeds: [mockFeed("f1", "Tech News")],
         selectedFeedId: "f1",
@@ -425,7 +445,13 @@ describe("ArticleList", () => {
 
       const { container } = render(<ArticleList />);
 
-      expect(container.querySelector("img")).not.toBeInTheDocument();
+      // Title bar may include the favicon; article rows must not.
+      const articleRows = container.querySelectorAll(
+        "[data-testid='article-item']",
+      );
+      for (const row of Array.from(articleRows)) {
+        expect(row.querySelector("img")).toBeNull();
+      }
     });
   });
 

--- a/tests/components/ui/expanding-pill.test.tsx
+++ b/tests/components/ui/expanding-pill.test.tsx
@@ -87,7 +87,7 @@ describe("ExpandingPill", () => {
     expect(label.className).toMatch(/overflow-hidden/);
   });
 
-  it("expand-on-hover: label uses group-hover:max-w- to reveal on parent hover", () => {
+  it("expansion is wired to hover, focus-visible, AND active (mobile tap)", () => {
     render(
       <ExpandingPill
         icon={<SettingsIcon />}
@@ -96,10 +96,13 @@ describe("ExpandingPill", () => {
       />,
     );
     const label = screen.getByText("Feed settings");
-    // Group + group-hover:max-w-* is the desktop expand pattern. Don't
-    // pin the exact width — just confirm the mechanism is wired.
+    // Three expansion triggers: desktop pointer hover, keyboard
+    // focus-visible, and mobile tap (group-active while the press is
+    // held). Don't pin the exact width — just confirm each mechanism
+    // is wired.
     expect(label.className).toMatch(/group-hover:max-w-/);
     expect(label.className).toMatch(/group-focus-visible:max-w-/);
+    expect(label.className).toMatch(/group-active:max-w-/);
   });
 
   it("when alwaysExpanded is true, the label has no max-w-0 constraint (mobile-always-visible mode)", () => {


### PR DESCRIPTION
## Summary

Visual tweaks to the cog + sort pills you asked for:

1. **Float them in the feed title bar.** On desktop, the previously thin sticky-top controls strip becomes a proper title bar: feed indicator (favicon + title / icon + label) on the left, cog + sort pills on the right. On mobile, the pills move into the global `<header>` next to the breadcrumbs so they share the one bar.
2. **Icon-only by default.** Both pills are circles at rest on every viewport.
3. **Expand on hover/tap.** Desktop hover expands. Keyboard focus-visible expands. Mobile tap also expands (via `:active`) — the label briefly flashes during the press, giving tap feedback before the dialog opens.
4. **No overlap when expanded.** Flex layout (right-aligned + `gap-2`) already handles this — the rightmost pill stays anchored at the right edge; the leftmost shifts when its neighbour grows.

## Commits (2)

1. **`feat(ui): icon-only pills everywhere + mobile tap expansion`** — `ExpandingPill` primitive gains `group-active` expansion alongside hover and focus-visible; consumers drop the `alwaysExpanded={isMobile}` path so pills are icon-only by default on every viewport.
2. **`feat(articles): cog + sort pills move into the feed title bar`** — `ArticleListControls` becomes a desktop title bar (feed indicator + pills); new `MobileHeaderPills` wrapper mounts in the global mobile header. Article-list tests updated to scope per-article assertions correctly.

## Test plan

- [x] `npm test` exits 0 (2859 passing, 31 smoke skipped, no regressions)
- [x] `npx tsc --noEmit` clean
- [x] **Primitive** — `ExpandingPill`: existing 9 tests + the renamed "expansion is wired to hover, focus-visible, AND active" assertion
- [x] **Title bar** — new `tests/components/articles/article-list-controls.test.tsx`: 10 tests covering the desktop title-bar shape (renders on desktop, hides on mobile, correct label per view type, settings pill hides on aggregated, sort stays) and the `MobileHeaderPills` wrapper (renders pills, no sticky/title chrome, settings hides on aggregated)
- [x] **Article list** — two test assertions rescoped to per-article rows now that the title bar shows the feed name + favicon at the top
- [ ] Manual smoke against `npm run dev` — recommend before merge: check that the desktop title bar looks right on each view type, the mobile header has the pills + breadcrumb side by side, and the tap-flash on mobile is smooth

## What changed in the rendered UI

**Desktop:**
- Before: thin strip at the top of the article list with a tiny text+icon sort menu (and the cog from PR #139)
- After: proper title bar (h-12, bordered) showing the current feed's favicon + name on the left, two icon-only floating pills on the right that expand horizontally on hover

**Mobile:**
- Before: pills inside the article list with `alwaysExpanded` showing their labels; the global header at the very top of the screen only had breadcrumbs
- After: the global header now has the breadcrumb on the left and two icon-only pills on the right; the article list's sticky top strip is gone (the title is already in the header)

No behaviour changes — sort options, settings dispatch, gate visibility all unchanged. Pure visual + layout refactor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkuzqkyNGYxZsEdXhkPGMr)_