### PR TITLE
feat(bridges): URL-translation bridges for non-RSS sources (MVP)

### DIFF
--- a/docs/decisions/021-bridges-url-translation.md
+++ b/docs/decisions/021-bridges-url-translation.md
@@ -1,0 +1,75 @@
+# ADR 021: Bridges are URL Translators, Not Scrapers
+
+## Status
+
+Accepted (2026-05-22).
+
+## Context
+
+Users repeatedly ask FeedZero to follow sources that don't *look* like feeds:
+a YouTube channel, a subreddit, a Mastodon profile, a GitHub repo. The
+inspiration is the [rss-bridge](https://github.com/RSS-Bridge/rss-bridge)
+project, which generates feeds for hundreds of sites — including many that
+publish no feed at all (Twitter/X, Instagram, arbitrary HTML pages) by
+scraping their markup.
+
+Scraping is a perpetual maintenance treadmill: every target's HTML changes a
+couple of times a year, each change silently breaks that bridge, and several
+of the highest-demand targets (Twitter/X, Instagram) are also ToS-hostile and
+anonymity-fraught to fetch. This is the same maintenance-model trap ADR 020
+calls out for paywall detection.
+
+But there's a large, high-value subset that needs **no scraping at all**: many
+"non-RSS" sources actually publish a perfectly good native feed at a
+non-obvious URL.
+
+| Source | Native feed | Transform |
+|--------|-------------|-----------|
+| YouTube channel | `youtube.com/feeds/videos.xml?channel_id=…` | pure (1 fetch to resolve `@handle`→id) |
+| Reddit sub/user | `reddit.com/r/<x>/.rss` | pure |
+| Mastodon profile | `<instance>/@user.rss` | pure |
+| GitHub repo | `github.com/<o>/<r>/releases.atom` | pure |
+
+## Decision
+
+FeedZero ships **bridges that are pure URL translators**. A bridge recognises a
+source URL and maps it to the URL of a native feed that source already
+publishes. It never parses or scrapes the source's HTML for content (the one
+fetch a bridge may make — YouTube `@handle`→channelId — reads a single opaque
+id, not article content).
+
+Every bridge output is a *candidate*: the discovery cascade validates it via
+`tryParseFeed` (strategy 0, before the HTML-based strategies). A wrong guess
+fails to parse and the cascade falls through, so bridges can be imprecise
+without being unsafe. This is what keeps each bridge a few lines of stable
+URL convention with near-zero maintenance.
+
+### Forbidden
+
+- **No HTML scraping for content.** If a future bridge proposes parsing a
+  page's markup into feed items (because the source publishes no feed), it
+  must come with an ADR superseding this one and an explicit owner for the
+  per-target maintenance cost.
+- **No bridges for ToS-hostile / anonymity-fraught targets** (Twitter/X,
+  Instagram) in this model — they require scraping by definition.
+
+## Consequences
+
+- `src/core/bridges/` — `Bridge` interface, ordered registry, one file per
+  source, `resolveBridgeFeedUrl()` public API. Mirrors the
+  `paywall-detectors/` and extractor `adapters/` registry pattern.
+- `discoverFeed(url, { bridges })` runs bridge resolution as strategy 0.
+- `bridges` is a Personal-tier, shipped feature in the tier matrix. The gate
+  is resolved at the store layer (`feed-store`) and threaded into
+  `addFeedFlow` → `discoverFeed` as a plain boolean, so core stays
+  store-agnostic.
+- Adding a source = one file + registration + tests. No UI work: bridges are
+  transparent — the user pastes the channel/sub/profile/repo URL into the
+  normal "Add feed" box.
+
+## References
+
+- `src/core/bridges/`, `src/core/discovery/discovery.ts` (strategy 0).
+- ADR 020 (browser-extension surface) — same maintenance-model reasoning for
+  paywall detectors.
+- Feature 020 (`docs/features/020-bridges.md`).

