### PR TITLE
feat: scope header refresh to current view + mobile empty-stage fallback

### DIFF
--- a/docs/features/005-feed-refresh.md
+++ b/docs/features/005-feed-refresh.md
@@ -5,7 +5,7 @@ Implemented
 
 ## Summary
 
-Feeds can be refreshed to fetch new articles and update changed ones. Refresh happens automatically on app load, on a background interval (`AUTO_REFRESH_INTERVAL_MS`, 30 min) while the app is open, and when a stale tab regains focus. It can also be triggered manually per-feed or for all feeds — the all-feeds control is reachable on both desktop (sidebar header) and mobile (header pill + nav-drawer row). New articles are detected via guid-based deduplication using a compound IndexedDB index.
+Feeds can be refreshed to fetch new articles and update changed ones. Refresh happens automatically on app load, on a background interval (`AUTO_REFRESH_INTERVAL_MS`, 30 min) while the app is open, and when a stale tab regains focus. It can also be triggered manually. The global "refresh all" control lives on the desktop sidebar header, the mobile nav-drawer row, and the `R` keyboard shortcut. The **header refresh control** (mobile header pill) is instead **scoped to the current view** via `refreshView`: viewing a single feed refreshes only that feed, a folder refreshes only its members, and an aggregated view (All items / Starred / a smart filter) refreshes every feed. When an article list is empty, that same scoped refresh is offered as a prominent in-list button. New articles are detected via guid-based deduplication using a compound IndexedDB index.
 
 ## Behaviour
 
@@ -29,11 +29,28 @@ Feature: Feed refresh
     Then all feeds are refreshed
     But a return within the interval does not trigger a refresh
 
-  Scenario: Refresh all feeds on mobile
-    Given the user is on a mobile viewport with feeds
-    Then a "Refresh all" control is available in the header and the nav drawer
+  Scenario: Scoped refresh from the mobile header
+    Given the user is on a mobile viewport viewing a single feed
+    Then a "Refresh" control is available in the header
     When the user taps it
-    Then all feeds are refreshed and the control shows a spinning "Refreshing…" state
+    Then only that feed is refreshed and its article list updates in place
+    And the control shows a spinning "Refreshing…" state
+
+  Scenario: Scoped refresh of an aggregated view
+    Given the user is viewing All items, Starred, or a smart filter
+    When the user taps the header "Refresh" control
+    Then every feed is refreshed (the view aggregates across all feeds)
+
+  Scenario: Scoped refresh of a folder
+    Given the user is viewing a folder
+    When the user taps the header "Refresh" control
+    Then only the folder's member feeds are refreshed
+
+  Scenario: Refresh path from an empty article list
+    Given the selected feed/folder/filter has no articles and is not loading
+    Then the article list shows a prominent "Refresh" button
+    When the user taps it
+    Then the current view is refreshed and any new articles appear in place
 
   Scenario: Manual refresh all feeds
     Given the user has multiple feeds
@@ -94,11 +111,12 @@ Feature: Feed refresh
 | `src/core/feeds/feed-service.js` | `refreshFeed()`, `refreshAllFeeds()` — fetch, parse, dedup, store |
 | `src/core/storage/db.js` | `getArticleByGuid(feedId, guid)` — compound index lookup |
 | `src/core/storage/schema.js` | `createArticle()` accepts `guid` param, defaults to `link` |
-| `src/stores/feed-store.ts` | `refreshAll()` action with `isRefreshingAll` guard; records `lastRefreshAllAt`; per-feed `refreshSingleFeed`/`reloadSingleFeed` |
+| `src/stores/feed-store.ts` | `refreshAll()` (global) + `refreshView(feedId)` (scoped: concrete feed / folder members / aggregated→all, then reloads the article list); both guard on `isRefreshingAll`; only full refreshes stamp `lastRefreshAllAt`; per-feed `refreshSingleFeed`/`reloadSingleFeed` |
 | `src/hooks/use-auto-refresh.ts` | Background interval + focus-when-stale refresh; mounted in `AppLayout` |
