### PR TITLE
feat(refresh): periodic auto-refresh, mobile refresh-all, and action feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ URL is the source of truth for navigation state. `FeedsPage` syncs URL params �
 
 - **use-keyboard-nav** — Article nav `j`/`k` (clicks DOM elements — same code path as mouse). Feed nav `u`/`i`. Actions: `o` open original, `e` toggle view (`toggleViewMode()`), `n` add feed (custom event), `[` toggle sidebar, `r` refresh. Disabled when focus is in input/textarea/contenteditable.
 - **use-media-query / use-mobile** — `useIsDesktop()` ≥1024px; `useIsMobile()` <768px (sidebar/sheet).
+- **use-auto-refresh** — Background `refreshAll()` on the `AUTO_REFRESH_INTERVAL_MS` (30 min) timer plus a focus-when-stale trigger (returning to a tab idle longer than the interval refreshes immediately). Reads the store via `getState()` inside its handlers so it subscribes once; mounted in `AppLayout`. Staleness is judged against `feed-store.lastRefreshAllAt`.
 
 ### Styling
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,7 +213,7 @@ main.tsx → app.tsx
 │   ├── components/feeds/ (feed-list, feed-item, add-feed-form)
 │   ├── components/articles/ (article-list, article-item)
 │   ├── components/reader/ (reader-panel, view-toggle, article-content)