--- a/docs/features/020-bridges.md
+++ b/docs/features/020-bridges.md
@@ -1,0 +1,99 @@
+# Feature 020: Bridges — Non-RSS Sources as Feeds
+
+## Status
+Implemented (MVP: Reddit, GitHub, Mastodon, YouTube).
+
+## Summary
+
+Bridges let users follow sources that don't look like feeds — a YouTube
+channel, a subreddit, a Mastodon profile, a GitHub repo — by pasting the normal
+source URL into "Add feed". A bridge maps the URL to the **native feed each
+source already publishes** (no scraping). Personal-tier feature; see ADR 021
+for why this is URL translation, not the rss-bridge scraping model.
+
+## Behaviour
+
+```gherkin
+Feature: Bridges
+
+  Scenario: Add a subreddit by its URL
+    Given the user is on Personal tier (or paid tier inactive)
+    When they add "https://www.reddit.com/r/selfhosted"
+    Then the feed resolves to "https://www.reddit.com/r/selfhosted/.rss"
+    And articles load as for any feed
+
+  Scenario: Add a YouTube channel by @handle
+    Given the user adds "https://www.youtube.com/@LinusTechTips"
+    When discovery runs the YouTube bridge
+    Then the page is fetched once to recover the channelId
+    And the feed resolves to ".../feeds/videos.xml?channel_id=UC…"
+
+  Scenario: Bridge gate is off (Free tier, paid tier active)
+    When a Free user adds a subreddit URL
+    Then bridges do not run; normal HTML discovery applies
+    And the subreddit's native HTML <link> autodiscovery may still resolve it
+
+  Scenario: Wrong bridge guess
+    Given a non-Mastodon "/@user" URL slips past the host denylist
+    When the bridge proposes "<origin>/@user.rss"
+    Then tryParseFeed fails to parse it
+    And discovery falls through to the page-based strategies
+```
+
+## Architecture
+
+### Flow
+
+1. User adds a URL. `addFeedFlow` fetches `/api/feed` and tries `parse()`.
+2. If it parses, it's already a feed — done (bridges never run for real feeds).
+3. If not, `discoverFeed(url, { bridges })` runs. The `bridges` boolean is the
+   Personal-tier `gateState("bridges", …)` result, resolved in `feed-store`
+   and threaded down (core stays store-agnostic).
+4. **Strategy 0 — bridges:** `resolveBridgeFeedUrl(url)` picks the first
+   matching bridge and returns a candidate feed URL. `tryParseFeed` validates
+   it; on success, discovery returns immediately (no page fetch).
+5. Otherwise the existing strategies run: HTML `<link>` autodiscovery,
+   well-known paths, anchor scanning.
+
+### Files
+
+| File | Role |
+|------|------|
+| `src/core/bridges/types.ts` | `Bridge` interface (`matches`, `toFeedUrl`). |
+| `src/core/bridges/registry.ts` | Ordered first-match registry. |
+| `src/core/bridges/{reddit,github,mastodon,youtube}.ts` | One bridge each. |
+| `src/core/bridges/index.ts` | `resolveBridgeFeedUrl()` + registration order. |
+| `src/core/discovery/discovery.ts` | Strategy 0 wiring + `{ bridges }` option. |
+| `src/core/feeds/feed-service.ts` | `addFeedFlow` threads `bridgesEnabled`. |
+| `src/stores/feed-store.ts` | Resolves the `bridges` gate, passes the boolean. |
+| `src/core/features/tier-matrix.ts` | `bridges`: Personal+, shipped. |
+
+### Tests
+
+| File | Coverage |
+|------|----------|
+| `tests/core/bridges/bridges.test.ts` | Every bridge's match/translate + negatives (deep reddit URLs, github reserved/sub-page, medium.com/@user, YouTube channelId extraction, no-match/unparseable). |
+| `tests/core/discovery/discovery.test.js` | Strategy 0 short-circuits before the page fetch when enabled; bridge URL never tried when the gate is off. |
+| `tests/core/features/tier-matrix.test.ts` | `bridges` is Personal+, shipped. |
+
+## Design Decisions
+
+- **URL translation, not scraping** — ADR 021. Bridges propose; `tryParseFeed`
+  disposes. Near-zero maintenance.
+- **Strategy 0, before the page fetch** — a recognised source resolves without
+  fetching its landing page at all.
+- **Gate resolved at the store, threaded as a boolean** — core never imports
+  the license store.
+- **Registration order** — host-scoped bridges before Mastodon, whose
+  host-agnostic `/@user` matcher would otherwise shadow YouTube's `/@handle`.
+
+## Limitations
+
+- Sources that publish **no** native feed (Twitter/X, Instagram, arbitrary
+  pages) are out of scope — they require scraping (ADR 021 forbids it here).
+- GitHub defaults to `releases.atom`; per-repo commit/tag feeds aren't
+  selectable yet.
+- Shorthand inputs (`r/foo`, `@user@instance`) aren't accepted — the user
+  pastes the full source URL. A shorthand parser is possible future work.
+- Mastodon detection is host-denylist based; an unknown platform reusing the
+  `/@user` path shape produces a candidate that simply fails to parse.

--- a/docs/tier-matrix.md
+++ b/docs/tier-matrix.md
@@ -58,7 +58,7 @@ Legend:
 |---|---|---|---|---|
 | **Authenticated fetchers** — Fetch feeds behind HTTP basic auth, cookies, or signed URLs (Patreon, paywalled newsletters). | — | — | ✓ | Coming soon |
 | **Send to Kindle** — One-click delivery of an article to your Kindle email address. | — | — | ✓ | Coming soon |