-| `src/components/layout/app-sidebar.tsx` | Desktop sidebar "Refresh" button calls `refreshAll()` |
-| `src/components/articles/article-list-controls.tsx` | Mobile header `RefreshPill` calls `refreshAll()` |
-| `src/components/layout/mobile-nav-drawer.tsx` | Mobile nav-drawer "Refresh all" row calls `refreshAll()` |
+| `src/components/layout/app-sidebar.tsx` | Desktop sidebar "Refresh" button calls `refreshAll()` (global) |
+| `src/components/articles/article-list-controls.tsx` | Mobile header `RefreshPill` calls `refreshView(selectedFeedId)` (scoped to the current view) |
+| `src/components/articles/article-list.tsx` | `EmptyArticleList` — prominent in-list "Refresh" button when the view has no articles; calls `refreshView` |
+| `src/components/layout/mobile-nav-drawer.tsx` | Mobile nav-drawer "Refresh all" row calls `refreshAll()` (global) |
 | `src/components/feeds/feed-settings-dialog.tsx` | Per-feed "Refresh now"/"Clear cached articles" with pending state + toast |
 | `src/hooks/use-keyboard-nav.ts` | R key calls `refreshAll()` directly |
 

--- a/docs/features/010-mobile-navigation.md
+++ b/docs/features/010-mobile-navigation.md
@@ -40,6 +40,19 @@ Feature: Mobile navigation
     And the user can select a different article
     And no automatic navigation occurs
 
+  Rule: An empty stage falls back to the article list
+
+  Scenario: Viewed article disappears from cache
+    Given the user is reading an article on mobile
+    When that article is removed from the loaded set (e.g. the article cache is cleared)
+    Then the user is navigated back to the article list
+    And the reader is not left showing a blank stage
+
+  Scenario: Deeplink to an already-empty feed does not bounce
+    Given the user opens an article URL for a feed that loads no articles
+    Then the user stays on that URL (the reader shows its own empty state)
+    And no automatic back-navigation occurs
+
   Rule: Mobile layout is single-panel
 
   Scenario: Mobile shows one content panel at a time
@@ -70,7 +83,7 @@ Feature: Mobile navigation
 
 | File | Role |
 |------|------|
-| `src/pages/feeds-page.tsx` | Main page component with mobile/desktop layout switching, Back button handler, and auto-select suppression logic |
+| `src/pages/feeds-route.tsx` | Mobile/desktop layout switching, scroll-snap nav, auto-select suppression, and the empty-stage→list fallback (present→absent transition guard) |
 | `src/hooks/use-media-query.ts` | `useIsDesktop()` hook for responsive breakpoint detection |
 
 ### Tests
@@ -87,6 +100,8 @@ Feature: Mobile navigation
 - **Stack-based navigation** — Mobile navigation follows the standard iOS/Android pattern: Article → Article List → Feed List. This matches user mental models for drill-down interfaces.
 
 - **Auto-select only on feed switch** — Auto-selecting the first article when switching feeds improves UX by showing content immediately. But auto-select is suppressed after Back navigation because the user explicitly wanted to see the article list (to pick a different article).
+
+- **Empty-stage fallback is a transition, not a state** — The reader bounces back to the article list only when the viewed article goes from *present* to *absent* (tracked with `viewedArticlePresentRef`). A deeplink to a feed that simply loads empty is left alone so the reader can show its own empty state — distinguishing "the thing I was reading vanished" from "there was never anything here."
 
 ## Limitations
 

