### PR TITLE
feat(license): daily in-session license re-verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ URL is the source of truth for navigation state. `FeedsPage` syncs URL params �
 - **use-keyboard-nav** — Article nav `j`/`k` (clicks DOM elements — same code path as mouse). Feed nav `u`/`i`. Actions: `o` open original, `e` toggle view (`toggleViewMode()`), `n` add feed (custom event), `[` toggle sidebar, `r` refresh. Disabled when focus is in input/textarea/contenteditable.
 - **use-media-query / use-mobile** — `useIsDesktop()` ≥1024px; `useIsMobile()` <768px (sidebar/sheet).
 - **use-auto-refresh** — Background `refreshAll()` on the `AUTO_REFRESH_INTERVAL_MS` (30 min) timer plus a focus-when-stale trigger (returning to a tab idle longer than the interval refreshes immediately). Reads the store via `getState()` inside its handlers so it subscribes once; mounted in `AppLayout`. Staleness is judged against `feed-store.lastRefreshAllAt`.
+- **use-license-refresh** — Same shape as `use-auto-refresh` but for license re-verification: a daily `LICENSE_RECHECK_INTERVAL_MS` (24h) timer + focus-when-stale trigger calling `license-store.refresh()`. Closes the gap where a tab left open for days never reboots, so a revoked subscription would keep its paid tier for the whole session. Staleness is judged against `license-store.lastCheckedAt`, which `refresh()` stamps only on a *definitive* resolution (no-token, 200, or 4xx) — transient 5xx/network failures leave it stale so focus retries promptly instead of waiting a full day. Mounted in `AppLayout` alongside `use-auto-refresh`.
 
 ### Styling
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,7 +213,7 @@ main.tsx → app.tsx
 │   ├── components/feeds/ (feed-list, feed-item, add-feed-form)
 │   ├── components/articles/ (article-list, article-item)
 │   ├── components/reader/ (reader-panel, view-toggle, article-content)