-| **Bridges** — Adapters that turn non-RSS sources (YouTube channels, Reddit, Mastodon) into feeds. | — | — | ✓ | Coming soon |
+| **Bridges** — Turn non-RSS sources (YouTube channels, Reddit, Mastodon, GitHub repos) into feeds by mapping them to the native feed URL each already publishes. | — | ✓ | ✓ | Shipped |
 
 ## Appearance
 

--- a/src/core/bridges/github.ts
+++ b/src/core/bridges/github.ts
@@ -1,0 +1,43 @@
+import type { Bridge } from "./types.ts";
+
+const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
+
+// Top-level paths that look like /<owner>/<repo> but aren't repositories.
+const RESERVED_OWNERS = new Set([
+  "features",
+  "about",
+  "pricing",
+  "marketplace",
+  "sponsors",
+  "topics",
+  "collections",
+  "trending",
+  "settings",
+  "notifications",
+  "explore",
+  "orgs",
+  "organizations",
+  "users",
+  "login",
+  "join",
+  "new",
+  "search",
+  "apps",
+]);
+
+export const githubBridge: Bridge = {
+  name: "github",
+  matches(url) {
+    if (!GITHUB_HOSTS.has(url.hostname.toLowerCase())) return false;
+    const segs = url.pathname.split("/").filter(Boolean);
+    if (segs.length !== 2) return false;
+    if (RESERVED_OWNERS.has(segs[0].toLowerCase())) return false;
+    return true;
+  },
+  async toFeedUrl(url) {
+    const [owner, repo] = url.pathname.split("/").filter(Boolean);
+    // Releases is the highest-signal default — most repos a user follows
+    // they follow for releases, not every commit.
+    return `https://github.com/${owner}/${repo.replace(/\.git$/, "")}/releases.atom`;
+  },
+};

--- a/src/core/bridges/index.ts
+++ b/src/core/bridges/index.ts
@@ -1,0 +1,35 @@
+import { bridgeRegistry } from "./registry.ts";
+import { redditBridge } from "./reddit.ts";
+import { githubBridge } from "./github.ts";
+import { youtubeBridge } from "./youtube.ts";
+import { mastodonBridge } from "./mastodon.ts";
+
+// Order: host-scoped bridges first; mastodon last because its `/@user`
+// matcher is host-agnostic and would otherwise shadow youtube's `/@handle`.
+bridgeRegistry.register(redditBridge);
+bridgeRegistry.register(githubBridge);
+bridgeRegistry.register(youtubeBridge);
+bridgeRegistry.register(mastodonBridge);
+
+/**
+ * Translate a source URL into a native feed URL, or null when no bridge
+ * recognises it. The discovery cascade calls this as "strategy 0" and
+ * validates the result with tryParseFeed, so the returned URL is a
+ * *candidate*, not a guarantee.
+ */
+export async function resolveBridgeFeedUrl(
+  rawUrl: string,
+): Promise<string | null> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  const bridge = bridgeRegistry.find(url);
+  if (!bridge) return null;
+  return bridge.toFeedUrl(url);
+}
+
+export { extractYouTubeChannelId } from "./youtube.ts";
+export type { Bridge } from "./types.ts";

--- a/src/core/bridges/mastodon.ts
+++ b/src/core/bridges/mastodon.ts
@@ -1,0 +1,32 @@
+import type { Bridge } from "./types.ts";
+
+// Mastodon is federated, so we can't allowlist hosts. Instead we denylist
+// the well-known platforms that ALSO use a `/@user` path shape but are not
+// Mastodon (so we don't emit a bogus `.rss` candidate for them). A wrong
+// guess would still be caught by tryParseFeed; this just avoids the wasted
+// fetch for the common collisions.
+const NON_MASTODON_HOSTS = new Set([
+  "medium.com",
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "twitter.com",
+  "x.com",
+  "github.com",
+  "www.github.com",
+]);
+
+// A single `/@handle` segment, optional trailing slash.
+const MASTODON_PATH = /^\/@[^/]+\/?$/;
+
+export const mastodonBridge: Bridge = {
+  name: "mastodon",
+  matches(url) {
+    if (NON_MASTODON_HOSTS.has(url.hostname.toLowerCase())) return false;
+    return MASTODON_PATH.test(url.pathname);
+  },
+  async toFeedUrl(url) {
+    const handle = url.pathname.replace(/\/$/, "");
+    return `${url.origin}${handle}.rss`;
+  },
+};