--- a/src/components/articles/article-list-controls.tsx
+++ b/src/components/articles/article-list-controls.tsx
@@ -151,13 +151,17 @@ export function MobileHeaderPills() {
 }
 
 /**
- * Refresh-every-feed control for the mobile header. The desktop refresh
- * lives in the sidebar header, which mobile never renders — without this
- * the only way to refresh on mobile was the (also-hidden) keyboard `r`.
+ * Refresh control for the mobile header. The desktop refresh lives in the
+ * sidebar header, which mobile never renders — without this the only way to
+ * refresh on mobile was the (also-hidden) keyboard `r`. Scoped to the current
+ * view via `refreshView`: a single feed refreshes only that feed, a folder
+ * only its members, an aggregated view (All / Starred / filter) every feed.
  * Hidden when there are no feeds, mirroring the desktop button.
  */
 function RefreshPill() {
   const feeds = useFeedStore((s) => s.feeds);
+  const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
+  const refreshView = useFeedStore((s) => s.refreshView);
   const refreshAll = useFeedStore((s) => s.refreshAll);
   const isRefreshingAll = useFeedStore((s) => s.isRefreshingAll);
 
@@ -166,11 +170,13 @@ function RefreshPill() {
   return (
     <ExpandingPill
       icon={<RefreshCw className={isRefreshingAll ? "animate-spin" : ""} />}
-      label={isRefreshingAll ? "Refreshing…" : "Refresh all"}
-      aria-label="Refresh all feeds"
-      dataTestId="mobile-refresh-all"
+      label={isRefreshingAll ? "Refreshing…" : "Refresh"}
+      aria-label="Refresh"
+      dataTestId="mobile-refresh"
       disabled={isRefreshingAll}
-      onClick={() => void refreshAll()}
+      onClick={() =>
+        void (selectedFeedId ? refreshView(selectedFeedId) : refreshAll())
+      }
     />
   );
 }

--- a/src/components/articles/article-list.tsx
+++ b/src/components/articles/article-list.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useEffect, useRef, useCallback } from "react";
-import { CheckCheck } from "lucide-react";
+import { CheckCheck, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils.ts";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
@@ -66,6 +67,7 @@ function isItemVisible(scrollEl: HTMLElement, articleId: string): boolean {
 
 export function ArticleList({ onArticleSelect }: ArticleListProps) {
   const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
+  const isRefreshing = useFeedStore((s) => s.isRefreshingAll);
   const feeds = useFeedStore((s) => s.feeds);
   const articles = useArticleStore((s) => s.articles);
   const selectedArticle = useArticleStore((s) => s.selectedArticle);
@@ -229,13 +231,14 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
   }
 
   if (articles.length === 0) {
-    return isLoading ? (
-      <div ref={scrollRef} className="h-full overflow-y-auto" />
-    ) : (
+    // Show the blank placeholder only during the initial silent load. Once a
+    // load settles with nothing — or while a user-initiated refresh runs — the
+    // empty state with its refresh affordance stays put so the user has a
+    // prominent way to pull this feed/folder/filter again.
+    const showBlank = isLoading && !isRefreshing;
+    return (
       <div ref={scrollRef} className="h-full overflow-y-auto">
-        <div className="p-2 text-muted-foreground text-sm">
-          No articles found.
-        </div>
+        {showBlank ? null : <EmptyArticleList feedId={selectedFeedId} />}
       </div>
     );
   }
@@ -307,6 +310,34 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
         })}
       </ul>
       <MarkReadPill unreadCount={unreadCount} onMarkAll={markAllAsRead} />
+    </div>
+  );
+}
+
+/**
+ * Empty-list state. An empty feed is most often a feed that just hasn't been
+ * fetched yet (or one whose cache was cleared), so the primary action is to
+ * refresh — scoped to whatever the user is viewing via `refreshView`.
+ */
+function EmptyArticleList({ feedId }: { feedId: string }) {
+  const refreshView = useFeedStore((s) => s.refreshView);
+  const isRefreshing = useFeedStore((s) => s.isRefreshingAll);
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+      <p className="text-sm text-muted-foreground">
+        No articles here yet.
+      </p>
+      <Button
+        data-testid="empty-refresh"
+        variant="secondary"
+        size="sm"
+        disabled={isRefreshing}
+        onClick={() => void refreshView(feedId)}
+      >
+        <RefreshCw className={cn("size-4", isRefreshing && "animate-spin")} />
+        {isRefreshing ? "Refreshing…" : "Refresh"}
+      </Button>
     </div>
   );
 }

--- a/src/pages/feeds-route.tsx
+++ b/src/pages/feeds-route.tsx
@@ -131,6 +131,27 @@ export function FeedsRoute() {
     }
   }, [articleId]);
 