-│   └── hooks/ (use-keyboard-nav, use-media-query)
+│   └── hooks/ (use-keyboard-nav, use-media-query, use-auto-refresh)
 └── index.css (Tailwind)
 ```
 

--- a/docs/features/005-feed-refresh.md
+++ b/docs/features/005-feed-refresh.md
@@ -5,7 +5,7 @@ Implemented
 
 ## Summary
 
-Feeds can be refreshed to fetch new articles and update changed ones. Refresh happens automatically on app load and can be triggered manually per-feed or for all feeds. New articles are detected via guid-based deduplication using a compound IndexedDB index.
+Feeds can be refreshed to fetch new articles and update changed ones. Refresh happens automatically on app load, on a background interval (`AUTO_REFRESH_INTERVAL_MS`, 30 min) while the app is open, and when a stale tab regains focus. It can also be triggered manually per-feed or for all feeds — the all-feeds control is reachable on both desktop (sidebar header) and mobile (header pill + nav-drawer row). New articles are detected via guid-based deduplication using a compound IndexedDB index.
 
 ## Behaviour
 
@@ -17,6 +17,23 @@ Feature: Feed refresh
     When the app finishes initializing
     Then all feeds are refreshed in the background
     And new articles appear in the feed list
+
+  Scenario: Periodic background refresh
+    Given the app has been open with existing feeds
+    When AUTO_REFRESH_INTERVAL_MS elapses
+    Then all feeds are refreshed in the background
+
+  Scenario: Refresh on focus when stale
+    Given the app has been in a background tab longer than AUTO_REFRESH_INTERVAL_MS
+    When the user returns focus to the tab
+    Then all feeds are refreshed
+    But a return within the interval does not trigger a refresh
+
+  Scenario: Refresh all feeds on mobile
+    Given the user is on a mobile viewport with feeds
+    Then a "Refresh all" control is available in the header and the nav drawer
+    When the user taps it
+    Then all feeds are refreshed and the control shows a spinning "Refreshing…" state
 
   Scenario: Manual refresh all feeds
     Given the user has multiple feeds
@@ -77,8 +94,12 @@ Feature: Feed refresh
 | `src/core/feeds/feed-service.js` | `refreshFeed()`, `refreshAllFeeds()` — fetch, parse, dedup, store |
 | `src/core/storage/db.js` | `getArticleByGuid(feedId, guid)` — compound index lookup |
 | `src/core/storage/schema.js` | `createArticle()` accepts `guid` param, defaults to `link` |
-| `src/stores/feed-store.ts` | `refreshAll()` action with `isRefreshingAll` guard |
-| `src/components/layout/app-sidebar.tsx` | "Refresh" button calls `refreshAll()` |
+| `src/stores/feed-store.ts` | `refreshAll()` action with `isRefreshingAll` guard; records `lastRefreshAllAt`; per-feed `refreshSingleFeed`/`reloadSingleFeed` |
+| `src/hooks/use-auto-refresh.ts` | Background interval + focus-when-stale refresh; mounted in `AppLayout` |
+| `src/components/layout/app-sidebar.tsx` | Desktop sidebar "Refresh" button calls `refreshAll()` |
+| `src/components/articles/article-list-controls.tsx` | Mobile header `RefreshPill` calls `refreshAll()` |
+| `src/components/layout/mobile-nav-drawer.tsx` | Mobile nav-drawer "Refresh all" row calls `refreshAll()` |
+| `src/components/feeds/feed-settings-dialog.tsx` | Per-feed "Refresh now"/"Clear cached articles" with pending state + toast |
 | `src/hooks/use-keyboard-nav.ts` | R key calls `refreshAll()` directly |
 
 ### Tests
@@ -98,6 +119,5 @@ Feature: Feed refresh
 
 ## Limitations
 
-- No refresh interval — auto-refresh only on app load, no periodic polling
+- Background refresh only runs while a tab is open — there is no Service Worker / push-based update when the app is closed
 - Sequential refresh could be slow with many feeds
-- No visual progress indicator during refresh

--- a/src/components/articles/article-list-controls.tsx
+++ b/src/components/articles/article-list-controls.tsx
@@ -1,9 +1,10 @@
-import { Layers, Star, Filter, Folder as FolderIcon } from "lucide-react";
+import { Layers, Star, Filter, Folder as FolderIcon, RefreshCw } from "lucide-react";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
 import { useIsMobile } from "@/hooks/use-mobile.ts";
 import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
+import { ExpandingPill } from "@/components/ui/expanding-pill.tsx";
 import { SortPill } from "./sort-pill.tsx";
 import { SettingsPill } from "./settings-pill.tsx";
 import {
@@ -142,8 +143,34 @@ export function MobileHeaderPills() {
       data-testid="mobile-header-pills"
       className="flex items-center gap-2"
     >
+      <RefreshPill />
       <SettingsPill />
       <SortPill mode={articleSortMode} onChange={setArticleSortMode} />
     </div>
+  );
+}
+
+/**
+ * Refresh-every-feed control for the mobile header. The desktop refresh
+ * lives in the sidebar header, which mobile never renders — without this
+ * the only way to refresh on mobile was the (also-hidden) keyboard `r`.
+ * Hidden when there are no feeds, mirroring the desktop button.
+ */
+function RefreshPill() {
+  const feeds = useFeedStore((s) => s.feeds);
+  const refreshAll = useFeedStore((s) => s.refreshAll);
+  const isRefreshingAll = useFeedStore((s) => s.isRefreshingAll);
+
+  if (feeds.length === 0) return null;
+
+  return (
+    <ExpandingPill
+      icon={<RefreshCw className={isRefreshingAll ? "animate-spin" : ""} />}
+      label={isRefreshingAll ? "Refreshing…" : "Refresh all"}
+      aria-label="Refresh all feeds"
+      dataTestId="mobile-refresh-all"
+      disabled={isRefreshingAll}
+      onClick={() => void refreshAll()}
+    />
   );
 }

--- a/src/components/feeds/feed-settings-dialog.tsx
+++ b/src/components/feeds/feed-settings-dialog.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import {
   Settings2,
   RefreshCw,
@@ -295,6 +296,27 @@ function ActionsSection({ feed }: { feed: Feed }) {
   const reloadSingleFeed = useFeedStore((s) => s.reloadSingleFeed);
   const removeFeed = useFeedStore((s) => s.removeFeed);
   const close = useFeedStore((s) => s.closeFeedSettings);
+  const [busy, setBusy] = useState<"refresh" | "clear" | null>(null);
+
+  async function handleRefresh() {
+    setBusy("refresh");
+    try {
+      await refreshSingleFeed(feed.id);
+      toast("Feed refreshed");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleClear() {
+    setBusy("clear");
+    try {
+      await reloadSingleFeed(feed.id);
+      toast("Cleared cached articles");
+    } finally {
+      setBusy(null);
+    }
+  }
 
   return (
     <section className="space-y-2">
@@ -305,18 +327,22 @@ function ActionsSection({ feed }: { feed: Feed }) {
           variant="outline"
           size="sm"
           data-testid="feed-settings-refresh"
-          onClick={() => refreshSingleFeed(feed.id)}
+          disabled={busy !== null}
+          onClick={handleRefresh}
         >
-          <RefreshCw className="size-4" /> Refresh now
+          <RefreshCw className={`size-4 ${busy === "refresh" ? "animate-spin" : ""}`} />
+          {busy === "refresh" ? "Refreshing…" : "Refresh now"}
         </Button>
         <Button
           type="button"
           variant="outline"
           size="sm"
           data-testid="feed-settings-clear-cache"
-          onClick={() => reloadSingleFeed(feed.id)}
+          disabled={busy !== null}
+          onClick={handleClear}
         >
-          <RotateCcw className="size-4" /> Clear cached articles
+          <RotateCcw className={`size-4 ${busy === "clear" ? "animate-spin" : ""}`} />
+          {busy === "clear" ? "Clearing…" : "Clear cached articles"}
         </Button>
         <AlertDialog>
           <AlertDialogTrigger asChild>

--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
-import { ChevronUp, Layers, Settings } from "lucide-react";
+import { ChevronUp, Layers, RefreshCw, Settings } from "lucide-react";
 import { Drawer } from "vaul";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
@@ -25,6 +25,8 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
   const navigate = useNavigate();
   const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
   const feeds = useFeedStore((s) => s.feeds);
+  const refreshAll = useFeedStore((s) => s.refreshAll);
+  const isRefreshingAll = useFeedStore((s) => s.isRefreshingAll);
 
   useEffect(() => {
     function handleToggle() {
@@ -131,6 +133,20 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
               <SidebarMenu>
                 <NewFolderInput trailing={<AutoOrganizePill />} />
               </SidebarMenu>
+              {feeds.length > 0 && (
+                <button
+                  type="button"
+                  data-testid="drawer-refresh-all"
+                  onClick={() => void refreshAll()}
+                  disabled={isRefreshingAll}
+                  className="flex items-center gap-3 w-full px-2 py-3 text-left text-sm font-medium rounded-md hover:bg-accent disabled:opacity-50"
+                >
+                  <RefreshCw
+                    className={`size-4 shrink-0 text-muted-foreground ${isRefreshingAll ? "animate-spin" : ""}`}
+                  />
+                  {isRefreshingAll ? "Refreshing…" : "Refresh all"}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={handleSettings}

--- a/src/hooks/use-auto-refresh.ts
+++ b/src/hooks/use-auto-refresh.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import { AUTO_REFRESH_INTERVAL_MS } from "@/utils/constants.ts";
+
+/**
+ * Keeps an open tab's feeds fresh without user action.
+ *
+ * Two triggers, one threshold (AUTO_REFRESH_INTERVAL_MS):
+ *  - a background timer refreshes every feed on each interval
+ *  - returning focus to a tab that's been idle longer than the interval
+ *    refreshes immediately rather than waiting out the remainder
+ *
+ * Reads the store via getState() inside the handlers so the effect can
+ * run once (empty deps) and never re-subscribe — refreshAll already
+ * no-ops while a refresh is in flight, so overlapping triggers are safe.
+ *
+ * Mount once, inside the authenticated app shell (AppLayout), so it only
+ * runs after the DB is ready.
+ */
+export function useAutoRefresh() {
+  useEffect(() => {
+    function refreshNow() {
+      if (typeof navigator !== "undefined" && navigator.onLine === false) return;
+      void useFeedStore.getState().refreshAll();
+    }
+
+    const timer = setInterval(refreshNow, AUTO_REFRESH_INTERVAL_MS);
+
+    function refreshIfStale() {
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      ) {
+        return;
+      }
+      const last = useFeedStore.getState().lastRefreshAllAt;
+      if (last !== null && Date.now() - last < AUTO_REFRESH_INTERVAL_MS) return;
+      refreshNow();
+    }
+
+    window.addEventListener("focus", refreshIfStale);
+    document.addEventListener("visibilitychange", refreshIfStale);
+
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener("focus", refreshIfStale);
+      document.removeEventListener("visibilitychange", refreshIfStale);
+    };
+  }, []);
+}

--- a/src/pages/app-layout.tsx
+++ b/src/pages/app-layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useNavigate, useLocation, useParams } from "react-router";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useIsDesktop } from "@/hooks/use-media-query.ts";
 import { useKeyboardNav } from "@/hooks/use-keyboard-nav.ts";
+import { useAutoRefresh } from "@/hooks/use-auto-refresh.ts";
 import { useSharedSidebarSize } from "@/hooks/use-shared-sidebar-size.ts";
 import { useSidebar } from "@/components/ui/sidebar.tsx";
 import { ALL_FEEDS_ID, PANEL_LAYOUT_ID } from "@/utils/constants.ts";
@@ -89,6 +90,7 @@ export function AppLayout() {
   const navigate = useNavigate();
   const { feedId } = useParams();
   useKeyboardNav();
+  useAutoRefresh();
   useDefaultFeedsRedirect();
 
   function handleFeedSelect(id: string) {

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -82,6 +82,11 @@ interface FeedStore {
   isLoading: boolean;
   isRefreshingAll: boolean;
   refreshingFeedIds: Set<string>;
+  /**
+   * Epoch ms of the last completed refreshAll, or null if it hasn't run
+   * this session. Drives the focus-staleness check in useAutoRefresh.
+   */
+  lastRefreshAllAt: number | null;
   error: string | null;
   feedSortMode: FeedSortMode;
   feedCustomOrder: string[];
@@ -338,6 +343,7 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
   isLoading: false,
   isRefreshingAll: false,
   refreshingFeedIds: new Set(),
+  lastRefreshAllAt: null,
   error: null,
   feedSortMode: readSortMode(),
   feedCustomOrder: readJsonArray(LOCAL_STORAGE.FEED_CUSTOM_ORDER),
@@ -486,7 +492,7 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
       await reloadFeeds(set);
       schedulePush();
     } finally {
-      set({ isRefreshingAll: false });
+      set({ isRefreshingAll: false, lastRefreshAllAt: Date.now() });
     }
     // Fire-and-forget — refreshAll returns once the feeds are fresh,
     // prefetch continues in the background.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -142,6 +142,15 @@ export const ARTICLE_GROUPING = {
 } as const;
 
 /**
+ * How often the app refreshes every feed in the background while it's
+ * open. A timer fires on this interval; the same window doubles as the
+ * staleness threshold for the focus-triggered refresh — returning to a
+ * tab that's been idle longer than this pulls fresh articles instead of
+ * waiting out the rest of the interval.
+ */
+export const AUTO_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
+
+/**
  * Group ids for the desktop ResizablePanelGroup tree.
  *
  * Two-tier model:

--- a/tests/components/articles/article-list-controls.test.tsx
+++ b/tests/components/articles/article-list-controls.test.tsx
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import {
   ArticleListControls,
@@ -42,6 +43,13 @@ vi.mock("@/core/sync/sync-service", () => ({
   pushVault: vi.fn(),
   pullVault: vi.fn(),
   importVault: vi.fn(),
+}));
+
+vi.mock("@/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn().mockResolvedValue(undefined),
+  reloadFeed: vi.fn(),
 }));
 
 const { useIsMobileSpy } = vi.hoisted(() => ({
@@ -159,6 +167,7 @@ describe("MobileHeaderPills", () => {
       feeds: [feed("f-tech", "Tech Crunchies")],
       folders: [],
       selectedFeedId: "f-tech",
+      isRefreshingAll: false,
     });
     useSmartFilterStore.setState({ filters: [] });
     useArticleStore.setState({ articleSortMode: "newest" });
@@ -188,5 +197,46 @@ describe("MobileHeaderPills", () => {
     );
     expect(screen.queryByTestId("settings-pill")).toBeNull();
     expect(screen.getByLabelText(/sort/i)).toBeInTheDocument();
+  });
+
+  it("shows a refresh-all control when feeds exist", () => {
+    render(
+      <MemoryRouter>
+        <MobileHeaderPills />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("mobile-refresh-all")).toBeInTheDocument();
+  });
+
+  it("hides the refresh-all control when there are no feeds", () => {
+    useFeedStore.setState({ feeds: [], selectedFeedId: ALL_FEEDS_ID });
+    render(
+      <MemoryRouter>
+        <MobileHeaderPills />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("mobile-refresh-all")).toBeNull();
+  });
+
+  it("tapping refresh-all refreshes every feed", async () => {
+    const { refreshAllFeeds } = await import("@/core/feeds/feed-service.ts");
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <MobileHeaderPills />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByTestId("mobile-refresh-all"));
+    expect(refreshAllFeeds).toHaveBeenCalled();
+  });
+
+  it("disables the refresh-all control while a refresh is in flight", () => {
+    useFeedStore.setState({ isRefreshingAll: true });
+    render(
+      <MemoryRouter>
+        <MobileHeaderPills />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("mobile-refresh-all")).toBeDisabled();
   });
 });

--- a/tests/components/feeds/feed-settings-dialog.test.tsx
+++ b/tests/components/feeds/feed-settings-dialog.test.tsx
@@ -9,12 +9,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
+import { toast } from "sonner";
 import { FeedSettingsDialog } from "@/components/feeds/feed-settings-dialog.tsx";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import type { Feed, Folder } from "@/types/index.ts";
+
+vi.mock("sonner", () => ({ toast: vi.fn() }));
 
 vi.mock("@/core/storage/db.ts", () => ({
   getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
@@ -219,6 +222,43 @@ describe("FeedSettingsDialog", () => {
     renderDialog();
     await user.click(screen.getByTestId("feed-settings-clear-cache"));
     expect(reloadSingleFeed).toHaveBeenCalledWith("f-tech");
+  });
+
+  it("Refresh now shows a pending state and disables the actions while in flight", async () => {
+    const user = userEvent.setup();
+    let resolveRefresh!: () => void;
+    refreshSingleFeed.mockImplementation(
+      () => new Promise<void>((resolve) => { resolveRefresh = resolve; }),
+    );
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+
+    const refreshBtn = screen.getByTestId("feed-settings-refresh");
+    const clearBtn = screen.getByTestId("feed-settings-clear-cache");
+    await user.click(refreshBtn);
+
+    expect(refreshBtn).toBeDisabled();
+    expect(clearBtn).toBeDisabled();
+    expect(refreshBtn).toHaveTextContent(/Refreshing/i);
+
+    await act(async () => { resolveRefresh(); });
+    await waitFor(() => expect(refreshBtn).toBeEnabled());
+  });
+
+  it("Refresh now confirms completion with a toast", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+    await user.click(screen.getByTestId("feed-settings-refresh"));
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+  });
+
+  it("Clear cached articles confirms completion with a toast", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feedSettingsDialogId: "f-tech" });
+    renderDialog();
+    await user.click(screen.getByTestId("feed-settings-clear-cache"));
+    await waitFor(() => expect(toast).toHaveBeenCalled());
   });
 
   it("Delete button shows a confirmation, then calls removeFeed when confirmed", async () => {

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -179,6 +179,29 @@ describe("MobileNavDrawer", () => {
     expect(screen.getByTestId("probe-path")).toHaveTextContent("/settings");
   });
 
+  it("renders a 'Refresh all' row that refreshes every feed when feeds exist", async () => {
+    const { refreshAllFeeds } = await import("@/core/feeds/feed-service.ts");
+    const user = userEvent.setup();
+    useFeedStore.setState({ feeds: [makeFeed("f1", "Test Feed")] });
+    renderDrawer();
+    await user.click(screen.getByRole("button", { name: "Open feed list" }));
+
+    const refreshBtn = await screen.findByTestId("drawer-refresh-all");
+    await user.click(refreshBtn);
+
+    expect(refreshAllFeeds).toHaveBeenCalled();
+  });
+
+  it("hides the 'Refresh all' row when there are no feeds", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({ feeds: [] });
+    renderDrawer();
+    await user.click(screen.getByRole("button", { name: "Open feed list" }));
+    // Settings is always present; refresh row is feed-gated.
+    await screen.findByRole("button", { name: "Settings" });
+    expect(screen.queryByTestId("drawer-refresh-all")).toBeNull();
+  });
+
   it("drawer body content has horizontal padding so feed/settings rows don't run edge-to-edge", async () => {
     const user = userEvent.setup();
     useFeedStore.setState({ feeds: [makeFeed("f1", "Test Feed")] });

--- a/tests/hooks/use-auto-refresh.test.ts
+++ b/tests/hooks/use-auto-refresh.test.ts
@@ -1,0 +1,88 @@
+/**
+ * useAutoRefresh — background freshness for an open tab.
+ *
+ * Behaviour under test (all user-observable through refreshAll):
+ *   - fires refreshAll on the AUTO_REFRESH_INTERVAL_MS timer
+ *   - refreshes on tab focus when the corpus is stale (last refresh
+ *     older than the interval)
+ *   - does NOT refresh on focus when feeds are still fresh
+ *   - skips refresh while offline
+ *   - tears down its timer and listeners on unmount
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAutoRefresh } from "@/hooks/use-auto-refresh.ts";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import { AUTO_REFRESH_INTERVAL_MS } from "@/utils/constants.ts";
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", { value, configurable: true });
+}
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    configurable: true,
+  });
+}
+
+describe("useAutoRefresh", () => {
+  let refreshAll: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    refreshAll = vi.fn().mockResolvedValue(undefined);
+    useFeedStore.setState({ refreshAll, lastRefreshAllAt: null });
+    setOnline(true);
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes all feeds when the interval elapses", () => {
+    renderHook(() => useAutoRefresh());
+    expect(refreshAll).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(AUTO_REFRESH_INTERVAL_MS);
+    expect(refreshAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh on the timer while offline", () => {
+    setOnline(false);
+    renderHook(() => useAutoRefresh());
+
+    vi.advanceTimersByTime(AUTO_REFRESH_INTERVAL_MS);
+    expect(refreshAll).not.toHaveBeenCalled();
+  });
+
+  it("refreshes on focus when the corpus is stale", () => {
+    useFeedStore.setState({
+      lastRefreshAllAt: Date.now() - AUTO_REFRESH_INTERVAL_MS - 1,
+    });
+    renderHook(() => useAutoRefresh());
+
+    window.dispatchEvent(new Event("focus"));
+    expect(refreshAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh on focus when the corpus is still fresh", () => {
+    useFeedStore.setState({ lastRefreshAllAt: Date.now() });
+    renderHook(() => useAutoRefresh());
+
+    window.dispatchEvent(new Event("focus"));
+    expect(refreshAll).not.toHaveBeenCalled();
+  });
+
+  it("stops refreshing after unmount", () => {
+    const { unmount } = renderHook(() => useAutoRefresh());
+    unmount();
+
+    vi.advanceTimersByTime(AUTO_REFRESH_INTERVAL_MS * 2);
+    window.dispatchEvent(new Event("focus"));
+    expect(refreshAll).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Addresses three gaps in the refresh UX:

1. No periodic refresh — feeds only updated on boot or manual trigger.
   Adds useAutoRefresh (mounted in AppLayout): a 30-min background timer
   (AUTO_REFRESH_INTERVAL_MS) plus a focus-when-stale trigger that pulls
   fresh articles when a tab idle longer than the interval regains focus.
   feed-store now records lastRefreshAllAt for the staleness check.

2. No refresh-all on mobile — the refresh control lived only in the
   desktop sidebar header. Adds a RefreshPill to the mobile header and a
   "Refresh all" row to the mobile nav drawer, both feed-gated and showing
   a spinning "Refreshing…" state.

3. No tap feedback on per-feed actions — "Refresh now" and "Clear cached
   articles" in the feed settings dialog gave no visual response. Both now
   disable during the operation, spin their icon, swap to a pending label,
   and fire a confirmation toast on completion.

Key files: src/hooks/use-auto-refresh.ts, src/stores/feed-store.ts,
src/components/articles/article-list-controls.tsx,
src/components/layout/mobile-nav-drawer.tsx,
src/components/feeds/feed-settings-dialog.tsx, src/utils/constants.ts.

https://claude.ai/code/session_01P3hHxWtGRd6aaJt8Czb5od