--- a/src/core/bridges/reddit.ts
+++ b/src/core/bridges/reddit.ts
@@ -1,0 +1,26 @@
+import type { Bridge } from "./types.ts";
+
+const REDDIT_HOSTS = new Set([
+  "reddit.com",
+  "www.reddit.com",
+  "old.reddit.com",
+  "np.reddit.com",
+]);
+
+// /r/<sub>, /user/<u>, or the /u/<u> shorthand — single path segment after
+// the prefix, optional trailing slash.
+const REDDIT_PATH = /^\/(r|u|user)\/[^/]+\/?$/;
+
+export const redditBridge: Bridge = {
+  name: "reddit",
+  matches(url) {
+    if (!REDDIT_HOSTS.has(url.hostname.toLowerCase())) return false;
+    return REDDIT_PATH.test(url.pathname);
+  },
+  async toFeedUrl(url) {
+    // Normalise /u/ → /user/ (Reddit redirects it, but emitting the
+    // canonical form avoids a redirect hop) and append /.rss.
+    const path = url.pathname.replace(/\/$/, "").replace(/^\/u\//, "/user/");
+    return `https://www.reddit.com${path}/.rss`;
+  },
+};

--- a/src/core/bridges/registry.ts
+++ b/src/core/bridges/registry.ts
@@ -1,0 +1,23 @@
+import type { Bridge } from "./types.ts";
+
+/**
+ * Ordered registry of bridges. First match wins, so register the
+ * narrow-host bridges (youtube, github) before the broad path matchers
+ * (mastodon's `/@user`) — see index.ts.
+ */
+class BridgeRegistry {
+  private bridges: Bridge[] = [];
+
+  register(bridge: Bridge): void {
+    this.bridges.push(bridge);
+  }
+
+  find(url: URL): Bridge | null {
+    for (const bridge of this.bridges) {
+      if (bridge.matches(url)) return bridge;
+    }
+    return null;
+  }
+}
+
+export const bridgeRegistry = new BridgeRegistry();

--- a/src/core/bridges/types.ts
+++ b/src/core/bridges/types.ts
@@ -1,0 +1,27 @@
+/**
+ * A bridge turns a human-facing URL for a source that doesn't *look* like a
+ * feed (a YouTube channel page, a subreddit, a Mastodon profile, a GitHub
+ * repo) into the URL of a real, native feed that source already publishes.
+ *
+ * Bridges are URL translators, NOT scrapers. Every output is a feed URL that
+ * the discovery cascade then validates via `tryParseFeed` — so a bridge only
+ * needs to *propose* a candidate; a wrong guess simply fails to parse and the
+ * cascade falls through. This keeps bridges tiny and near-zero-maintenance:
+ * there is no publisher HTML to track, only stable feed-URL conventions.
+ *
+ * (Contrast with the rss-bridge project, which scrapes markup for sources
+ * that publish no feed at all — that inherits a perpetual maintenance
+ * treadmill we deliberately stay out of. See docs/decisions/021.)
+ */
+export interface Bridge {
+  /** Human-readable name for debugging. */
+  name: string;
+  /** Whether this bridge recognises the (already-parsed) URL. */
+  matches(url: URL): boolean;
+  /**
+   * Translate to a native feed URL. Async because some sources (YouTube
+   * @handles) need one fetch to resolve an opaque id. Returns null when the
+   * URL is recognised but a feed URL can't be produced.
+   */
+  toFeedUrl(url: URL): Promise<string | null>;
+}

--- a/src/core/bridges/youtube.ts
+++ b/src/core/bridges/youtube.ts
@@ -1,0 +1,52 @@
+import type { Bridge } from "./types.ts";
+import { proxyFetch } from "../proxy/proxy-fetch.ts";
+
+const YOUTUBE_HOSTS = new Set([
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+]);
+
+// /channel/UC… (resolvable without a fetch), or /@handle, /c/name, /user/name
+// (need the page HTML to recover the opaque channel id).
+const YOUTUBE_PATH = /^\/(channel\/UC[\w-]+|@[^/]+|c\/[^/]+|user\/[^/]+)\/?$/;
+
+function feedFromChannelId(channelId: string): string {
+  return `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+}
+
+/**
+ * Recover a YouTube channel id (UC…) from a channel page's HTML. YouTube
+ * embeds it in several places; we try the structured `"channelId":"UC…"`
+ * JSON field first, then the `/channel/UC…` canonical href as a fallback.
+ * Pure — exported for unit testing without a network round-trip.
+ */
+export function extractYouTubeChannelId(html: string): string | null {
+  const json = html.match(/"(?:externalId|channelId)"\s*:\s*"(UC[\w-]+)"/);
+  if (json) return json[1];
+  const href = html.match(/\/channel\/(UC[\w-]+)/);
+  return href ? href[1] : null;
+}
+
+export const youtubeBridge: Bridge = {
+  name: "youtube",
+  matches(url) {
+    if (!YOUTUBE_HOSTS.has(url.hostname.toLowerCase())) return false;
+    return YOUTUBE_PATH.test(url.pathname);
+  },
+  async toFeedUrl(url) {
+    const direct = url.pathname.match(/^\/channel\/(UC[\w-]+)/);
+    if (direct) return feedFromChannelId(direct[1]);
+
+    // @handle / c/ / user/ — fetch the page and recover the channel id.
+    try {
+      const response = await proxyFetch("/api/page", url.href);
+      if (!response.ok) return null;
+      const html = await response.text();
+      const channelId = extractYouTubeChannelId(html);
+      return channelId ? feedFromChannelId(channelId) : null;
+    } catch {
+      return null;
+    }
+  },
+};

--- a/src/core/discovery/discovery.ts
+++ b/src/core/discovery/discovery.ts
@@ -8,6 +8,7 @@ import {
   findFeedLinksInAnchors,
 } from "./strategies.ts";
 import { proxyFetch } from "../proxy/proxy-fetch.ts";
+import { resolveBridgeFeedUrl } from "../bridges/index.ts";
 
 interface DiscoveryResult extends ParseResult {
   feedUrl: string;
@@ -46,14 +47,29 @@ async function tryCandidates(urls: string[]): Promise<DiscoveryResult | null> {
  * Discover a feed from a website URL using a multi-strategy cascade.
  *
  * Strategies (in order):
+ * 0. Bridges — non-RSS sources (YouTube/Reddit/Mastodon/GitHub) mapped to
+ *    their native feed URL. Only run when `options.bridges` is true (the
+ *    caller resolves the Personal-tier gate). Runs before the page fetch so
+ *    a recognised source resolves without scraping the landing page.
  * 1. HTML <link rel="alternate"> autodiscovery
  * 2. Well-known feed paths (/feed, /rss, /atom.xml, etc.)
  * 3. Anchor link scanning for feed-like URLs
  */
 export async function discoverFeed(
   url: string,
+  options?: { bridges?: boolean },
 ): Promise<Result<DiscoveryResult>> {
   try {
+    // Strategy 0: bridges. The candidate is validated by tryParseFeed, so a
+    // wrong guess falls through to the page-based strategies below.
+    if (options?.bridges) {
+      const bridged = await resolveBridgeFeedUrl(url);
+      if (bridged) {
+        const fromBridge = await tryParseFeed(bridged);
+        if (fromBridge) return ok(fromBridge);
+      }
+    }
+
     // Fetch the page HTML (reused for strategies 1 and 3)
     const pageResponse = await proxyFetch("/api/page", url);
     if (!pageResponse.ok) {

--- a/src/core/features/tier-matrix.ts
+++ b/src/core/features/tier-matrix.ts
@@ -300,10 +300,10 @@ export const TIER_MATRIX = {
     id: "bridges",
     name: "Bridges",
     description:
-      "Adapters that turn non-RSS sources (YouTube channels, Reddit, Mastodon) into feeds.",
+      "Turn non-RSS sources (YouTube channels, Reddit, Mastodon, GitHub repos) into feeds by mapping them to the native feed URL each already publishes.",
     category: "delivery",
-    status: "coming-soon",
-    tiers: { free: UNAVAILABLE, personal: UNAVAILABLE, pro: AVAILABLE },
+    status: "shipped",
+    tiers: { free: UNAVAILABLE, personal: AVAILABLE, pro: AVAILABLE },
   },
 
   // ── Appearance ─────────────────────────────────────────────────────────

--- a/src/core/feeds/feed-service.ts
+++ b/src/core/feeds/feed-service.ts
@@ -142,7 +142,7 @@ function fetchFailure(message: string): AddFeedFlowResult {
  */
 export async function addFeedFlow(
   rawUrl: string,
-  options?: { prefetchedContent?: string },
+  options?: { prefetchedContent?: string; bridgesEnabled?: boolean },
 ): Promise<AddFeedFlowResult> {
   const url = normalizeUrl(rawUrl);
   try {
@@ -184,8 +184,12 @@ export async function addFeedFlow(
       feedData = parseResult.value.feed;
       parsedArticles = parseResult.value.articles;
     } else {
-      // Not a feed — try discovering a feed from this URL
-      const discovery = await discoverFeed(url);
+      // Not a feed — try discovering a feed from this URL. Bridges
+      // (strategy 0) only run when the caller resolved the Personal-tier
+      // gate; the boolean is threaded down so core stays store-agnostic.
+      const discovery = await discoverFeed(url, {
+        bridges: options?.bridgesEnabled ?? false,
+      });
       if (!discovery.ok) return err(friendlyError(discovery.error));
 
       feedData = discovery.value.feed;

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -399,7 +399,15 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
     }
 
     set({ isLoading: true, error: null });
-    const result = await addFeedFlow(url);
+    // Resolve the bridges gate here (store layer owns license/self-host
+    // state) and pass it down as a plain boolean — core stays store-agnostic.
+    const bridgesEnabled = gateState(
+      "bridges",
+      useLicenseStore.getState().tier,
+      isSelfHosted(),
+      isPaidTierActive(),
+    ).enabled;
+    const result = await addFeedFlow(url, { bridgesEnabled });
     if (!result.ok) {
       set({ isLoading: false, error: result.error });
       // Preserve the reason discriminator so import-side callers can

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -214,7 +214,10 @@ describe("App sync-aware init", () => {
     });
 
     await waitFor(() => {
-      expect(addFeedFlow).toHaveBeenCalledWith(CHANGELOG_FEED_URL);
+      expect(addFeedFlow).toHaveBeenCalledWith(
+        CHANGELOG_FEED_URL,
+        expect.objectContaining({ bridgesEnabled: expect.any(Boolean) }),
+      );
     });
   });
 

--- a/tests/core/bridges/bridges.test.ts
+++ b/tests/core/bridges/bridges.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  resolveBridgeFeedUrl,
+  extractYouTubeChannelId,
+} from "@/core/bridges/index.ts";
+import { proxyFetch } from "@/core/proxy/proxy-fetch.ts";
+
+vi.mock("@/core/proxy/proxy-fetch.ts", () => ({
+  proxyFetch: vi.fn(),
+}));
+
+describe("resolveBridgeFeedUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("reddit", () => {
+    it("maps a subreddit URL to its .rss feed", async () => {
+      expect(await resolveBridgeFeedUrl("https://www.reddit.com/r/selfhosted")).toBe(
+        "https://www.reddit.com/r/selfhosted/.rss",
+      );
+    });
+
+    it("handles a trailing slash", async () => {
+      expect(await resolveBridgeFeedUrl("https://reddit.com/r/rss/")).toBe(
+        "https://www.reddit.com/r/rss/.rss",
+      );
+    });
+
+    it("maps a /user/ profile URL", async () => {
+      expect(await resolveBridgeFeedUrl("https://www.reddit.com/user/spez")).toBe(
+        "https://www.reddit.com/user/spez/.rss",
+      );
+    });
+
+    it("normalises the /u/ shorthand to /user/", async () => {
+      expect(await resolveBridgeFeedUrl("https://www.reddit.com/u/spez")).toBe(
+        "https://www.reddit.com/user/spez/.rss",
+      );
+    });
+
+    it("does not match a deep comment URL", async () => {
+      expect(
+        await resolveBridgeFeedUrl(
+          "https://www.reddit.com/r/selfhosted/comments/abc/title",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("github", () => {
+    it("maps a repo URL to its releases atom feed", async () => {
+      expect(await resolveBridgeFeedUrl("https://github.com/forcingfx/feedzero")).toBe(
+        "https://github.com/forcingfx/feedzero/releases.atom",
+      );
+    });
+
+    it("strips a trailing .git", async () => {
+      expect(await resolveBridgeFeedUrl("https://github.com/a/b.git")).toBe(
+        "https://github.com/a/b/releases.atom",
+      );
+    });
+
+    it("does not match a single-segment (owner-only) path", async () => {
+      expect(await resolveBridgeFeedUrl("https://github.com/forcingfx")).toBeNull();
+    });
+
+    it("does not match a reserved path like /features", async () => {
+      expect(await resolveBridgeFeedUrl("https://github.com/features/copilot")).toBeNull();
+    });
+
+    it("does not match a sub-page like /owner/repo/issues", async () => {
+      expect(
+        await resolveBridgeFeedUrl("https://github.com/forcingfx/feedzero/issues"),
+      ).toBeNull();
+    });
+  });
+
+  describe("mastodon", () => {
+    it("maps a profile URL to its .rss feed on the same instance", async () => {
+      expect(await resolveBridgeFeedUrl("https://mastodon.social/@Gargron")).toBe(
+        "https://mastodon.social/@Gargron.rss",
+      );
+    });
+
+    it("works for any instance host", async () => {
+      expect(await resolveBridgeFeedUrl("https://fosstodon.org/@kev")).toBe(
+        "https://fosstodon.org/@kev.rss",
+      );
+    });
+
+    it("does not fire for medium.com/@user (not Mastodon)", async () => {
+      expect(await resolveBridgeFeedUrl("https://medium.com/@someone")).toBeNull();
+    });
+  });
+
+  describe("youtube", () => {
+    it("maps a /channel/UC… URL directly without a fetch", async () => {
+      const out = await resolveBridgeFeedUrl(
+        "https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw",
+      );
+      expect(out).toBe(
+        "https://www.youtube.com/feeds/videos.xml?channel_id=UCXuqSBlHAE6Xw-yeJA0Tunw",
+      );
+      expect(proxyFetch).not.toHaveBeenCalled();
+    });
+
+    it("resolves an @handle by fetching the page and extracting the channelId", async () => {
+      vi.mocked(proxyFetch).mockResolvedValue({
+        ok: true,
+        text: () =>
+          Promise.resolve(
+            '<html><body><meta itemprop="channelId" content="x">' +
+              '<script>{"channelId":"UCabcdefghijklmnopqrstuv"}</script></body></html>',
+          ),
+      } as unknown as Response);
+
+      const out = await resolveBridgeFeedUrl("https://www.youtube.com/@LinusTechTips");
+
+      expect(out).toBe(
+        "https://www.youtube.com/feeds/videos.xml?channel_id=UCabcdefghijklmnopqrstuv",
+      );
+      expect(proxyFetch).toHaveBeenCalled();
+    });
+
+    it("returns null when the channelId cannot be found in the page", async () => {
+      vi.mocked(proxyFetch).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("<html><body>no id here</body></html>"),
+      } as unknown as Response);
+
+      expect(
+        await resolveBridgeFeedUrl("https://www.youtube.com/@whoever"),
+      ).toBeNull();
+    });
+  });
+
+  describe("no bridge match", () => {
+    it("returns null for an unrelated URL", async () => {
+      expect(await resolveBridgeFeedUrl("https://example.com/blog")).toBeNull();
+    });
+
+    it("returns null for an unparseable input", async () => {
+      expect(await resolveBridgeFeedUrl("not a url")).toBeNull();
+    });
+  });
+});
+
+describe("extractYouTubeChannelId", () => {
+  it("extracts from a channelId JSON field", () => {
+    expect(
+      extractYouTubeChannelId('foo {"channelId":"UCabcdefghijklmnopqrstuv"} bar'),
+    ).toBe("UCabcdefghijklmnopqrstuv");
+  });
+
+  it("extracts from a /channel/UC… canonical href", () => {
+    expect(
+      extractYouTubeChannelId(
+        '<link rel="canonical" href="https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw">',
+      ),
+    ).toBe("UCXuqSBlHAE6Xw-yeJA0Tunw");
+  });
+
+  it("returns null when no id is present", () => {
+    expect(extractYouTubeChannelId("<html></html>")).toBeNull();
+  });
+});

--- a/tests/core/discovery/discovery.test.js
+++ b/tests/core/discovery/discovery.test.js
@@ -68,6 +68,66 @@ describe("discoverFeed", () => {
     expect(articles.length).toBeGreaterThan(0);
   });
 
+  it("resolves a bridge URL as strategy 0 when bridges are enabled (no page fetch needed)", async () => {
+    globalThis.fetch = vi.fn().mockImplementation((endpoint, opts) => {
+      if (
+        endpoint === "/api/feed" &&
+        targetUrlFrom(opts) === "https://www.reddit.com/r/selfhosted/.rss"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(ATOM_XML),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    const result = await discoverFeed("https://www.reddit.com/r/selfhosted", {
+      bridges: true,
+    });
+
+    expect(isOk(result)).toBe(true);
+    expect(unwrap(result).feedUrl).toBe(
+      "https://www.reddit.com/r/selfhosted/.rss",
+    );
+    const pageCalls = globalThis.fetch.mock.calls.filter(
+      ([endpoint]) => endpoint === "/api/page",
+    );
+    expect(pageCalls).toHaveLength(0);
+  });
+
+  it("does NOT run bridges when the gate is off (defaults to page strategies)", async () => {
+    globalThis.fetch = vi.fn().mockImplementation((endpoint, opts) => {
+      if (endpoint === "/api/page") {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(PAGE_WITH_NO_FEED),
+        });
+      }
+      if (
+        endpoint === "/api/feed" &&
+        targetUrlFrom(opts) === "https://www.reddit.com/r/selfhosted/.rss"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(ATOM_XML),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    const result = await discoverFeed("https://www.reddit.com/r/selfhosted");
+
+    expect(isErr(result)).toBe(true);
+    // The bridge's .rss candidate must never be requested when the gate is off.
+    const triedBridgeUrl = globalThis.fetch.mock.calls.some(
+      ([endpoint, opts]) =>
+        endpoint === "/api/feed" &&
+        targetUrlFrom(opts) === "https://www.reddit.com/r/selfhosted/.rss",
+    );
+    expect(triedBridgeUrl).toBe(false);
+  });
+
   it("should discover feed via well-known path when no HTML link exists", async () => {
     globalThis.fetch = vi.fn().mockImplementation((endpoint, opts) => {
       if (endpoint === "/api/page") {

--- a/tests/core/features/tier-matrix.test.ts
+++ b/tests/core/features/tier-matrix.test.ts
@@ -77,6 +77,11 @@ describe("tier-matrix — currently shipped gated features", () => {
     expect(getRequiredTier("filters")).toBe("personal");
   });
 
+  it("bridges is Personal+, shipped", () => {
+    expect(getEntry("bridges").status).toBe("shipped");
+    expect(getRequiredTier("bridges")).toBe("personal");
+  });
+
   it("offline-prefetch is Personal+, shipped", () => {
     expect(getEntry("offline-prefetch").status).toBe("shipped");
     expect(getRequiredTier("offline-prefetch")).toBe("personal");
@@ -94,7 +99,6 @@ describe("tier-matrix — coming-soon features", () => {
     "ai-signal",
     "authenticated-fetchers",
     "send-to-kindle",
-    "bridges",
     "themes-commercial",
   ] as const)("%s is Pro-tier, coming-soon", (id) => {
     const entry = getEntry(id);

--- a/tests/stores/feed-store.test.ts
+++ b/tests/stores/feed-store.test.ts
@@ -141,7 +141,10 @@ describe("feed-store", () => {
 
       await useFeedStore.getState().addFeed("https://new.com/feed");
 
-      expect(addFeedFlow).toHaveBeenCalledWith("https://new.com/feed");
+      expect(addFeedFlow).toHaveBeenCalledWith(
+        "https://new.com/feed",
+        expect.objectContaining({ bridgesEnabled: expect.any(Boolean) }),
+      );
       expect(useFeedStore.getState().feeds).toEqual([feed]);
       expect(useFeedStore.getState().selectedFeedId).toBe("new");
     });


### PR DESCRIPTION
## Summary

Lets users follow sources that don't look like feeds — a YouTube channel, a subreddit, a Mastodon profile, a GitHub repo — by pasting the normal source URL into "Add feed". A **bridge** maps the URL to the native feed each source already publishes. **URL translation, not scraping** (ADR 021), so each bridge is a few lines of stable convention with near-zero maintenance.

| Input | Resolves to |
|---|---|
| `reddit.com/r/selfhosted` | `…/r/selfhosted/.rss` |
| `github.com/forcingfx/feedzero` | `…/releases.atom` |
| `mastodon.social/@Gargron` | `…/@Gargron.rss` |
| `youtube.com/@LinusTechTips` | `…/feeds/videos.xml?channel_id=…` (1 fetch to resolve the handle) |

## How it works

- `src/core/bridges/` — a registry of pure URL translators (mirrors the paywall-detector / extractor-adapter pattern). A bridge *proposes* a candidate; `tryParseFeed` validates it, so a wrong guess self-corrects by falling through to the existing HTML strategies.
- Runs as **strategy 0** in `discoverFeed`, before the page fetch — a recognised source resolves with zero landing-page scraping.
- **Personal-tier** gate, resolved at the store layer (`feed-store`) and threaded into `addFeedFlow` → `discoverFeed` as a plain boolean, so core never imports the license store.
- Tier matrix flipped `bridges` from coming-soon/Pro → shipped/Personal+; `feature-gates` and `docs/tier-matrix.md` derive from the matrix.

## Scope (deliberate)

- Sources with **no** native feed (Twitter/X, Instagram, arbitrary pages) are out — they require scraping, which ADR 021 forbids in this model (the rss-bridge maintenance treadmill).
- GitHub defaults to `releases.atom`; commit/tag feeds aren't selectable yet.
- Shorthand inputs (`r/foo`, `@user@instance`) aren't accepted — full source URL only.

## Context

This work was authored on `claude/paywall-extension-feature-hR15P` *after* PR #146 was squash-merged, so it was stranded on that merged branch. This PR re-bases it cleanly onto current `main` (the pre-bridges tree was identical to main; this is exactly the 2-commit bridges delta).

## Test plan

- [x] `tests/core/bridges/bridges.test.ts` — every bridge's match/translate + negatives (deep reddit URLs, github reserved/sub-pages, medium.com/@user not firing mastodon, YouTube channelId extraction, no-match/unparseable)
- [x] `tests/core/discovery/discovery.test.js` — strategy 0 short-circuits before the page fetch when enabled; bridge URL never tried when the gate is off
- [x] `tests/core/features/tier-matrix.test.ts` — `bridges` is Personal+, shipped
- [x] `npx tsc --noEmit` clean; full unit suite green via pre-push hook
- [ ] **Not done in-environment:** real-service check against live `youtube.com/@handle` (Playwright CDN blocked here). The channelId-extraction regex depends on YouTube's actual HTML — worth a manual add on the deploy preview.

https://claude.ai/code/session_01FvvKdykLAR2eJv2kiwQ7X9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvvKdykLAR2eJv2kiwQ7X9)_