+  // Mobile: when the article being read disappears from the loaded set (e.g.
+  // the user clears the article cache), the reader stage goes empty. Send them
+  // back to the article list rather than stranding them on a blank reader.
+  //
+  // Tracked as a present→absent transition so a deeplink to an already-empty
+  // feed still shows the reader's own empty state instead of bouncing — the
+  // bounce only fires for an article that *was* on screen and then vanished.
+  const viewedArticlePresentRef = useRef(false);
+  useEffect(() => {
+    if (isDesktop || !feedId || !articleId || isLoadingArticles) return;
+    if (articles.some((a) => a.id === articleId)) {
+      viewedArticlePresentRef.current = true;
+      return;
+    }
+    if (!viewedArticlePresentRef.current) return;
+    viewedArticlePresentRef.current = false;
+    skipAutoSelectRef.current = true;
+    scrollToList();
+    navigate(`/feeds/${feedId}`, { replace: true });
+  }, [isDesktop, feedId, articleId, articles, isLoadingArticles, navigate, scrollToList]);
+
   // Scroll to the reader panel when the user explicitly navigates to an article.
   // snapScrollMountedRef skips the initial render so loading the app with an
   // articleId already in the URL lands on the article list, not the reader.

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -31,7 +31,13 @@ import { retryFailedFavicons } from "../core/favicon/favicon-cache.ts";
 import { isPaidTierActive } from "../core/features/paid-tier-active.ts";
 import { checkFeedQuota, quotaErrorMessage } from "../core/features/quotas.ts";
 import { isFeatureEnabled, enforceFeature } from "./enforce-feature.ts";