-│   └── hooks/ (use-keyboard-nav, use-media-query, use-auto-refresh)
+│   └── hooks/ (use-keyboard-nav, use-media-query, use-auto-refresh, use-license-refresh)
 └── index.css (Tailwind)
 ```
 

--- a/src/hooks/use-license-refresh.ts
+++ b/src/hooks/use-license-refresh.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useLicenseStore } from "@/stores/license-store.ts";
+import { LICENSE_RECHECK_INTERVAL_MS } from "@/utils/constants.ts";
+
+/**
+ * Re-verifies the license token against the server while a tab stays open.
+ *
+ * Boot (app.tsx) and cross-tab storage events already re-resolve the tier,
+ * but a tab left open for days never reboots — so a subscription revoked
+ * mid-session would keep its paid tier until the next reload. Two triggers,
+ * one threshold (LICENSE_RECHECK_INTERVAL_MS):
+ *  - a background timer re-verifies once a day
+ *  - returning focus to a tab whose last definitive check is older than the
+ *    interval re-verifies immediately, catching a machine that slept (which
+ *    suspends the timer) rather than waiting out a fresh full day
+ *
+ * Reads the store via getState() inside the handlers so the effect runs
+ * once (empty deps) and never re-subscribes. refresh() handles its own
+ * transient-failure tolerance, so overlapping triggers are safe.
+ *
+ * Mount once, inside the authenticated app shell (AppLayout), alongside
+ * useAutoRefresh.
+ */
+export function useLicenseRefresh() {
+  useEffect(() => {
+    function refreshNow() {
+      if (typeof navigator !== "undefined" && navigator.onLine === false) return;
+      void useLicenseStore.getState().refresh();
+    }
+
+    const timer = setInterval(refreshNow, LICENSE_RECHECK_INTERVAL_MS);
+
+    function refreshIfStale() {
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      ) {
+        return;
+      }
+      const last = useLicenseStore.getState().lastCheckedAt;
+      if (last !== null && Date.now() - last < LICENSE_RECHECK_INTERVAL_MS) return;
+      refreshNow();
+    }
+
+    window.addEventListener("focus", refreshIfStale);
+    document.addEventListener("visibilitychange", refreshIfStale);
+
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener("focus", refreshIfStale);
+      document.removeEventListener("visibilitychange", refreshIfStale);
+    };
+  }, []);
+}

--- a/src/pages/app-layout.tsx
+++ b/src/pages/app-layout.tsx
@@ -4,6 +4,7 @@ import { useFeedStore } from "@/stores/feed-store.ts";
 import { useIsDesktop } from "@/hooks/use-media-query.ts";
 import { useKeyboardNav } from "@/hooks/use-keyboard-nav.ts";
 import { useAutoRefresh } from "@/hooks/use-auto-refresh.ts";
+import { useLicenseRefresh } from "@/hooks/use-license-refresh.ts";
 import { useSharedSidebarSize } from "@/hooks/use-shared-sidebar-size.ts";
 import { useSidebar } from "@/components/ui/sidebar.tsx";
 import { ALL_FEEDS_ID, PANEL_LAYOUT_ID } from "@/utils/constants.ts";
@@ -91,6 +92,7 @@ export function AppLayout() {
   const { feedId } = useParams();
   useKeyboardNav();
   useAutoRefresh();
+  useLicenseRefresh();
   useDefaultFeedsRedirect();
 
   function handleFeedSelect(id: string) {

--- a/src/stores/license-store.ts
+++ b/src/stores/license-store.ts
@@ -33,6 +33,13 @@ import type { Tier } from "@/core/features/feature-gates";
 interface LicenseState {
   tier: Tier;
   verifying: boolean;
+  /**
+   * Epoch ms of the last *definitive* tier resolution — a no-token check,
+   * a server confirmation (200), or an explicit server rejection (4xx).
+   * Transient failures (5xx, network) deliberately leave this untouched so
+   * the focus-when-stale trigger in useLicenseRefresh retries them sooner.
+   */
+  lastCheckedAt: number | null;
   refresh: () => Promise<void>;
   /** Direct setter used by tests and explicit overrides. */
   setTier: (tier: Tier) => void;
@@ -53,13 +60,14 @@ function decodeTierFromToken(token: string): Tier {
 export const useLicenseStore = create<LicenseState>((set) => ({
   tier: "free",
   verifying: false,
+  lastCheckedAt: null,
 
   setTier: (tier) => set({ tier }),
 
   refresh: async () => {
     const token = getLicenseToken();
     if (!token) {
-      set({ tier: "free", verifying: false });
+      set({ tier: "free", verifying: false, lastCheckedAt: Date.now() });
       return;
     }
 
@@ -77,7 +85,8 @@ export const useLicenseStore = create<LicenseState>((set) => ({
         // 5xx = transient (Vercel hiccup, Upstash blip). DO NOT clear the
         // token — a paying customer would see their tier silently flip to
         // Free and panic. Keep the locally-decoded tier; the next refresh
-        // (page load, cross-tab event) will retry.
+        // (page load, cross-tab event) will retry. Leave lastCheckedAt
+        // stale so the focus-when-stale trigger retries promptly.
         // 4xx = the server explicitly rejected this token (revoked,
         // expired, forged). Clear so we don't keep sending an invalid
         // Bearer on every sync request.
@@ -86,18 +95,19 @@ export const useLicenseStore = create<LicenseState>((set) => ({
           return;
         }
         clearLicenseToken();
-        set({ tier: "free", verifying: false });
+        set({ tier: "free", verifying: false, lastCheckedAt: Date.now() });
         return;
       }
       const serverTier = body.license?.tier;
       if (isTier(serverTier)) {
-        set({ tier: serverTier, verifying: false });
+        set({ tier: serverTier, verifying: false, lastCheckedAt: Date.now() });
       } else {
-        set({ verifying: false });
+        set({ verifying: false, lastCheckedAt: Date.now() });
       }
     } catch {
       // Network failure: keep the locally-decoded tier. An offline user
-      // should not lose paid status mid-session.
+      // should not lose paid status mid-session. Leave lastCheckedAt stale
+      // so the next focus retries instead of waiting out the full day.
       set({ verifying: false });
     }
   },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -151,6 +151,18 @@ export const ARTICLE_GROUPING = {
 export const AUTO_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
 
 /**
+ * How often an open tab re-verifies the license token against the server.
+ * The boot-time check (app.tsx) and cross-tab storage events catch most
+ * changes, but a tab left open for days never reboots — so a lapsed
+ * subscription would keep its paid tier for the whole session. A daily
+ * timer (and a focus-when-stale trigger for tabs whose timer was
+ * suspended by a sleeping machine) closes that gap. Once a day is enough:
+ * revocation is not time-critical, and a tighter cadence would add
+ * needless server traffic for a rare event.
+ */
+export const LICENSE_RECHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
  * Group ids for the desktop ResizablePanelGroup tree.
  *
  * Two-tier model:

--- a/tests/hooks/use-license-refresh.test.ts
+++ b/tests/hooks/use-license-refresh.test.ts
@@ -1,0 +1,80 @@
+/**
+ * useLicenseRefresh — daily license re-verification for an open tab.
+ *
+ * Behaviour under test (all user-observable through the store's refresh):
+ *   - fires refresh on the LICENSE_RECHECK_INTERVAL_MS timer
+ *   - re-verifies on tab focus when the last check is stale (older than
+ *     the interval) — catches a slept laptop whose timer was suspended
+ *   - does NOT re-verify on focus when the last check is still fresh
+ *   - skips while offline
+ *   - tears down its timer and listeners on unmount
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useLicenseRefresh } from "@/hooks/use-license-refresh.ts";
+import { useLicenseStore } from "@/stores/license-store.ts";
+import { LICENSE_RECHECK_INTERVAL_MS } from "@/utils/constants.ts";
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", { value, configurable: true });
+}
+
+describe("useLicenseRefresh", () => {
+  let refresh: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    refresh = vi.fn().mockResolvedValue(undefined);
+    useLicenseStore.setState({ refresh, lastCheckedAt: null });
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("re-verifies the license when the interval elapses", () => {
+    renderHook(() => useLicenseRefresh());
+    expect(refresh).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(LICENSE_RECHECK_INTERVAL_MS);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-verify on the timer while offline", () => {
+    setOnline(false);
+    renderHook(() => useLicenseRefresh());
+
+    vi.advanceTimersByTime(LICENSE_RECHECK_INTERVAL_MS);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("re-verifies on focus when the last check is stale", () => {
+    useLicenseStore.setState({
+      lastCheckedAt: Date.now() - LICENSE_RECHECK_INTERVAL_MS - 1,
+    });
+    renderHook(() => useLicenseRefresh());
+
+    window.dispatchEvent(new Event("focus"));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-verify on focus when the last check is still fresh", () => {
+    useLicenseStore.setState({ lastCheckedAt: Date.now() });
+    renderHook(() => useLicenseRefresh());
+
+    window.dispatchEvent(new Event("focus"));
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("stops re-verifying after unmount", () => {
+    const { unmount } = renderHook(() => useLicenseRefresh());
+    unmount();
+
+    vi.advanceTimersByTime(LICENSE_RECHECK_INTERVAL_MS * 2);
+    window.dispatchEvent(new Event("focus"));
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/tests/stores/license-store.test.ts
+++ b/tests/stores/license-store.test.ts
@@ -26,7 +26,7 @@ const personalToken = makeToken("personal");
 const proToken = makeToken("pro");
 
 function resetStore() {
-  useLicenseStore.setState({ tier: "free", verifying: false });
+  useLicenseStore.setState({ tier: "free", verifying: false, lastCheckedAt: null });
 }
 
 describe("useLicenseStore", () => {
@@ -141,6 +141,62 @@ describe("useLicenseStore", () => {
 
       await useLicenseStore.getState().refresh();
       expect(useLicenseStore.getState().tier).toBe("free");
+    });
+  });
+
+  describe("refresh — lastCheckedAt tracking", () => {
+    it("stamps lastCheckedAt when there is no token (definitive: free)", async () => {
+      const before = Date.now();
+      await useLicenseStore.getState().refresh();
+      const stamped = useLicenseStore.getState().lastCheckedAt;
+      expect(stamped).not.toBeNull();
+      expect(stamped as number).toBeGreaterThanOrEqual(before);
+    });
+
+    it("stamps lastCheckedAt when the server confirms the tier (200)", async () => {
+      setLicenseToken(personalToken);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, license: { tier: "personal" } }), {
+          status: 200,
+        }),
+      );
+      const before = Date.now();
+      await useLicenseStore.getState().refresh();
+      expect(useLicenseStore.getState().lastCheckedAt as number).toBeGreaterThanOrEqual(
+        before,
+      );
+    });
+
+    it("stamps lastCheckedAt when the server rejects the token (4xx)", async () => {
+      setLicenseToken(proToken);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ ok: false, error: "revoked" }), {
+          status: 401,
+        }),
+      );
+      const before = Date.now();
+      await useLicenseStore.getState().refresh();
+      expect(useLicenseStore.getState().lastCheckedAt as number).toBeGreaterThanOrEqual(
+        before,
+      );
+    });
+
+    it("does NOT stamp lastCheckedAt on a transient 5xx (so focus retries sooner)", async () => {
+      setLicenseToken(personalToken);
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ ok: false, error: "bad gateway" }), {
+          status: 502,
+        }),
+      );
+      await useLicenseStore.getState().refresh();
+      expect(useLicenseStore.getState().lastCheckedAt).toBeNull();
+    });
+
+    it("does NOT stamp lastCheckedAt when the network fetch throws", async () => {
+      setLicenseToken(personalToken);
+      fetchMock.mockRejectedValue(new Error("offline"));
+      await useLicenseStore.getState().refresh();
+      expect(useLicenseStore.getState().lastCheckedAt).toBeNull();
     });
   });
 


### PR DESCRIPTION
Add useLicenseRefresh, a daily timer + focus-when-stale hook that
re-verifies the license token against the server while a tab stays open.

Previously the client only re-resolved tier at boot (app.tsx) and on
cross-tab storage events. A tab left open for days never reboots, so a
subscription revoked mid-session kept its paid tier for the whole
session — the lapse was only discovered on the next full reload.

The hook mirrors useAutoRefresh: a LICENSE_RECHECK_INTERVAL_MS (24h)
timer plus a focus-when-stale trigger that catches a slept machine whose
timer was suspended. Staleness is judged against a new
license-store.lastCheckedAt, stamped only on a definitive resolution
(no-token, 200, or 4xx); transient 5xx/network failures leave it stale
so focus retries promptly instead of waiting a full day.

Key files: src/hooks/use-license-refresh.ts (new), src/stores/license-store.ts
(lastCheckedAt), src/utils/constants.ts (LICENSE_RECHECK_INTERVAL_MS),
src/pages/app-layout.tsx (mount).

https://claude.ai/code/session_01GgBt6m8yCim8tQRFow6rmv