-import { CHANGELOG_FEED_URL, LOCAL_STORAGE } from "../utils/constants.ts";
+import {
+  CHANGELOG_FEED_URL,
+  LOCAL_STORAGE,
+  isFolderFeedId,
+  fromFolderFeedId,
+  isAggregatedFeedId,
+} from "../utils/constants.ts";
 import { pickNextFolderColor } from "../lib/folder-colors.ts";
 import type {
   Feed,
@@ -117,6 +123,15 @@ interface FeedStore {
   reloadSingleFeed: (feedId: string) => Promise<void>;
   selectFeed: (feedId: string) => void;
   refreshAll: () => Promise<void>;
+  /**
+   * Refresh only the scope currently being viewed, then reload the article
+   * list so new items appear in place. The header refresh control routes
+   * here so it never silently refreshes feeds the user isn't looking at:
+   *  - concrete feed id     → that feed only
+   *  - folder:<id>          → the folder's member feeds
+   *  - all / starred / filter → every feed (these views aggregate across all)
+   */
+  refreshView: (feedId: string) => Promise<void>;
   refreshSingleFeed: (feedId: string) => Promise<void>;
   createFolder: (name: string) => Promise<void>;
   renameFolder: (folderId: string, name: string) => Promise<void>;
@@ -238,6 +253,30 @@ async function reloadFolders(
 ): Promise<void> {
   const result = await dbGetFolders();
   if (result.ok) set({ folders: sortFoldersByName(result.value) });
+}
+
+/**
+ * Resolve which feeds a scoped refresh should touch, given the id of the
+ * currently-viewed list. `isFullRefresh` distinguishes the aggregated views
+ * (all / starred / filter) — which span every feed and so reuse the batched
+ * `refreshAllFeeds` path — from a folder or single feed, which refresh a
+ * targeted subset and must not reset the all-feeds staleness clock.
+ */
+function resolveRefreshTargets(
+  feeds: Feed[],
+  feedId: string,
+): { targets: Feed[]; isFullRefresh: boolean } {
+  if (isFolderFeedId(feedId)) {
+    const folderId = fromFolderFeedId(feedId);
+    return {
+      targets: feeds.filter((f) => f.folderId === folderId),
+      isFullRefresh: false,
+    };
+  }
+  if (isAggregatedFeedId(feedId)) {
+    return { targets: feeds, isFullRefresh: true };
+  }
+  return { targets: feeds.filter((f) => f.id === feedId), isFullRefresh: false };
 }
 
 /**
@@ -496,6 +535,45 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
     }
     // Fire-and-forget — refreshAll returns once the feeds are fresh,
     // prefetch continues in the background.
+    void schedulePrefetch(get().feeds);
+  },
+
+  refreshView: async (feedId) => {
+    if (get().isRefreshingAll) return;
+    set({ isRefreshingAll: true });
+    retryFailedFavicons();
+    const { targets, isFullRefresh } = resolveRefreshTargets(
+      get().feeds,
+      feedId,
+    );
+    try {
+      if (isFullRefresh) {
+        const syncStore = useSyncStore.getState();
+        if (syncStore.credentials) {
+          await syncStore.pull();
+          await reloadFeeds(set);
+        }
+        await refreshAllFeeds();
+      } else {
+        await Promise.all(targets.map((feed) => refreshFeed(feed)));
+      }
+      await reloadFeeds(set);
+      // Reload the article store so the freshly-fetched items show up in the
+      // open list without the user re-navigating. preloadAll keeps the other
+      // views coherent; loadArticles re-derives the visible list for this one.
+      const articleStore = useArticleStore.getState();
+      await articleStore.preloadAll();
+      await articleStore.loadArticles(feedId);
+      schedulePush();
+    } finally {
+      // A scoped refresh leaves other feeds untouched, so it must not stamp
+      // lastRefreshAllAt — that clock gates the background full auto-refresh.
+      set(
+        isFullRefresh
+          ? { isRefreshingAll: false, lastRefreshAllAt: Date.now() }
+          : { isRefreshingAll: false },
+      );
+    }
     void schedulePrefetch(get().feeds);
   },
 

--- a/tests/components/articles/article-list-controls.test.tsx
+++ b/tests/components/articles/article-list-controls.test.tsx
@@ -16,6 +16,7 @@ import {
   ArticleListControls,
   MobileHeaderPills,
 } from "@/components/articles/article-list-controls.tsx";
+import { getFeeds } from "@/core/storage/db.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
@@ -37,6 +38,8 @@ vi.mock("@/core/storage/db.ts", () => ({
   removeFeed: vi.fn(),
   addFolder: vi.fn(),
   getSmartFilters: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getAllArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
 }));
 
 vi.mock("@/core/sync/sync-service", () => ({
@@ -199,26 +202,46 @@ describe("MobileHeaderPills", () => {
     expect(screen.getByLabelText(/sort/i)).toBeInTheDocument();
   });
 
-  it("shows a refresh-all control when feeds exist", () => {
+  it("shows a refresh control when feeds exist", () => {
     render(
       <MemoryRouter>
         <MobileHeaderPills />
       </MemoryRouter>,
     );
-    expect(screen.getByTestId("mobile-refresh-all")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-refresh")).toBeInTheDocument();
   });
 
-  it("hides the refresh-all control when there are no feeds", () => {
+  it("hides the refresh control when there are no feeds", () => {
     useFeedStore.setState({ feeds: [], selectedFeedId: ALL_FEEDS_ID });
     render(
       <MemoryRouter>
         <MobileHeaderPills />
       </MemoryRouter>,
     );
-    expect(screen.queryByTestId("mobile-refresh-all")).toBeNull();
+    expect(screen.queryByTestId("mobile-refresh")).toBeNull();
   });
 
-  it("tapping refresh-all refreshes every feed", async () => {
+  it("tapping refresh on a single feed view refreshes only that feed", async () => {
+    const { refreshFeed, refreshAllFeeds } = await import(
+      "@/core/feeds/feed-service.ts"
+    );
+    vi.mocked(getFeeds).mockResolvedValue({
+      ok: true,
+      value: [feed("f-tech", "Tech Crunchies")],
+    });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <MobileHeaderPills />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByTestId("mobile-refresh"));
+    expect(refreshFeed).toHaveBeenCalledTimes(1);
+    expect(refreshAllFeeds).not.toHaveBeenCalled();
+  });
+
+  it("tapping refresh on the All-items view refreshes every feed", async () => {
+    useFeedStore.setState({ selectedFeedId: ALL_FEEDS_ID });
     const { refreshAllFeeds } = await import("@/core/feeds/feed-service.ts");
     const user = userEvent.setup();
     render(
@@ -226,17 +249,17 @@ describe("MobileHeaderPills", () => {
         <MobileHeaderPills />
       </MemoryRouter>,
     );
-    await user.click(screen.getByTestId("mobile-refresh-all"));
+    await user.click(screen.getByTestId("mobile-refresh"));
     expect(refreshAllFeeds).toHaveBeenCalled();
   });
 
-  it("disables the refresh-all control while a refresh is in flight", () => {
+  it("disables the refresh control while a refresh is in flight", () => {
     useFeedStore.setState({ isRefreshingAll: true });
     render(
       <MemoryRouter>
         <MobileHeaderPills />
       </MemoryRouter>,
     );
-    expect(screen.getByTestId("mobile-refresh-all")).toBeDisabled();
+    expect(screen.getByTestId("mobile-refresh")).toBeDisabled();
   });
 });

--- a/tests/components/articles/article-list.test.tsx
+++ b/tests/components/articles/article-list.test.tsx
@@ -13,6 +13,7 @@ import {
 
 vi.mock("@/core/storage/db.ts", () => ({
   getArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getAllArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
   updateArticle: vi.fn().mockResolvedValue({ ok: true, value: true }),
   getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
   getFeed: vi.fn(),
@@ -85,6 +86,71 @@ describe("ArticleList", () => {
     expect(
       screen.getByText("Select a feed to view articles."),
     ).toBeInTheDocument();
+  });
+
+  it("offers a prominent refresh path when the selected feed has no articles", () => {
+    useFeedStore.setState({
+      feeds: [mockFeed("f1", "Feed 1")],
+      selectedFeedId: "f1",
+      isLoading: false,
+      error: null,
+    });
+    useArticleStore.setState({
+      articles: [],
+      selectedArticle: null,
+      isLoading: false,
+    });
+
+    render(<ArticleList />);
+
+    expect(screen.getByTestId("empty-refresh")).toBeInTheDocument();
+  });
+
+  it("does not show the refresh path while the feed is still loading", () => {
+    useFeedStore.setState({
+      feeds: [mockFeed("f1", "Feed 1")],
+      selectedFeedId: "f1",
+      isLoading: false,
+      error: null,
+    });
+    useArticleStore.setState({
+      articles: [],
+      selectedArticle: null,
+      isLoading: true,
+    });
+
+    render(<ArticleList />);
+
+    expect(screen.queryByTestId("empty-refresh")).toBeNull();
+  });
+
+  it("tapping the empty-state refresh refreshes the current feed", async () => {
+    const { refreshFeed } = await import("@/core/feeds/feed-service.ts");
+    const { getFeed } = await import("@/core/storage/db.ts");
+    const f1 = mockFeed("f1", "Feed 1");
+    vi.mocked(getFeed).mockResolvedValue({ ok: true, value: f1 });
+    vi.mocked(refreshFeed).mockResolvedValue({
+      ok: true,
+      value: { newCount: 0, updatedCount: 0 },
+    });
+    useFeedStore.setState({
+      feeds: [f1],
+      selectedFeedId: "f1",
+      isRefreshingAll: false,
+      isLoading: false,
+      error: null,
+    });
+    useArticleStore.setState({
+      articles: [],
+      selectedArticle: null,
+      isLoading: false,
+    });
+    const user = userEvent.setup();
+
+    render(<ArticleList />);
+    await user.click(screen.getByTestId("empty-refresh"));
+
+    expect(refreshFeed).toHaveBeenCalledWith(f1);
   });
 
   it("never renders a Load more button — the display cap has been removed", () => {

--- a/tests/pages/feeds-page-behavior.test.tsx
+++ b/tests/pages/feeds-page-behavior.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Routes, Route, useLocation, useNavigate } from "react-router";
 import { lazy, Suspense } from "react";
@@ -395,6 +395,49 @@ describe("FeedsPage behavior — mobile", () => {
     renderPage("/feeds/feed-1/articles/art-1");
     // With breadcrumbs, mobile header shows fallback "Articles" when feed isn't in store
     expect(screen.getByText("Articles")).toBeInTheDocument();
+  });
+
+  it("navigates back to the article list when the viewed article's stage goes empty (mobile)", async () => {
+    // The user is reading an article when its cache is cleared (e.g. "delete
+    // all articles from cache"). The reader stage goes empty — on mobile the
+    // user should land back on the article list, not a blank reader.
+    const article = makeArticle("art-1", "feed-1");
+    vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [article] });
+    useFeedStore.setState({
+      feeds: [makeFeed("feed-1")],
+      selectedFeedId: "feed-1",
+    });
+
+    renderPage("/feeds/feed-1/articles/art-1");
+
+    // Start on the reader with the article selected.
+    await vi.waitFor(() => {
+      expect(useArticleStore.getState().selectedArticle?.id).toBe("art-1");
+    });
+
+    // Clearing the cache empties the stage.
+    act(() => {
+      clearArticleCache();
+    });
+
+    await vi.waitFor(() => {
+      expect(currentUrl).toBe("/feeds/feed-1");
+    });
+  });
+
+  it("stays on a deeplinked article URL when the feed simply loads empty (no bounce)", async () => {
+    // A deeplink to a feed that fetches no articles must NOT bounce — there
+    // was never an article to leave. Only a present→absent transition (cache
+    // cleared mid-read) sends the user back. Guards the empty-feed deeplink.
+    useFeedStore.setState({
+      feeds: [makeFeed("feed-1")],
+      selectedFeedId: "feed-1",
+    });
+
+    renderPage("/feeds/feed-1/articles/art-1");
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(currentUrl).toBe("/feeds/feed-1/articles/art-1");
   });
 
   it("redirects /feeds to /explore on mobile when feed count is minimal", async () => {

--- a/tests/stores/feed-store.test.ts
+++ b/tests/stores/feed-store.test.ts
@@ -41,6 +41,10 @@ vi.mock("../../src/core/storage/db.ts", () => ({
   addFolder: vi.fn(),
   updateFolder: vi.fn(),
   removeFolder: vi.fn(),
+  // refreshView reloads the article store after refreshing, which queries
+  // these. Default to empty so the reload is a no-op unless a test overrides.
+  getArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getAllArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
 }));
 
 vi.mock("../../src/core/feeds/feed-service.ts", () => ({
@@ -64,7 +68,8 @@ vi.mock("../../src/core/sync/sync-service", () => ({
   importVault: vi.fn(),
 }));
 
-import { getFeeds, getFeed, removeFeed, updateFeed, getFolders, addFolder, updateFolder, removeFolder } from "../../src/core/storage/db.ts";
+import { getFeeds, getFeed, removeFeed, updateFeed, getFolders, addFolder, updateFolder, removeFolder, getArticles } from "../../src/core/storage/db.ts";
+import { ALL_FEEDS_ID, toFolderFeedId } from "../../src/utils/constants.ts";
 import {
   addFeedFlow,
   addPlaceholderFeed,
@@ -95,6 +100,9 @@ describe("feed-store", () => {
       folders: [],
       selectedFeedId: null,
       isLoading: false,
+      isRefreshingAll: false,
+      refreshingFeedIds: new Set(),
+      lastRefreshAllAt: null,
       error: null,
     });
     vi.clearAllMocks();
@@ -576,6 +584,102 @@ describe("feed-store", () => {
 
       expect(getFeed).toHaveBeenCalledWith("f1");
       expect(refreshFeed).toHaveBeenCalledWith(feed);
+    });
+  });
+
+  describe("refreshView", () => {
+    it("refreshes only the viewed feed when a concrete feed is selected", async () => {
+      const f1 = mockFeed("f1", "Feed 1");
+      const f2 = mockFeed("f2", "Feed 2");
+      useFeedStore.setState({ feeds: [f1, f2] });
+      vi.mocked(refreshFeed).mockResolvedValue({
+        ok: true,
+        value: { newCount: 1, updatedCount: 0 },
+      });
+      vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [f1, f2] });
+
+      await useFeedStore.getState().refreshView("f1");
+
+      expect(refreshFeed).toHaveBeenCalledTimes(1);
+      expect(refreshFeed).toHaveBeenCalledWith(f1);
+      expect(refreshAllFeeds).not.toHaveBeenCalled();
+    });
+
+    it("refreshes only the folder's member feeds when a folder is viewed", async () => {
+      const f1 = { ...mockFeed("f1", "Feed 1"), folderId: "tech" };
+      const f2 = { ...mockFeed("f2", "Feed 2"), folderId: "tech" };
+      const f3 = mockFeed("f3", "Feed 3");
+      useFeedStore.setState({ feeds: [f1, f2, f3] });
+      vi.mocked(refreshFeed).mockResolvedValue({
+        ok: true,
+        value: { newCount: 0, updatedCount: 0 },
+      });
+      vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [f1, f2, f3] });
+
+      await useFeedStore.getState().refreshView(toFolderFeedId("tech"));
+
+      expect(refreshFeed).toHaveBeenCalledTimes(2);
+      expect(refreshFeed).toHaveBeenCalledWith(f1);
+      expect(refreshFeed).toHaveBeenCalledWith(f2);
+      expect(refreshFeed).not.toHaveBeenCalledWith(f3);
+      expect(refreshAllFeeds).not.toHaveBeenCalled();
+    });
+
+    it("refreshes every feed when an aggregated view (all items) is selected", async () => {
+      const f1 = mockFeed("f1", "Feed 1");
+      useFeedStore.setState({ feeds: [f1] });
+      vi.mocked(refreshAllFeeds).mockResolvedValue({
+        ok: true,
+        value: { results: [] },
+      });
+      vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [f1] });
+
+      await useFeedStore.getState().refreshView(ALL_FEEDS_ID);
+
+      expect(refreshAllFeeds).toHaveBeenCalled();
+      expect(refreshFeed).not.toHaveBeenCalled();
+    });
+
+    it("reloads the viewed feed's articles so new items appear in place", async () => {
+      const f1 = mockFeed("f1", "Feed 1");
+      useFeedStore.setState({ feeds: [f1] });
+      vi.mocked(refreshFeed).mockResolvedValue({
+        ok: true,
+        value: { newCount: 1, updatedCount: 0 },
+      });
+      vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [f1] });
+
+      await useFeedStore.getState().refreshView("f1");
+
+      expect(getArticles).toHaveBeenCalledWith("f1");
+    });
+
+    it("only stamps lastRefreshAllAt on a full refresh, not a scoped one", async () => {
+      const f1 = mockFeed("f1", "Feed 1");
+      useFeedStore.setState({ feeds: [f1], lastRefreshAllAt: null });
+      vi.mocked(refreshFeed).mockResolvedValue({
+        ok: true,
+        value: { newCount: 0, updatedCount: 0 },
+      });
+      vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [f1] });
+
+      await useFeedStore.getState().refreshView("f1");
+
+      // A single-feed refresh must not reset the all-feeds staleness clock,
+      // otherwise the background auto-refresh would skip a needed full pass.
+      expect(useFeedStore.getState().lastRefreshAllAt).toBeNull();
+    });
+
+    it("no-ops while a refresh is already in flight", async () => {
+      useFeedStore.setState({
+        feeds: [mockFeed("f1", "Feed 1")],
+        isRefreshingAll: true,
+      });
+
+      await useFeedStore.getState().refreshView("f1");
+
+      expect(refreshFeed).not.toHaveBeenCalled();
+      expect(refreshAllFeeds).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/stores/feed-store.test.ts
+++ b/tests/stores/feed-store.test.ts
@@ -43,10 +43,6 @@ vi.mock("../../src/core/storage/db.ts", () => ({
   addFolder: vi.fn(),
   updateFolder: vi.fn(),
   removeFolder: vi.fn(),
-  // refreshView reloads the article store after refreshing, which queries
-  // these. Default to empty so the reload is a no-op unless a test overrides.
-  getArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
-  getAllArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
 }));
 
 vi.mock("../../src/core/feeds/feed-service.ts", () => ({


### PR DESCRIPTION
Three related mobile/refresh behaviours:

- Mobile empty-stage fallback: when the article being read disappears from
  the loaded set (e.g. the article cache is cleared), the reader stage goes
  empty. The user is now navigated back to the article list instead of being
  stranded on a blank reader. Tracked as a present→absent transition
  (`viewedArticlePresentRef`) so a deeplink to an already-empty feed still
  shows the reader's own empty state rather than bouncing.

- Prominent refresh path from an empty list: the bare "No articles found."
  text is replaced with an `EmptyArticleList` state carrying a prominent
  Refresh button wired to the new scoped refresh.

- Scoped header refresh: the mobile header refresh control now calls
  `refreshView(selectedFeedId)` instead of the global `refreshAll`. A concrete
  feed refreshes only that feed, a folder only its members, and an aggregated
  view (All items / Starred / smart filter) every feed. `refreshView` also
  reloads the article store so new items appear in place, and only stamps
  `lastRefreshAllAt` on a full refresh so the background auto-refresh clock
  isn't reset by a scoped pull. The desktop sidebar + nav-drawer "Refresh all"
  and the `R` shortcut stay global.

Key files: src/stores/feed-store.ts (refreshView + resolveRefreshTargets),
src/components/articles/article-list.tsx (EmptyArticleList),
src/components/articles/article-list-controls.tsx (RefreshPill),
src/pages/feeds-route.tsx (empty-stage effect).

https://claude.ai/code/session_01VeJPViFF992vxM95dijuZW