### PR TITLE
feat(signal): anchor topics on entities, group same-story coverage, add preview-then-read

### DIFF
--- a/docs/features/020-signal.md
+++ b/docs/features/020-signal.md
@@ -7,9 +7,17 @@ Implemented
 
 Signal surfaces the topics emerging across the user's feeds — "what's loud
 right now" — derived entirely from local cross-feed term frequency. No
-LLM, no model download, no third-party call. Phase 1 is a plain-text
-ranked list (no cards, no images, no magazine layout) accessible at
-`/signal` from a Sparkles entry in the sidebar. Tier: Personal+.
+LLM, no model download, no third-party call. It is a plain-text ranked list
+(no cards, no images, no magazine layout) accessible at `/signal` from a
+Sparkles entry in the sidebar. Tier: Personal+.
+
+Topics anchor **only on proper nouns and compound nouns** ("OpenAI",
+"Iran War", "Supreme Court") — never bare common nouns — detected by
+capitalization consensus across the corpus (no ML). Within a topic, articles
+covering the same/similar story collapse into one **story** row badged
+"Covered by N outlets", expandable to each outlet's version. Each row peeks
+on hover (desktop) or tap (mobile) before opening the full item in the
+reader, so triage doesn't require leaving the page.
 
 Gating: the feature unlocks once the user has ≥100 articles in their
 local store. Below the gate, the page renders a progress tile ("X / 100
@@ -26,19 +34,31 @@ Feature: Signal — cross-feed topic surface
     Given my local article store contains 47 articles
     When I navigate to /signal
     Then I see a locked tile titled "Signal"
-    And the tile shows "47 / 100" with a progress bar
-    And the copy reads "Signal needs noise to filter — come back at 100."
+    And the tile shows "53 more articles to unlock" with a progress bar
+    And the copy reads "47 of 100 articles in your store"
 
   Scenario: Unlocked, with cross-feed signal
     Given my local article store contains ≥100 articles
-    And the engine finds terms appearing in ≥2 articles across ≥2 feeds
+    And the engine finds a proper/compound noun in ≥2 articles across ≥2 feeds
     When I navigate to /signal
     Then I see a header "Signal · <window> · N articles · M feeds"
     And up to 10 topic blocks ranked by cross-feed signal strength
-    And each block shows a muted-uppercase term chip plus a count line
-    And under it up to 6 article rows (title — feed · relative time)
-    When I click an article
+    And each block shows the entity in original casing plus a count line
+    And under it up to 6 story rows (headline — feed · relative time)
+    And a story carried by multiple feeds reads "Covered by N outlets"
+
+  Scenario: A common noun never anchors a topic
+    Given the only term shared across feeds is the common noun "tariffs"
+    When I navigate to /signal
+    Then no topic is anchored on "tariffs"
+
+  Scenario: Peek then read
+    Given a topic with story rows
+    When I hover a row on desktop (or tap it on mobile)
+    Then a preview shows the headline, source, and a teaser
+    When I click the row (desktop) or "Open in reader" (mobile)
     Then I am navigated to /feeds/:feedId/articles/:articleId
+    And the browser back button returns me to /signal
 
   Scenario: Unlocked, no cross-feed signal
     Given my local article store contains ≥100 articles
@@ -75,42 +95,57 @@ Feature: Signal — cross-feed topic surface
    `generateReport()`:
    1. **Window pick:** try 7d → 14d → 30d → all; stop at first window
       with ≥ `SIGNAL_MIN_PER_WINDOW` (50) articles.
-   2. **Dedupe** by normalized title hash (lowercase, strip punctuation)
-      — syndicated copies of the same story would otherwise inflate
-      every term equally.
-   3. **Tokenize** title + plain-text body with `tokenize.ts`: HTML
-      stripped, lowercased, English stopwords + feed-noise terms
-      dropped, numeric-only and <3-char tokens dropped, light suffix
-      stripping with double-consonant collapse for `-ing`/`-ed`.
-   4. **Index** per term: distinct article ids (DF) and distinct feed
-      ids (FF).
-   5. **Score** `signal(t) = distinctArticles(t) * log(1 + distinctFeeds(t))`.
-      Drop terms with <2 articles OR <2 feeds.
-   6. **Greedy cluster:** sort by signal desc, term asc. For each term,
-      claim unclaimed articles containing it, capped at
-      `ceil(corpus / 10) + 5`. **Bleed-over guard:** if <50% of the
-      term's original articles survive prior claims, skip — it's just a
-      fragment of a stronger cluster (e.g. "ship" after "openai" eats
-      every "OpenAI ships X" headline).
-   7. Order articles within each topic by recency desc.
-   8. `pickDisplayTerm` recovers the most common original casing from
-      the articles actually assigned to the cluster (`openai` → `OpenAI`).
-5. The store writes the report to localStorage and sets status
-   `"ready"`. The page renders topic blocks. Topic terms missing from
-   the result render as `topics: []` and the empty-but-ready caption.
-6. Article click navigates to the existing reader route. The article is
-   already in `useArticleStore`, so the reader page renders without an
-   additional DB read.
+   2. **Group exact duplicates** by normalized title (lowercase, strip
+      punctuation): keep a representative (most recent) per story plus a
+      map of every member sharing its title, so a syndicated story is one
+      representative for scoring but still knows every outlet that ran it.
+   3. **Extract entities** from each representative with `entities.ts`.
+      `buildLexicon` tallies corpus-wide casing to confirm proper nouns
+      (capitalized in ≥70% of non-initial occurrences, or only ever seen
+      capitalized and never lowercase); Title-Cased headlines are excluded
+      from the casing tally. `extractEntities` then emits confirmed proper
+      nouns as unigram keys and contiguous capitalized runs as compound
+      keys (e.g. `iran war`). No common nouns enter the index.
+   4. **Index** per entity key: distinct article ids (DF), distinct feed
+      ids (FF), word count, and a casing histogram for display.
+   5. **Score** `signal(t) = distinctArticles(t) * log(1 + distinctFeeds(t))
+      * (1 + 0.5·(words−1))`. The phrase boost makes a compound outrank its
+      constituent. Drop entities with <2 articles OR <2 feeds.
+   6. **Greedy cluster:** sort by signal desc, key asc. For each entity,
+      claim unclaimed representatives containing it, capped at
+      `ceil(reps / 10) + 5`. **Bleed-over guard:** if <50% of the entity's
+      original articles survive prior claims, skip — it's a fragment of a
+      stronger cluster (e.g. `iran` after `iran war` claims its articles).
+   7. **Group into stories:** within each topic, `stories.ts` merges
+      representatives whose significant title tokens overlap ≥60% (Jaccard)
+      and absorbs each representative's exact-duplicate members. Stories are
+      ordered by outlet count desc, then recency. Member ids run most-recent
+      first.
+5. The store writes the report to localStorage (tagged with
+   `SIGNAL_REPORT_SCHEMA_VERSION`) and sets status `"ready"`. The page
+   renders topic blocks. No topics → `topics: []` and the empty-but-ready
+   caption. A cached report tagged with a different schema version is
+   discarded on read.
+6. Each story renders via `<StoryRow>`. On desktop the headline is wrapped
+   in a `HoverCard` (peek) and clicking it navigates to the reader; on
+   mobile a tap opens a bottom `Sheet` preview whose "Open in reader" button
+   navigates. Navigation passes `state: { from: "/signal" }`; the article is
+   already in `useArticleStore`, so the reader renders without a DB read.
 
 ### Files
 
 | File | Role |
 |------|------|
-| `src/pages/signal-page.tsx` | The page. Three render branches (locked / empty / ready), Refresh button, topic blocks, article rows. |
-| `src/stores/signal-store.ts` | Zustand store. `loadReport({ force? })`, status state machine, 24h localStorage cache with window + corpus-drift invalidation. |
-| `src/core/signal/types.ts` | `Topic`, `SignalReport`, `WindowChoice` plus the gate / target / TTL constants. |
-| `src/core/signal/tokenize.ts` | `tokenize()`, `lightStem()`, English `STOPWORDS`, `FEED_NOISE` set. |
-| `src/core/signal/frequency-engine.ts` | `generateReport()` + `pickWindow()` (exported so the store can detect cache staleness without rerunning the full engine). Internal helpers: `dedupeByTitle`, `buildIndex`, `scoreTerms`, `clusterGreedy`, `pickDisplayTerm`. |
+| `src/pages/signal-page.tsx` | The page. Three render branches (locked / empty / ready), Refresh button, topic blocks delegating each story to `<StoryRow>`. |
+| `src/stores/signal-store.ts` | Zustand store. `loadReport({ force? })`, status state machine, 24h localStorage cache with window + corpus-drift + schema-version invalidation. |
+| `src/core/signal/types.ts` | `Topic`, `Story`, `SignalReport`, `WindowChoice` plus gate / target / TTL constants and the `PROPER_NOUN_RATIO` / `PHRASE_BOOST` / `STORY_SIMILARITY` / `SIGNAL_REPORT_SCHEMA_VERSION` tuning knobs. |
+| `src/core/signal/tokenize.ts` | `tokenize()`, `lightStem()`, exported case-preserving `stripHtml()`, English `STOPWORDS`, `FEED_NOISE` set. |
+| `src/core/signal/entities.ts` | `buildLexicon()` (proper-noun casing consensus) + `extractEntities()` (proper/compound noun keys). |
+| `src/core/signal/stories.ts` | `groupIntoStories()` — fuzzy + exact same-story grouping with outlet counts. |
+| `src/core/signal/frequency-engine.ts` | `generateReport()` + `pickWindow()` (exported so the store can detect cache staleness without rerunning the full engine). Internal helpers: `groupExactDuplicates`, `buildIndex`, `scoreTerms`, `clusterGreedy`. |
+| `src/components/signal/story-row.tsx` | Renders a `Story`: single/multi-outlet row, hover/tap preview, expand-to-outlets. |
+| `src/components/signal/article-preview.tsx` | Compact peek body (title, source, teaser, open actions). |
+| `src/components/ui/hover-card.tsx` | Radix HoverCard wrapper for the desktop peek. |
 | `src/lib/format-relative.ts` | Newspaper-style relative date label ("5m ago", "yesterday", "Mon 15"). |
 | `src/components/layout/sidebar-body.tsx` | Sparkles "Signal" entry between Explore and All items. |
 | `src/app.tsx` | `<Route path="/signal" element={<SignalRoute />} />`, lazy-loaded. |
@@ -121,11 +156,13 @@ Feature: Signal — cross-feed topic surface
 | File | Coverage |
 |------|----------|
 | `tests/core/signal/tokenize.test.ts` | HTML strip, lowercase, stopword/feed-noise drop, light stemming with double-consonant collapse. |
-| `tests/core/signal/frequency-engine.test.ts` | Happy path: 60 articles across 8 feeds → topics ordered by signal, single-feed terms dropped, disjoint topics, intra-topic recency order, displayTerm casing. |
+| `tests/core/signal/entities.test.ts` | Proper-noun consensus (Apple≠apple, sentence-initial-only, common-word rejection, stopword skip), compound extraction, Title-Case headline guard, possessive stripping. |
+| `tests/core/signal/stories.test.ts` | Similar-headline merge, unrelated-headline split, exact-duplicate outlet counting, ordering by outlet count then recency, member recency order. |
+| `tests/core/signal/frequency-engine.test.ts` | Happy path: entity-anchored topics ordered by signal, compound preferred over constituent, single-feed terms dropped, multi-outlet story surfaced, disjoint stories, displayTerm casing, schema version. |
 | `tests/core/signal/frequency-engine-window.test.ts` | Adaptive window picks the smallest with ≥50 articles, falls back to "all" when every window is sparse. |
-| `tests/core/signal/frequency-engine-edge.test.ts` | Title-hash dedupe, single-feed corpus → empty topics, body-token fallback when title is uninformative, deterministic across input order, non-English content does not crash, dominant-term cap. |
+| `tests/core/signal/frequency-engine-edge.test.ts` | Common nouns never anchor a topic, syndicated story collapses to one multi-outlet story, single-feed corpus → empty, body-only entity detection, deterministic across input order, non-English does not crash, dominant-entity cap. |
 | `tests/stores/signal-store.test.ts` | Locked / loading / ready transitions, empty-ready handling, cache TTL hit, force-reload bypasses cache, window change invalidates cache, ±10% corpus drift invalidates cache, persistence across state reset. |
-| `tests/pages/signal-page.test.tsx` | Locked tile shows progress, empty-ready message, topic headers + article rows render, Refresh re-runs the engine, article click navigates to the reader, cache priming reads from localStorage. |
+| `tests/pages/signal-page.test.tsx` | Locked tile, empty-ready message, entity topic heading + story rows, multi-outlet badge + expand, desktop click → reader, mobile tap → preview → reader, Refresh re-runs, cache priming, schema-version invalidation. |
 | `tests/e2e/signal.spec.ts` | Sidebar Sparkles entry navigates to `/signal`, locked tile renders with the gate copy when the corpus is empty. |
 | `tests/core/features/tier-matrix.test.ts` | `signal` is shipped, Personal+ available, Free unavailable; round-trips through `GATED_FEATURE_IDS`. |
 
@@ -151,6 +188,30 @@ Feature: Signal — cross-feed topic surface
   every user reaches the feature; the gate only bites once
   `VITE_PAID_TIER_VISIBLE=1`. The sidebar entry stays visible
   regardless (discoverability).
+- **Entities only, by capitalization consensus.** A topic must name
+  something — a proper noun ("OpenAI") or compound noun ("Iran War") — not a
+  bare common noun ("tariffs"). Without an ML POS tagger, capitalization is
+  the available signal: a word capitalized across the corpus's sentence-case
+  bodies is a proper noun; "apple" the fruit stays lowercase, "Apple" the
+  company does not. Title-Cased headlines capitalize everything, so they are
+  excluded from the casing tally and only contribute already-confirmed
+  entities. Compounds come from contiguous capitalized runs. The trade-off
+  is recall on thin, Title-Case-only feeds (see Limitations) — accepted in
+  exchange for topics that are always nameable.
+- **Compound beats constituent via a phrase boost.** Multiplying signal by
+  `1 + 0.5·(words−1)` lets "Iran War" win the greedy claim before "Iran",
+  and the existing bleed-over guard then drops the fragmented unigram. This
+  reuses the clustering machinery instead of a separate subsumption pass.
+- **Same story across outlets is grouped, not hidden.** Earlier the engine
+  deduped syndicated copies and discarded all but the most recent. Now exact
+  duplicates are grouped (and similar headlines fuzzy-merged within a topic)
+  into a story that reports how many outlets ran it — the multi-outlet
+  signal the user asked to see. Scoring still runs on representatives so
+  syndication volume doesn't distort cluster strength.
+- **Peek before read.** A topic row is a triage surface, not a destination.
+  Hover (desktop) / tap (mobile) shows a teaser; the click commits to the
+  reader. Reusing `ArticleContent`, `HoverCard`, and `Sheet` keeps it to one
+  small component with no new primitives beyond the HoverCard wrapper.
 - **Cross-feed diversity is the signal.** Score = `articles × log(1 + feeds)`.
   Multiplying by log-feeds means a story appearing in 10 outlets
   outranks one outlet posting 10 times, which matches the
@@ -175,6 +236,18 @@ Feature: Signal — cross-feed topic surface
 
 ## Limitations
 
+- **Strict entity gate can leave sparse feeds quiet.** Proper-noun
+  detection needs sentence-case casing evidence. Feeds that publish only
+  Title-Case headlines with empty/thin bodies give the lexicon nothing to
+  confirm, so fewer (or no) topics surface. This is the deliberate
+  trade-off for "topics are always nameable"; the empty-but-ready caption
+  covers the degenerate case. A future relaxation could admit
+  recurring-bigram entities even from Title-Case headlines if recall proves
+  too low in practice.
+- **Capitalization is script-bound.** Casing-based entity detection only
+  works for cased scripts (Latin, Cyrillic, Greek). CJK and other caseless
+  scripts produce no entities and therefore no topics — a stricter form of
+  the English-only limitation below.
 - **English-only.** Stopwords are English; tokenize uses `\W+` which
   handles ASCII word boundaries cleanly but collapses CJK/RTL text into
   long single tokens. The engine produces *something* on non-English

--- a/src/components/signal/article-preview.tsx
+++ b/src/components/signal/article-preview.tsx
@@ -1,0 +1,55 @@
+import { BookOpen, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button.tsx";
+import { formatRelative } from "@/lib/format-relative.ts";
+import { decodeEntities } from "@/lib/decode-entities.ts";
+import type { Article } from "@/types/index.ts";
+
+interface ArticlePreviewProps {
+  article: Article;
+  feedTitle: string;
+  now: number;
+  onOpen: () => void;
+}
+
+/**
+ * Compact peek at an article — title, source, a plain-text teaser, and the
+ * two ways to act on it. Shown in a HoverCard (desktop) or Sheet (mobile)
+ * so the reader can triage from Signal without leaving the page.
+ */
+export function ArticlePreview({ article, feedTitle, now, onOpen }: ArticlePreviewProps) {
+  const teaser = toPlainText(article.content || article.summary || "");
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold leading-snug">{decodeEntities(article.title)}</h3>
+        <p className="text-xs text-muted-foreground">
+          {feedTitle}
+          {" · "}
+          {formatRelative(article.publishedAt, now)}
+        </p>
+      </div>
+      {teaser ? (
+        <p className="line-clamp-5 text-sm leading-relaxed text-muted-foreground">{teaser}</p>
+      ) : (
+        <p className="text-sm italic text-muted-foreground">No preview available.</p>
+      )}
+      <div className="flex items-center gap-2">
+        <Button size="sm" onClick={onOpen}>
+          <BookOpen className="size-3.5" />
+          Open in reader
+        </Button>
+        <Button size="sm" variant="ghost" asChild>
+          <a href={article.link} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="size-3.5" />
+            Original
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function toPlainText(html: string): string {
+  const stripped = html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+  return decodeEntities(stripped);
+}

--- a/src/components/signal/story-row.tsx
+++ b/src/components/signal/story-row.tsx
@@ -1,0 +1,161 @@
+import { useState, type ReactNode } from "react";
+import { useNavigate } from "react-router";
+import { ChevronDown } from "lucide-react";
+import { useIsDesktop } from "@/hooks/use-media-query.ts";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card.tsx";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from "@/components/ui/sheet.tsx";
+import { ArticlePreview } from "./article-preview.tsx";
+import { formatRelative } from "@/lib/format-relative.ts";
+import { decodeEntities } from "@/lib/decode-entities.ts";
+import { cn } from "@/lib/utils.ts";
+import type { Story } from "@/core/signal/types.ts";
+import type { Article, Feed } from "@/types/index.ts";
+
+const ROW_CLASS =
+  "flex w-full flex-col gap-1 py-3 text-left transition-colors hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none";
+
+interface StoryRowProps {
+  story: Story;
+  articleMap: Map<string, Article>;
+  feedMap: Map<string, Feed>;
+  now: number;
+}
+
+/**
+ * One story within a topic. A single-outlet story is a plain row; a
+ * multi-outlet story badges "Covered by N outlets" and expands to list each
+ * outlet's version. Either way the row peeks on hover/tap and opens the
+ * full item in the reader on click.
+ */
+export function StoryRow({ story, articleMap, feedMap, now }: StoryRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const head = resolveHead(story, articleMap);
+  if (!head) return null;
+
+  const headFeed = feedMap.get(head.feedId)?.title ?? "Unknown feed";
+  const multi = story.feedCount >= 2;
+
+  return (
+    <li>
+      <PreviewLink article={head} feedTitle={headFeed} now={now}>
+        <span className="text-sm text-foreground">{decodeEntities(head.title)}</span>
+        <span className="text-xs text-muted-foreground">
+          {multi ? `Covered by ${story.feedCount} outlets` : headFeed}
+          {" · "}
+          {formatRelative(head.publishedAt, now)}
+        </span>
+      </PreviewLink>
+
+      {multi ? (
+        <>
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            aria-expanded={expanded}
+            className="flex items-center gap-1 pb-2 text-xs font-medium text-primary hover:underline"
+          >
+            <ChevronDown className={cn("size-3 transition-transform", expanded && "rotate-180")} />
+            {expanded ? "Hide outlets" : `Show all ${story.feedCount} outlets`}
+          </button>
+          {expanded ? (
+            <ul className="mb-2 ml-1 border-l border-border pl-3">
+              {story.articleIds.map((id) => {
+                const member = articleMap.get(id);
+                if (!member) return null;
+                const feedTitle = feedMap.get(member.feedId)?.title ?? "Unknown feed";
+                return (
+                  <li key={id}>
+                    <PreviewLink article={member} feedTitle={feedTitle} now={now}>
+                      <span className="text-sm text-foreground">{feedTitle}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {formatRelative(member.publishedAt, now)}
+                      </span>
+                    </PreviewLink>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </>
+      ) : null}
+    </li>
+  );
+}
+
+function PreviewLink({
+  article,
+  feedTitle,
+  now,
+  children,
+}: {
+  article: Article;
+  feedTitle: string;
+  now: number;
+  children: ReactNode;
+}) {
+  const isDesktop = useIsDesktop();
+  const navigate = useNavigate();
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const openReader = () =>
+    navigate(`/feeds/${article.feedId}/articles/${article.id}`, {
+      state: { from: "/signal" },
+    });
+
+  if (isDesktop) {
+    return (
+      <HoverCard openDelay={120} closeDelay={80}>
+        <HoverCardTrigger asChild>
+          <button type="button" onClick={openReader} className={ROW_CLASS}>
+            {children}
+          </button>
+        </HoverCardTrigger>
+        <HoverCardContent align="start">
+          <ArticlePreview article={article} feedTitle={feedTitle} now={now} onOpen={openReader} />
+        </HoverCardContent>
+      </HoverCard>
+    );
+  }
+
+  return (
+    <>
+      <button type="button" onClick={() => setSheetOpen(true)} className={ROW_CLASS}>
+        {children}
+      </button>
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent side="bottom" className="max-h-[80vh] overflow-y-auto p-4">
+          <SheetTitle className="sr-only">Article preview</SheetTitle>
+          <SheetDescription className="sr-only">
+            Peek at this article and open it in the reader.
+          </SheetDescription>
+          <ArticlePreview
+            article={article}
+            feedTitle={feedTitle}
+            now={now}
+            onOpen={() => {
+              setSheetOpen(false);
+              openReader();
+            }}
+          />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+function resolveHead(story: Story, articleMap: Map<string, Article>): Article | undefined {
+  for (const id of story.articleIds) {
+    const article = articleMap.get(id);
+    if (article) return article;
+  }
+  return undefined;
+}

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { HoverCard as HoverCardPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
+
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />;
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal>
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-80 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  );
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/src/core/signal/entities.ts
+++ b/src/core/signal/entities.ts
@@ -1,0 +1,274 @@
+/**
+ * Named-entity extraction for the Signal frequency engine.
+ *
+ * Pure functions, deterministic, no ML. The engine clusters strictly
+ * around proper nouns and compound nouns ("Iran War", "Supreme Court").
+ * Detection rests on capitalization consensus across the corpus rather
+ * than part-of-speech tagging:
+ *
+ *  - A single word is a proper noun if, across the whole corpus, it is
+ *    capitalized in a high share of its NON-INITIAL occurrences (mid
+ *    sentence, where capitalization is meaningful) — or, when it only
+ *    ever appears sentence-initial, if it is never seen lowercase.
+ *  - A compound is a contiguous run of capitalized words (allowing a few
+ *    connector words like "of"), taken only from sentence-case context or
+ *    from runs of already-confirmed proper nouns. This avoids turning a
+ *    Title-Cased headline into one giant bogus entity.
+ *
+ * The casing evidence comes from sentence-case text. Title-Cased headlines
+ * (most words capitalized) carry no casing signal and are excluded from the
+ * consensus tally.
+ */
+
+import { stripHtml, STOPWORDS } from "./tokenize.ts";
+import { PROPER_NOUN_RATIO } from "./types.ts";
+import type { Article } from "../../types/index.ts";
+
+/** Lowercase connector words allowed to sit inside a compound entity. */
+const CONNECTORS = new Set([
+  "of", "and", "the", "for", "de", "von", "van", "da", "del", "al", "la", "le",
+]);
+
+/** Max significant words kept in a compound key. */
+const MAX_PHRASE_WORDS = 3;
+
+/** Fraction of alpha words capitalized above which a title is "Title Cased". */
+const TITLE_CASE_THRESHOLD = 0.6;
+
+const WORD_SPLIT = /\s+/;
+const ALPHA = /\p{L}/u;
+const SENTENCE_BREAK = /(?<=[.!?])\s+/u;
+
+export interface EntityLexicon {
+  /** lowercased word → most common original casing, for confirmed proper nouns. */
+  properNouns: Map<string, string>;
+}
+
+export interface EntityOccurrence {
+  /** Lowercased, normalized phrase used as the cluster key. */
+  key: string;
+  /** Original casing as seen, used for display. */
+  display: string;
+  /** Significant (non-connector) word count — drives the phrase boost. */
+  words: number;
+}
+
+interface CasingTally {
+  nonInitialCap: number;
+  nonInitialLower: number;
+  totalLower: number;
+  totalCap: number;
+  articleIds: Set<string>;
+  /** Histogram of original casings, for picking a display form. */
+  casings: Map<string, number>;
+}
+
+/**
+ * Build the proper-noun lexicon from corpus-wide casing consensus. Pass
+ * the representative articles (one per syndicated story) so a wire story
+ * running across many feeds doesn't dominate the tally.
+ */
+export function buildLexicon(articles: Article[]): EntityLexicon {
+  const tally = new Map<string, CasingTally>();
+
+  for (const article of articles) {
+    for (const segment of segments(article)) {
+      // A Title-Cased segment capitalizes everything, so its casing is
+      // worthless as proper-noun evidence — skip it entirely.
+      if (isTitleCased(segment.words)) continue;
+      segment.words.forEach((word, i) => {
+        const norm = normalizeWord(word);
+        if (!norm) return;
+        let t = tally.get(norm);
+        if (!t) {
+          t = {
+            nonInitialCap: 0,
+            nonInitialLower: 0,
+            totalLower: 0,
+            totalCap: 0,
+            articleIds: new Set(),
+            casings: new Map(),
+          };
+          tally.set(norm, t);
+        }
+        t.articleIds.add(article.id);
+        const cap = isCapitalized(word);
+        if (cap) {
+          t.totalCap += 1;
+          t.casings.set(word, (t.casings.get(word) ?? 0) + 1);
+        } else {
+          t.totalLower += 1;
+        }
+        if (i > 0) {
+          if (cap) t.nonInitialCap += 1;
+          else t.nonInitialLower += 1;
+        }
+      });
+    }
+  }
+
+  const properNouns = new Map<string, string>();
+  for (const [norm, t] of tally) {
+    if (t.articleIds.size < 2) continue;
+    if (STOPWORDS.has(norm) || norm.length < 3) continue;
+    if (isProperNoun(t)) {
+      properNouns.set(norm, pickCasing(t.casings, norm));
+    }
+  }
+  return { properNouns };
+}
+
+function isProperNoun(t: CasingTally): boolean {
+  const nonInitial = t.nonInitialCap + t.nonInitialLower;
+  if (nonInitial > 0) {
+    return t.nonInitialCap / nonInitial >= PROPER_NOUN_RATIO;
+  }
+  // Only ever seen sentence-initial: trust it only if never lowercase.
+  return t.totalLower === 0 && t.totalCap >= 2;
+}
+
+/**
+ * Extract entity occurrences (proper nouns + compounds) from an article.
+ * Duplicate keys may repeat across mentions; the caller dedupes per
+ * article for counting while accumulating display casings.
+ */
+export function extractEntities(article: Article, lexicon: EntityLexicon): EntityOccurrence[] {
+  const out: EntityOccurrence[] = [];
+  for (const segment of segments(article)) {
+    const titleCased = isTitleCased(segment.words);
+    collectFromSegment(segment.words, lexicon, titleCased, out);
+  }
+  return out;
+}
+
+function collectFromSegment(
+  words: string[],
+  lexicon: EntityLexicon,
+  titleCased: boolean,
+  out: EntityOccurrence[],
+): void {
+  let run: { display: string; norm: string }[] = [];
+
+  const flush = () => {
+    const significant = run.filter((w) => !CONNECTORS.has(w.norm));
+    if (significant.length === 0) {
+      run = [];
+      return;
+    }
+    // Unigram entities: only confirmed proper nouns (kills sentence-initial
+    // and Title-Case false positives like "Breaking" / "The").
+    for (const w of significant) {
+      if (lexicon.properNouns.has(w.norm)) {
+        out.push({ key: w.norm, display: lexicon.properNouns.get(w.norm)!, words: 1 });
+      }
+    }
+    // Compound entity: trim connectors from the ends, keep up to N words.
+    if (significant.length >= 2) {
+      const trimmed = trimConnectors(run);
+      const sig = trimmed.filter((w) => !CONNECTORS.has(w.norm));
+      if (sig.length >= 2 && sig.length <= MAX_PHRASE_WORDS) {
+        const eligible = titleCased
+          ? sig.every((w) => lexicon.properNouns.has(w.norm))
+          : true;
+        if (eligible) {
+          out.push({
+            key: trimmed.map((w) => w.norm).join(" "),
+            display: trimmed.map((w) => w.display).join(" "),
+            words: sig.length,
+          });
+        }
+      }
+    }
+    run = [];
+  };
+
+  words.forEach((word, i) => {
+    const norm = normalizeWord(word);
+    if (!norm) {
+      flush();
+      return;
+    }
+    const isInitial = i === 0;
+    const cap = isCapitalized(word);
+    const connector = CONNECTORS.has(norm) && run.length > 0;
+    // A capitalized, non-initial word extends a run; a confirmed proper
+    // noun extends it even sentence-initially; a connector bridges a gap.
+    const extends_ =
+      (cap && !isInitial) || lexicon.properNouns.has(norm) || connector;
+    if (extends_) {
+      run.push({ display: word, norm });
+    } else {
+      flush();
+    }
+  });
+  flush();
+}
+
+function trimConnectors(run: { display: string; norm: string }[]): { display: string; norm: string }[] {
+  let start = 0;
+  let end = run.length;
+  while (start < end && CONNECTORS.has(run[start].norm)) start += 1;
+  while (end > start && CONNECTORS.has(run[end - 1].norm)) end -= 1;
+  return run.slice(start, end);
+}
+
+interface Segment {
+  words: string[];
+}
+
+function segments(article: Article): Segment[] {
+  const out: Segment[] = [];
+  const title = stripHtml(article.title || "").trim();
+  if (title) out.push({ words: title.split(WORD_SPLIT) });
+  const body = stripHtml(article.content || article.summary || "").trim();
+  if (body) {
+    for (const sentence of body.split(SENTENCE_BREAK)) {
+      const words = sentence.trim().split(WORD_SPLIT).filter(Boolean);
+      if (words.length) out.push({ words });
+    }
+  }
+  return out;
+}
+
+function isTitleCased(words: string[]): boolean {
+  const alpha = words.filter((w) => ALPHA.test(w));
+  // Below 4 words the capitalized share is an unreliable Title-Case signal:
+  // an entity-dense sentence-case headline ("OpenAI launches Atlas") would
+  // trip a lower bar and lose its proper nouns. Require enough words first.
+  if (alpha.length < 4) return false;
+  const capped = alpha.filter((w) => isCapitalized(w)).length;
+  return capped / alpha.length >= TITLE_CASE_THRESHOLD;
+}
+
+function isCapitalized(word: string): boolean {
+  const first = firstAlpha(word);
+  return first !== null && first === first.toUpperCase() && first !== first.toLowerCase();
+}
+
+function firstAlpha(word: string): string | null {
+  for (const ch of word) {
+    if (ALPHA.test(ch)) return ch;
+  }
+  return null;
+}
+
+/** Lowercase, strip surrounding punctuation and a trailing possessive. */
+function normalizeWord(word: string): string {
+  const lower = word.toLowerCase().replace(/[’']s$/u, "");
+  const cleaned = lower.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "");
+  if (!ALPHA.test(cleaned)) return "";
+  return cleaned;
+}
+
+function pickCasing(casings: Map<string, number>, fallback: string): string {
+  let best = fallback;
+  let bestCount = -1;
+  for (const [casing, count] of casings) {
+    const clean = casing.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "");
+    if (count > bestCount || (count === bestCount && clean < best)) {
+      best = clean;
+      bestCount = count;
+    }
+  }
+  return best;
+}

--- a/src/core/signal/frequency-engine.ts
+++ b/src/core/signal/frequency-engine.ts
@@ -2,29 +2,36 @@
  * Frequency engine for the Signal surface.
  *
  * Pure-function, deterministic, no LLM, no Worker. Given the user's
- * stored articles and feeds, produces a ranked list of topics — terms
- * appearing across multiple feeds in the chosen recency window — with
- * the articles assigned to each.
+ * stored articles and feeds, produces a ranked list of topics — proper
+ * nouns and compound nouns appearing across multiple feeds in the chosen
+ * recency window — with the stories (multi-outlet article groups) assigned
+ * to each.
  *
  * Algorithm:
  *  1. Pick the smallest window with enough articles (7d → 14d → 30d → all).
- *  2. Dedupe near-identical syndicated articles by normalized title.
- *  3. Tokenize title + body (HTML stripped) with light stemming and
- *     stopword + feed-noise filtering.
- *  4. Score each term by `distinctArticles * log(1 + distinctFeeds)`,
- *     keeping only terms that appear in ≥2 articles AND ≥2 feeds.
- *  5. Greedy-cluster: highest-scoring term claims every article that
- *     mentions it, up to a per-topic cap so a single dominant term
- *     can't swallow the whole page.
- *  6. Within each topic, order articles most-recent first.
+ *  2. Group byte-identical syndicated articles by normalized title, keeping
+ *     a representative per story plus its cross-feed members.
+ *  3. Extract named entities (proper/compound nouns) from each
+ *     representative via capitalization consensus — no common nouns.
+ *  4. Score each entity by `distinctArticles * log(1 + distinctFeeds)`,
+ *     boosted for multi-word compounds, keeping only entities in ≥2
+ *     articles AND ≥2 feeds.
+ *  5. Greedy-cluster: highest-scoring entity claims every representative
+ *     that mentions it, up to a per-topic cap so a single dominant entity
+ *     can't swallow the page.
+ *  6. Within each topic, merge representatives into stories (same/similar
+ *     headline) so the UI can show "covered by N outlets".
  *
- * All sorts use total-ordered tiebreaks so the output is deterministic
- * for a given input — the 24h cache in the store depends on this.
+ * All sorts use total-ordered tiebreaks so the output is deterministic for
+ * a given input — the 24h cache in the store depends on this.
  */
 
-import { tokenize } from "./tokenize.ts";
+import { buildLexicon, extractEntities } from "./entities.ts";
+import { groupIntoStories } from "./stories.ts";
 import {
+  PHRASE_BOOST,
   SIGNAL_MIN_PER_WINDOW,
+  SIGNAL_REPORT_SCHEMA_VERSION,
   SIGNAL_TOPIC_STORE_CAP,
   SIGNAL_TOPIC_TARGET,
   SIGNAL_WINDOWS,
@@ -58,20 +65,23 @@ export function generateReport(
 ): Result<SignalReport> {
   const corpusSize = articles.length;
   const { window, inWindow } = pickWindow(articles, now);
-  const deduped = dedupeByTitle(inWindow);
-  const tokenized = deduped.map((article) => ({
+  const { reps, members } = groupExactDuplicates(inWindow);
+
+  const lexicon = buildLexicon(reps);
+  const tokenized = reps.map((article) => ({
     article,
-    tokens: new Set(allTokens(article)),
+    occurrences: extractEntities(article, lexicon),
   }));
 
   const feedsInWindow = new Set(inWindow.map((a) => a.feedId)).size;
 
   const termIndex = buildIndex(tokenized);
   const ranked = scoreTerms(termIndex);
-  const cap = Math.max(2, Math.ceil(deduped.length / SIGNAL_TOPIC_TARGET) + 5);
-  const topics = clusterGreedy(ranked, tokenized, cap);
+  const cap = Math.max(2, Math.ceil(reps.length / SIGNAL_TOPIC_TARGET) + 5);
+  const topics = clusterGreedy(ranked, tokenized, members, cap);
 
   return ok({
+    schemaVersion: SIGNAL_REPORT_SCHEMA_VERSION,
     topics,
     window,
     corpusSize,
@@ -83,15 +93,15 @@ export function generateReport(
 
 interface TokenizedArticle {
   article: Article;
-  tokens: Set<string>;
+  occurrences: ReturnType<typeof extractEntities>;
 }
 
 interface TermEntry {
   articleIds: Set<string>;
   feedIds: Set<string>;
+  words: number;
+  casings: Map<string, number>;
 }
-
-const WORD_BOUNDARY = /[^\p{L}\p{N}]+/u;
 
 /**
  * Pick the smallest window with enough articles to run on. Exported so
@@ -115,43 +125,72 @@ export function pickWindow(
   return { window: "all", inWindow: articles };
 }
 
-function dedupeByTitle(articles: Article[]): Article[] {
-  const seen = new Map<string, Article>();
+/**
+ * Group byte-identical syndicated articles by normalized title. Returns a
+ * representative (most recent) per story for scoring/clustering, plus a
+ * map from the representative's id to every member sharing its title — so
+ * a topic can later show how many outlets ran the story.
+ */
+function groupExactDuplicates(articles: Article[]): {
+  reps: Article[];
+  members: Map<string, Article[]>;
+} {
+  const byKey = new Map<string, Article[]>();
+  const standalone: Article[] = [];
   for (const article of articles) {
     const key = normalizeTitle(article.title);
     if (!key) {
-      seen.set(article.id, article);
+      standalone.push(article);
       continue;
     }
-    const existing = seen.get(key);
-    if (!existing || article.publishedAt > existing.publishedAt) {
-      seen.set(key, article);
-    }
+    const group = byKey.get(key);
+    if (group) group.push(article);
+    else byKey.set(key, [article]);
   }
-  return Array.from(seen.values());
+
+  const reps: Article[] = [];
+  const members = new Map<string, Article[]>();
+  for (const group of byKey.values()) {
+    const rep = mostRecent(group);
+    reps.push(rep);
+    members.set(rep.id, group);
+  }
+  for (const article of standalone) {
+    reps.push(article);
+    members.set(article.id, [article]);
+  }
+  return { reps, members };
+}
+
+function mostRecent(group: Article[]): Article {
+  return group.reduce((best, a) =>
+    a.publishedAt > best.publishedAt ||
+    (a.publishedAt === best.publishedAt && a.id < best.id)
+      ? a
+      : best,
+  );
 }
 
 function normalizeTitle(title: string): string {
   return title.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
-function allTokens(article: Article): string[] {
-  const titleTokens = tokenize(article.title);
-  const bodyTokens = tokenize(article.content || article.summary || "");
-  return titleTokens.concat(bodyTokens);
-}
-
 function buildIndex(tokenized: TokenizedArticle[]): Map<string, TermEntry> {
   const index = new Map<string, TermEntry>();
-  for (const { article, tokens } of tokenized) {
-    for (const term of tokens) {
-      let entry = index.get(term);
+  for (const { article, occurrences } of tokenized) {
+    const seen = new Set<string>();
+    for (const occ of occurrences) {
+      let entry = index.get(occ.key);
       if (!entry) {
-        entry = { articleIds: new Set(), feedIds: new Set() };
-        index.set(term, entry);
+        entry = { articleIds: new Set(), feedIds: new Set(), words: occ.words, casings: new Map() };
+        index.set(occ.key, entry);
       }
-      entry.articleIds.add(article.id);
-      entry.feedIds.add(article.feedId);
+      entry.casings.set(occ.display, (entry.casings.get(occ.display) ?? 0) + 1);
+      if (!seen.has(occ.key)) {
+        entry.articleIds.add(article.id);
+        entry.feedIds.add(article.feedId);
+        seen.add(occ.key);
+      }
     }
   }
   return index;
@@ -159,6 +198,7 @@ function buildIndex(tokenized: TokenizedArticle[]): Map<string, TermEntry> {
 
 interface RankedTerm {
   term: string;
+  displayTerm: string;
   signal: number;
   articleIds: Set<string>;
   feedCount: number;
@@ -169,9 +209,11 @@ function scoreTerms(index: Map<string, TermEntry>): RankedTerm[] {
   for (const [term, entry] of index) {
     if (entry.articleIds.size < 2) continue;
     if (entry.feedIds.size < 2) continue;
-    const signal = entry.articleIds.size * Math.log(1 + entry.feedIds.size);
+    const base = entry.articleIds.size * Math.log(1 + entry.feedIds.size);
+    const signal = base * (1 + PHRASE_BOOST * (entry.words - 1));
     out.push({
       term,
+      displayTerm: pickDisplay(entry.casings, term),
       signal,
       articleIds: entry.articleIds,
       feedCount: entry.feedIds.size,
@@ -182,26 +224,10 @@ function scoreTerms(index: Map<string, TermEntry>): RankedTerm[] {
   return out;
 }
 
-/**
- * Recover the most common original casing of a stem from the articles
- * actually assigned to the cluster. Runs once per surfaced topic
- * (~10 per report) rather than once per indexed term — cheaper and
- * avoids the `ies → y` blind spot of a prefix-match on every term.
- */
-function pickDisplayTerm(term: string, articles: Article[]): string {
-  const histogram = new Map<string, number>();
-  for (const article of articles) {
-    const text = article.title + " " + (article.content || article.summary || "");
-    for (const word of text.split(WORD_BOUNDARY)) {
-      if (!word) continue;
-      if (word.toLowerCase().startsWith(term)) {
-        histogram.set(word, (histogram.get(word) ?? 0) + 1);
-      }
-    }
-  }
-  let best = term;
-  let bestCount = 0;
-  for (const [casing, count] of histogram) {
+function pickDisplay(casings: Map<string, number>, fallback: string): string {
+  let best = fallback;
+  let bestCount = -1;
+  for (const [casing, count] of casings) {
     if (count > bestCount || (count === bestCount && casing < best)) {
       best = casing;
       bestCount = count;
@@ -213,9 +239,10 @@ function pickDisplayTerm(term: string, articles: Article[]): string {
 function clusterGreedy(
   ranked: RankedTerm[],
   tokenized: TokenizedArticle[],
+  members: Map<string, Article[]>,
   cap: number,
 ): Topic[] {
-  const articleById = new Map(tokenized.map((t) => [t.article.id, t]));
+  const articleById = new Map(tokenized.map((t) => [t.article.id, t.article]));
   const claimed = new Set<string>();
   const topics: Topic[] = [];
 
@@ -225,42 +252,43 @@ function clusterGreedy(
     const candidates: Article[] = [];
     for (const articleId of term.articleIds) {
       if (claimed.has(articleId)) continue;
-      const tok = articleById.get(articleId);
-      if (!tok) continue;
-      candidates.push(tok.article);
+      const article = articleById.get(articleId);
+      if (!article) continue;
+      candidates.push(article);
     }
     if (candidates.length < 2) continue;
 
-    // Bleed-over guard: if most of this term's articles were already
-    // claimed by a higher-signal cluster, this term is just a fragment
-    // of that cluster (e.g. "ship" surviving after "OpenAI" claims
-    // every "OpenAI ships X" article). Demand ≥50% of the term's
-    // original article set survive the peel-off.
+    // Bleed-over guard: if most of this entity's articles were already
+    // claimed by a higher-signal cluster (typically the compound that
+    // contains it — "Iran War" claiming the "Iran" articles), this entity
+    // is a fragment, not its own topic. Demand ≥50% survive the peel-off.
     if (candidates.length * 2 < originalSize) continue;
 
-    // Cross-feed check on remaining candidates: the cluster only counts
-    // if it still spans ≥2 feeds after greedy claiming peels off articles
-    // claimed by stronger terms.
     const feedIds = new Set(candidates.map((a) => a.feedId));
     if (feedIds.size < 2) continue;
 
-    // Most-recent first within the topic. Stable tiebreak by article id.
+    // Claim representatives most-recent first so the per-topic cap keeps
+    // the freshest stories. Stable tiebreak by id.
     candidates.sort((a, b) =>
       (b.publishedAt - a.publishedAt) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
     );
-    // Claim up to `cap` articles so a co-occurring term (e.g. "ship" in
-    // "OpenAI ships X") can't pick up the leftovers and form a near-
-    // duplicate cluster. Render limit is enforced separately via
-    // SIGNAL_ARTICLES_PER_TOPIC when the topic is consumed.
     const claimedHere = candidates.slice(0, cap);
     for (const article of claimedHere) claimed.add(article.id);
 
+    const stories = groupIntoStories(claimedHere, members);
+    const allMembers = stories.reduce((n, s) => n + s.articleIds.length, 0);
+    const topicFeeds = new Set<string>();
+    for (const article of claimedHere) {
+      for (const m of members.get(article.id) ?? [article]) topicFeeds.add(m.feedId);
+    }
+
     topics.push({
       term: term.term,
-      displayTerm: pickDisplayTerm(term.term, claimedHere),
-      articleIds: claimedHere.slice(0, SIGNAL_TOPIC_STORE_CAP).map((a) => a.id),
-      totalArticlesInCluster: claimedHere.length,
-      feedCount: feedIds.size,
+      displayTerm: term.displayTerm,
+      stories: stories.slice(0, SIGNAL_TOPIC_STORE_CAP),
+      totalStories: stories.length,
+      totalArticlesInCluster: allMembers,
+      feedCount: topicFeeds.size,
     });
   }
 

--- a/src/core/signal/stories.ts
+++ b/src/core/signal/stories.ts
@@ -1,0 +1,82 @@
+/**
+ * Story grouping for the Signal frequency engine.
+ *
+ * Within a single topic, multiple articles often cover the same event —
+ * either byte-identical syndication (collapsed earlier by exact-title
+ * grouping) or independent reporting with similar headlines. This module
+ * merges a topic's representative articles into stories so the UI can show
+ * "covered by N outlets" instead of repeating the same event as separate
+ * rows.
+ *
+ * Runs per topic over a small set (≤ the per-topic claim cap), so the
+ * O(n²) similarity comparison is cheap.
+ */
+
+import { tokenize } from "./tokenize.ts";
+import { STORY_SIMILARITY, type Story } from "./types.ts";
+import type { Article } from "../../types/index.ts";
+
+interface StoryAccumulator {
+  members: Article[];
+  titleTokens: Set<string>;
+}
+
+/**
+ * Group a topic's representative articles into stories. `members` maps a
+ * representative article id to all articles sharing its exact title
+ * (including cross-feed syndicated copies) so the outlet count reflects
+ * every feed that ran the story.
+ */
+export function groupIntoStories(
+  reps: Article[],
+  members: Map<string, Article[]>,
+): Story[] {
+  const groups: StoryAccumulator[] = [];
+
+  for (const rep of reps) {
+    const tokens = new Set(tokenize(rep.title));
+    const match = groups.find((g) => jaccard(tokens, g.titleTokens) >= STORY_SIMILARITY);
+    const repMembers = members.get(rep.id) ?? [rep];
+    if (match) {
+      match.members.push(...repMembers);
+      for (const t of tokens) match.titleTokens.add(t);
+    } else {
+      groups.push({ members: [...repMembers], titleTokens: tokens });
+    }
+  }
+
+  const built = groups.map((g) => toStory(g.members));
+  // Outlet count first (multi-feed stories lead), then recency, then id.
+  built.sort(
+    (a, b) =>
+      b.story.feedCount - a.story.feedCount ||
+      b.headTime - a.headTime ||
+      (a.story.id < b.story.id ? -1 : a.story.id > b.story.id ? 1 : 0),
+  );
+  return built.map((b) => b.story);
+}
+
+function toStory(members: Article[]): { story: Story; headTime: number } {
+  const ordered = [...members].sort(
+    (a, b) =>
+      b.publishedAt - a.publishedAt || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+  const feedCount = new Set(ordered.map((a) => a.feedId)).size;
+  const head = ordered[0];
+  return {
+    story: {
+      id: head.id,
+      title: head.title,
+      articleIds: ordered.map((a) => a.id),
+      feedCount,
+    },
+    headTime: head.publishedAt,
+  };
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const t of a) if (b.has(t)) intersection += 1;
+  return intersection / (a.size + b.size - intersection);
+}

--- a/src/core/signal/tokenize.ts
+++ b/src/core/signal/tokenize.ts
@@ -102,6 +102,10 @@ export function tokenize(input: string): string[] {
   return out;
 }
 
-function stripHtml(input: string): string {
+/**
+ * Strip HTML tags and entities, preserving original case. Shared with the
+ * entity extractor, which needs casing intact to detect proper nouns.
+ */
+export function stripHtml(input: string): string {
   return input.replace(/<[^>]*>/g, " ").replace(/&[a-z0-9#]+;/gi, " ");
 }

--- a/src/core/signal/types.ts
+++ b/src/core/signal/types.ts
@@ -19,15 +19,15 @@ export const SIGNAL_MIN_PER_WINDOW = 50;
 /** Maximum topics surfaced on the Signal page. */
 export const SIGNAL_TOPIC_TARGET = 10;
 
-/** Default article rows rendered per topic before the user expands it. */
+/** Default story rows rendered per topic before the user expands it. */
 export const SIGNAL_ARTICLES_PER_TOPIC = 6;
 
 /**
- * Hard ceiling on articles stored per topic. The engine claims many
+ * Hard ceiling on stories stored per topic. The engine claims many
  * articles for a cluster (so leftover fragments can't form near-duplicate
  * topics — see `bleed-over guard` in frequency-engine), but the cached
- * report shouldn't carry hundreds of ids per topic when the user only
- * ever sees 6 by default. Bounds localStorage growth.
+ * report shouldn't carry hundreds of stories per topic when the user only
+ * ever sees a handful by default. Bounds localStorage growth.
  */
 export const SIGNAL_TOPIC_STORE_CAP = 30;
 
@@ -37,28 +37,77 @@ export const SIGNAL_REPORT_TTL_MS = 24 * 60 * 60 * 1000;
 /** Window choices the engine tries, in order of preference. */
 export const SIGNAL_WINDOWS: readonly WindowChoice[] = ["7d", "14d", "30d", "all"];
 
+/**
+ * Minimum share of an entity's non-initial occurrences that must be
+ * capitalized for it to count as a proper noun. Distinguishes "Apple"
+ * (company) from "apple" (fruit) via corpus-wide casing consensus.
+ */
+export const PROPER_NOUN_RATIO = 0.7;
+
+/**
+ * Per-extra-word multiplier applied to a multi-word entity's signal so a
+ * compound ("Iran War") outranks its constituent ("Iran") and wins the
+ * greedy claim first. The bleed-over guard then suppresses the
+ * now-fragmented unigram.
+ */
+export const PHRASE_BOOST = 0.5;
+
+/**
+ * Jaccard overlap of significant title tokens above which two articles in
+ * the same topic are treated as the same story (covered by multiple
+ * outlets). Catches "same / similar" wording, not just identical titles.
+ */
+export const STORY_SIMILARITY = 0.6;
+
+/**
+ * Bumped whenever the cached `SignalReport` shape changes. The store
+ * discards any cached report tagged with a different version so a stale
+ * payload from an older build can't mis-render.
+ */
+export const SIGNAL_REPORT_SCHEMA_VERSION = 2;
+
+/**
+ * A group of articles from one or more feeds covering the same story.
+ * Single-outlet stories are common; multi-outlet stories (feedCount ≥ 2)
+ * are the "covered by N outlets" rows the user wants surfaced.
+ */
+export interface Story {
+  /** Stable id — the most-recent member article's id. */
+  id: string;
+  /** Representative headline (the most-recent member's title). */
+  title: string;
+  /** All member article ids, ordered most-recent first. */
+  articleIds: string[];
+  /** Distinct feeds covering this story. */
+  feedCount: number;
+}
+
 export interface Topic {
-  /** Lowercased + stemmed term that anchors the cluster. */
+  /** Lowercased entity key that anchors the cluster (proper/compound noun). */
   term: string;
-  /** The term in its most common original casing across the corpus. */
+  /** The entity in its most common original casing across the corpus. */
   displayTerm: string;
   /**
-   * Articles assigned to this cluster, ordered most-recent first.
-   * Capped at `SIGNAL_TOPIC_STORE_CAP` — the UI shows the first
-   * `SIGNAL_ARTICLES_PER_TOPIC` by default and reveals the rest on
-   * an "expand" toggle.
+   * Stories assigned to this cluster, ordered by outlet count then
+   * recency. Capped at `SIGNAL_TOPIC_STORE_CAP` — the UI shows the first
+   * `SIGNAL_ARTICLES_PER_TOPIC` by default and reveals the rest on an
+   * "expand" toggle.
    */
-  articleIds: string[];
+  stories: Story[];
   /**
-   * Total articles claimed by this cluster before storage truncation.
-   * Drives the "+ N more" affordance and the topic's article count.
+   * Total stories claimed by this cluster before storage truncation.
+   * Drives the "+ N more" affordance.
    */
+  totalStories: number;
+  /** Total member articles across all stories in the cluster. */
   totalArticlesInCluster: number;
   /** Distinct feeds the cluster's articles came from. */
   feedCount: number;
 }
 
 export interface SignalReport {
+  /** Schema version of this cached payload. See `SIGNAL_REPORT_SCHEMA_VERSION`. */
+  schemaVersion: number;
   topics: Topic[];
   window: WindowChoice;
   /** Total articles in the user's store at generation time. */

--- a/src/pages/signal-page.tsx
+++ b/src/pages/signal-page.tsx
@@ -12,6 +12,7 @@ import {
   type WindowChoice,
 } from "@/core/signal/types.ts";
 import { Button } from "@/components/ui/button.tsx";
+import { StoryRow } from "@/components/signal/story-row.tsx";
 import { formatRelative } from "@/lib/format-relative.ts";
 import { goToSettings } from "@/lib/go-to-settings.ts";
 import { usePullToRefresh } from "@/hooks/use-pull-to-refresh.ts";
@@ -234,13 +235,11 @@ function TopicBlock({
   feedMap: Map<string, Feed>;
   now: number;
 }) {
-  const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
-  const allArticles = topic.articleIds
-    .map((id) => articleMap.get(id))
-    .filter((a): a is Article => a !== undefined);
-  const visible = expanded ? allArticles : allArticles.slice(0, SIGNAL_ARTICLES_PER_TOPIC);
-  const hiddenCount = topic.totalArticlesInCluster - visible.length;
+  const visible = expanded
+    ? topic.stories
+    : topic.stories.slice(0, SIGNAL_ARTICLES_PER_TOPIC);
+  const hiddenCount = topic.totalStories - visible.length;
 
   return (
     <section>
@@ -251,25 +250,15 @@ function TopicBlock({
         </p>
       </header>
       <ul className="divide-y divide-border">
-        {visible.map((article) => {
-          const feed = feedMap.get(article.feedId);
-          return (
-            <li key={article.id}>
-              <button
-                type="button"
-                onClick={() => navigate(`/feeds/${article.feedId}/articles/${article.id}`)}
-                className="flex w-full flex-col gap-1 py-3 text-left transition-colors hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none"
-              >
-                <span className="text-sm text-foreground">{article.title}</span>
-                <span className="text-xs text-muted-foreground">
-                  {feed?.title ?? "Unknown feed"}
-                  {" · "}
-                  {formatRelative(article.publishedAt, now)}
-                </span>
-              </button>
-            </li>
-          );
-        })}
+        {visible.map((story) => (
+          <StoryRow
+            key={story.id}
+            story={story}
+            articleMap={articleMap}
+            feedMap={feedMap}
+            now={now}
+          />
+        ))}
       </ul>
       {hiddenCount > 0 && !expanded ? (
         <button

--- a/src/stores/signal-store.ts
+++ b/src/stores/signal-store.ts
@@ -4,6 +4,7 @@ import { useFeedStore } from "./feed-store.ts";
 import { generateReport, pickWindow } from "../core/signal/frequency-engine.ts";
 import {
   SIGNAL_CORPUS_GATE,
+  SIGNAL_REPORT_SCHEMA_VERSION,
   SIGNAL_REPORT_TTL_MS,
   type SignalReport,
 } from "../core/signal/types.ts";
@@ -106,6 +107,10 @@ function readCache(): CachedReport | null {
     if (!raw) return null;
     const parsed = JSON.parse(raw);
     if (!parsed?.report || typeof parsed.report.generatedAt !== "number") {
+      return null;
+    }
+    // Discard a report written by a build with an incompatible shape.
+    if (parsed.report.schemaVersion !== SIGNAL_REPORT_SCHEMA_VERSION) {
       return null;
     }
     return { report: parsed.report as SignalReport };

--- a/tests/core/signal/entities.test.ts
+++ b/tests/core/signal/entities.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { buildLexicon, extractEntities } from "@/core/signal/entities.ts";
+import type { Article } from "@/types/index.ts";
+
+const NOW = new Date("2026-05-21T12:00:00Z").getTime();
+
+function makeArticle(id: string, title: string, content = ""): Article {
+  return {
+    id,
+    feedId: `feed-${id}`,
+    guid: id,
+    title,
+    link: `https://example.com/${id}`,
+    content,
+    summary: "",
+    author: "",
+    publishedAt: NOW,
+    read: false,
+    createdAt: NOW,
+  };
+}
+
+function keys(article: Article, lexicon: ReturnType<typeof buildLexicon>): string[] {
+  return extractEntities(article, lexicon).map((o) => o.key);
+}
+
+describe("buildLexicon — proper-noun consensus", () => {
+  it("admits a word capitalized mid-sentence across articles", () => {
+    const corpus = [
+      makeArticle("1", "Quarterly review", "The Apple event impressed critics this week."),
+      makeArticle("2", "Market notes", "Investors watched as Apple unveiled its plans."),
+    ];
+    const lexicon = buildLexicon(corpus);
+    expect(lexicon.properNouns.has("apple")).toBe(true);
+    expect(lexicon.properNouns.get("apple")).toBe("Apple");
+  });
+
+  it("rejects a word that appears lowercase mid-sentence", () => {
+    const corpus = [
+      makeArticle("1", "Snack notes", "I ate an apple and then another apple today."),
+      makeArticle("2", "More snacks", "She prefers an apple over an orange most days."),
+    ];
+    const lexicon = buildLexicon(corpus);
+    expect(lexicon.properNouns.has("apple")).toBe(false);
+  });
+
+  it("admits a word that only ever appears sentence-initial and never lowercase", () => {
+    const corpus = [
+      makeArticle("1", "OpenAI ships GPT release"),
+      makeArticle("2", "OpenAI hires research team"),
+    ];
+    const lexicon = buildLexicon(corpus);
+    expect(lexicon.properNouns.has("openai")).toBe(true);
+  });
+
+  it("rejects a common word capitalized only because it leads a headline", () => {
+    const corpus = [
+      makeArticle("1", "Markets tumble today", "Global markets fell as markets reacted to news."),
+      makeArticle("2", "Markets recover", "By noon the markets had clawed back losses in markets."),
+    ];
+    const lexicon = buildLexicon(corpus);
+    expect(lexicon.properNouns.has("markets")).toBe(false);
+  });
+
+  it("ignores stopwords and short tokens", () => {
+    const corpus = [
+      makeArticle("1", "review", "The And For event ran. The And For event ran again."),
+      makeArticle("2", "notes", "And For appeared. And For appeared once more."),
+    ];
+    const lexicon = buildLexicon(corpus);
+    expect(lexicon.properNouns.has("and")).toBe(false);
+    expect(lexicon.properNouns.has("the")).toBe(false);
+    expect(lexicon.properNouns.has("for")).toBe(false);
+  });
+});
+
+describe("extractEntities", () => {
+  it("emits a compound key for a mid-sentence capitalized run", () => {
+    const lexicon = buildLexicon([
+      makeArticle("seed", "Background", "Coverage of the Iran War deepened over the weekend."),
+    ]);
+    const article = makeArticle("1", "Update", "Tension over the Iran War grew sharply this month.");
+    expect(keys(article, lexicon)).toContain("iran war");
+  });
+
+  it("emits confirmed proper nouns as unigram keys", () => {
+    const corpus = [
+      makeArticle("1", "OpenAI ships GPT release"),
+      makeArticle("2", "OpenAI partners on safety"),
+    ];
+    const lexicon = buildLexicon(corpus);
+    expect(keys(corpus[0], lexicon)).toContain("openai");
+  });
+
+  it("does not turn a Title-Cased headline into one giant entity", () => {
+    const lexicon = buildLexicon([
+      makeArticle("seed1", "x", "The Apple keynote drew a crowd as Apple demoed devices."),
+      makeArticle("seed2", "y", "Later that day Apple confirmed the Apple lineup ships soon."),
+    ]);
+    const article = makeArticle("1", "Apple Unveils New Vision Pro Headset Today");
+    const extracted = keys(article, lexicon);
+    expect(extracted).not.toContain("apple unveils new vision pro headset today");
+    // The confirmed proper noun still surfaces.
+    expect(extracted).toContain("apple");
+  });
+
+  it("strips a trailing possessive so 'Trump's' matches 'Trump'", () => {
+    const lexicon = buildLexicon([
+      makeArticle("1", "x", "Critics said Trump misjudged the moment, and Trump pressed on."),
+      makeArticle("2", "y", "Later Trump reversed course while Trump allies grumbled."),
+    ]);
+    const article = makeArticle("3", "x", "The room reacted to Trump's remarks on Trump policy.");
+    expect(keys(article, lexicon)).toContain("trump");
+  });
+});

--- a/tests/core/signal/frequency-engine-edge.test.ts
+++ b/tests/core/signal/frequency-engine-edge.test.ts
@@ -44,10 +44,31 @@ function makeArticle(
 const FEEDS: Feed[] = Array.from({ length: 6 }, (_, i) => makeFeed(`f${i + 1}`));
 
 describe("frequency engine — edge cases", () => {
-  it("dedupes near-identical syndicated articles by normalized title", () => {
+  it("never anchors a topic on a bare common noun", () => {
     const articles: Article[] = [];
-    // 60 distinct headlines mostly, but one story syndicated across 6 feeds
-    // with slight punctuation variation. After dedupe, only one should survive.
+    // 60 headlines whose only shared word is the common noun "tariffs",
+    // which appears lowercase in bodies — so it must NOT form a topic.
+    for (let i = 0; i < 60; i++) {
+      articles.push(
+        makeArticle(
+          `a-${i}`,
+          `f${(i % 6) + 1}`,
+          `Tariffs shift trade number ${i}`,
+          i % 6,
+          `Analysts said tariffs would ripple as tariffs rose again number ${i}.`,
+        ),
+      );
+    }
+    const result = generateReport(articles, { feeds: FEEDS }, NOW);
+    expect(isOk(result)).toBe(true);
+    if (!result.ok) return;
+    const terms = result.value.topics.map((t) => t.term);
+    expect(terms).not.toContain("tariff");
+    expect(terms).not.toContain("tariffs");
+  });
+
+  it("collapses a syndicated story into one multi-outlet story, not a fake cluster", () => {
+    const articles: Article[] = [];
     for (let i = 0; i < 54; i++) {
       articles.push(makeArticle(`a-${i}`, `f${(i % 6) + 1}`, `Unique headline number ${i}`, i % 6));
     }
@@ -65,17 +86,16 @@ describe("frequency engine — edge cases", () => {
     const result = generateReport(articles, { feeds: FEEDS }, NOW);
     expect(isOk(result)).toBe(true);
     if (!result.ok) return;
-    // After dedupe, "mayor" / "resign" / "breaking" should NOT form a
-    // cross-feed cluster — they only survive on one article.
+    // "mayor" alone is a single deduped story across one normalized title —
+    // it must not masquerade as a cross-feed topic.
     const mayorTopic = result.value.topics.find((t) => t.term === "mayor");
     expect(mayorTopic).toBeUndefined();
   });
 
-  it("produces no topics when corpus is ≥ 100 articles but every term lives in one feed", () => {
+  it("produces no topics when every entity lives in one feed", () => {
     const articles: Article[] = [];
-    // 60 articles, all on f1, all distinct words.
     for (let i = 0; i < 60; i++) {
-      articles.push(makeArticle(`a-${i}`, "f1", `Singleton subject ${i}`, i % 6));
+      articles.push(makeArticle(`a-${i}`, "f1", `Solo Subject ${i}`, i % 6));
     }
     const result = generateReport(articles, { feeds: FEEDS }, NOW);
     expect(isOk(result)).toBe(true);
@@ -83,43 +103,44 @@ describe("frequency engine — edge cases", () => {
     expect(result.value.topics).toEqual([]);
   });
 
-  it("falls back to body tokens when the title yields nothing useful", () => {
+  it("detects an entity that only appears in the article body", () => {
     const articles: Article[] = [];
     for (let i = 0; i < 60; i++) {
-      // Title is just punctuation/numbers — nothing tokenizable.
       articles.push(
         makeArticle(
           `a-${i}`,
           `f${(i % 6) + 1}`,
           `... ${i}`,
           i % 6,
-          `OpenAI shipped quarterly results outpacing analyst forecasts ${i}`,
+          `Reports said OpenAI outpaced rivals as OpenAI expanded number ${i}.`,
         ),
       );
     }
     const result = generateReport(articles, { feeds: FEEDS }, NOW);
     expect(isOk(result)).toBe(true);
     if (!result.ok) return;
-    const terms = result.value.topics.map((t) => t.term);
-    expect(terms).toContain("openai");
+    expect(result.value.topics.map((t) => t.term)).toContain("openai");
   });
 
   it("is deterministic across two runs on the same input", () => {
     const articles: Article[] = [];
     for (let i = 0; i < 60; i++) {
       const cluster = i % 3;
-      const word = cluster === 0 ? "OpenAI" : cluster === 1 ? "Tariffs" : "Election";
+      const word = cluster === 0 ? "OpenAI" : cluster === 1 ? "Tesla" : "Reuters";
       articles.push(makeArticle(`a-${i}`, `f${(i % 6) + 1}`, `${word} update number ${i}`, i % 6));
     }
     const first = generateReport(articles, { feeds: FEEDS }, NOW);
     const second = generateReport([...articles].reverse(), { feeds: FEEDS }, NOW);
     expect(isOk(first) && isOk(second)).toBe(true);
     if (!first.ok || !second.ok) return;
-    // Ignore corpus stats (they're equal anyway); compare topic order +
-    // article ids strictly.
-    const firstShape = first.value.topics.map((t) => ({ term: t.term, ids: [...t.articleIds] }));
-    const secondShape = second.value.topics.map((t) => ({ term: t.term, ids: [...t.articleIds] }));
-    expect(secondShape).toEqual(firstShape);
+    const shape = (r: typeof first) =>
+      r.ok
+        ? r.value.topics.map((t) => ({
+            term: t.term,
+            stories: t.stories.map((s) => [...s.articleIds]),
+          }))
+        : null;
+    expect(shape(second)).toEqual(shape(first));
   });
 
   it("does not throw on non-English content; just produces fewer topics", () => {
@@ -132,14 +153,11 @@ describe("frequency engine — edge cases", () => {
     expect(isOk(result)).toBe(true);
   });
 
-  it("respects the per-topic claim cap so a dominant term cannot swallow the corpus", () => {
+  it("respects the per-topic claim cap so a dominant entity cannot swallow the corpus", () => {
     const articles: Article[] = [];
-    // 100 articles, all about openai, but tokens vary so other terms could
-    // still form clusters if the cap didn't apply. Each article also
-    // contains a distinct second proper noun to seed a smaller cluster.
     for (let i = 0; i < 100; i++) {
       articles.push(
-        makeArticle(`a-${i}`, `f${(i % 6) + 1}`, `OpenAI partners with Acme Corp ${i}`, i % 5),
+        makeArticle(`a-${i}`, `f${(i % 6) + 1}`, `OpenAI ships product number ${i}`, i % 5),
       );
     }
     const result = generateReport(articles, { feeds: FEEDS }, NOW);
@@ -147,12 +165,8 @@ describe("frequency engine — edge cases", () => {
     if (!result.ok) return;
     const openai = result.value.topics.find((t) => t.term === "openai");
     expect(openai).toBeDefined();
-    // Cluster cap = ceil(N/SIGNAL_TOPIC_TARGET) + 5 with N=100 → 15. So
-    // openai may claim up to 15 articles even though the corpus has 100
-    // openai-themed ones — the cap prevents page-swallow.
-    expect(openai!.totalArticlesInCluster).toBeLessThanOrEqual(15);
-    // Storage cap is generous so the page can offer an "expand" affordance,
-    // but still bounded.
-    expect(openai!.articleIds.length).toBeLessThanOrEqual(30);
+    // Cap = ceil(N/SIGNAL_TOPIC_TARGET) + 5 with N=100 → 15 representatives.
+    expect(openai!.totalStories).toBeLessThanOrEqual(15);
+    expect(openai!.stories.length).toBeLessThanOrEqual(30);
   });
 });

--- a/tests/core/signal/frequency-engine.test.ts
+++ b/tests/core/signal/frequency-engine.test.ts
@@ -42,80 +42,72 @@ function makeArticle(
 }
 
 describe("generateReport — happy path", () => {
-  // 8 feeds, 60 articles across two dominant topics ("openai" and "tariffs"),
-  // plus a third smaller topic ("election") and a long tail of single-feed
-  // chatter that should be discarded.
   const feeds: Feed[] = Array.from({ length: 8 }, (_, i) => makeFeed(`f${i + 1}`));
 
-  // Each headline carries one distinctive proper noun plus filler so the
-  // cluster anchor is unambiguous. Real headlines vary more than this, but
-  // the fixture's job is to assert ordering, not realism.
+  // "OpenAI" is a proper noun (only ever capitalized). The objects are
+  // lowercase so no competing entity forms within the cluster.
   const OPENAI_VARIANTS = [
-    "OpenAI ships GPT release",
-    "OpenAI hires research team",
-    "OpenAI partners with Microsoft",
-    "OpenAI cuts API prices",
-    "OpenAI faces lawsuit",
-    "OpenAI opens Tokyo office",
+    "OpenAI ships a release",
+    "OpenAI hires a team",
+    "OpenAI cuts api prices",
+    "OpenAI faces a lawsuit",
     "OpenAI updates safety policy",
-    "OpenAI hosts developer event",
-    "OpenAI buys hardware startup",
-    "OpenAI launches Atlas browser",
-    "OpenAI rolls back feature",
-    "OpenAI funds research grant",
+    "OpenAI hosts a developer event",
+    "OpenAI buys a hardware startup",
+    "OpenAI rolls back a feature",
+    "OpenAI funds a research grant",
     "OpenAI revenue beats forecast",
     "OpenAI faces regulatory scrutiny",
+    "OpenAI expands cloud capacity",
   ];
-  const TARIFF_VARIANTS = [
-    "Tariffs jolt global markets",
-    "Tariffs spark trade debate",
-    "Tariffs hit consumer prices",
-    "Tariffs reshape supply chains",
-    "Tariffs draw EU response",
-    "Tariffs prompt factory closures",
-    "Tariffs target electric vehicles",
-    "Tariffs squeeze farm exports",
-    "Tariffs raise inflation worry",
-    "Tariffs trigger retaliation threat",
-    "Tariffs dent corporate guidance",
-    "Tariffs widen budget gap",
-  ];
-  const ELECTION_VARIANTS = [
-    "Election polls swing late",
-    "Election ground game intensifies",
-    "Election fundraising sets record",
-    "Election turnout exceeds forecast",
-    "Election results delayed by recount",
-    "Election security upgraded statewide",
-    "Election debate reshuffles race",
-    "Election ad spending surges",
-    "Election workers report calm day",
+  // "Supreme Court" is a compound (Court recurs capitalized mid-headline).
+  const COURT_VARIANTS = [
+    "Supreme Court rules on a case",
+    "Supreme Court hears arguments",
+    "Supreme Court weighs a challenge",
+    "Supreme Court issues an opinion",
+    "Supreme Court delays a decision",
+    "Supreme Court reviews a petition",
+    "Supreme Court splits on a ruling",
+    "Supreme Court declines a case",
   ];
 
   const articles: Article[] = [];
   OPENAI_VARIANTS.forEach((title, i) => {
     articles.push(makeArticle(`a-openai-${i}`, `f${(i % 6) + 1}`, title, 1 + (i % 5)));
   });
-  TARIFF_VARIANTS.forEach((title, i) => {
-    articles.push(makeArticle(`a-tariff-${i}`, `f${(i % 5) + 1}`, title, 1 + (i % 4)));
+  // One OpenAI story syndicated verbatim across three outlets.
+  ["f1", "f2", "f3"].forEach((feedId, i) => {
+    articles.push(makeArticle(`a-openai-syn-${i}`, feedId, "OpenAI launches atlas browser", 2));
   });
-  ELECTION_VARIANTS.forEach((title, i) => {
-    articles.push(makeArticle(`a-elect-${i}`, `f${(i % 4) + 1}`, title, 2 + (i % 3)));
+  COURT_VARIANTS.forEach((title, i) => {
+    articles.push(makeArticle(`a-court-${i}`, `f${(i % 5) + 1}`, title, 1 + (i % 4)));
   });
   // Long tail: single-feed chatter that shouldn't form cross-feed clusters.
-  for (let i = 0; i < 25; i++) {
+  for (let i = 0; i < 30; i++) {
     articles.push(makeArticle(`a-noise-${i}`, "f8", `Singleton subject ${i}`, 2));
   }
 
   const result = generateReport(articles, { feeds }, NOW);
 
-  it("returns ok with topics ordered by signal strength", () => {
+  it("anchors topics on proper nouns and compound nouns", () => {
     expect(isOk(result)).toBe(true);
     if (!result.ok) return;
     const terms = result.value.topics.map((t) => t.term);
-    expect(terms[0]).toBe("openai");
-    expect(terms[1]).toBe("tariff");
-    expect(terms[2]).toBe("election");
+    expect(terms).toContain("openai");
+    expect(terms).toContain("supreme court");
+  });
+
+  it("orders topics by signal strength (OpenAI is loudest)", () => {
+    if (!result.ok) return;
+    expect(result.value.topics[0].term).toBe("openai");
+  });
+
+  it("prefers the compound over its constituents", () => {
+    if (!result.ok) return;
+    const terms = result.value.topics.map((t) => t.term);
+    expect(terms).not.toContain("supreme");
+    expect(terms).not.toContain("court");
   });
 
   it("produces at most SIGNAL_TOPIC_TARGET topics", () => {
@@ -130,24 +122,23 @@ describe("generateReport — happy path", () => {
     }
   });
 
+  it("surfaces a multi-outlet story with its outlet count", () => {
+    if (!result.ok) return;
+    const openai = result.value.topics.find((t) => t.term === "openai");
+    const multi = openai?.stories.find((s) => s.feedCount >= 2);
+    expect(multi).toBeDefined();
+    expect(multi!.articleIds.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("topics are disjoint — no article appears in two topics", () => {
     if (!result.ok) return;
     const seen = new Set<string>();
     for (const topic of result.value.topics) {
-      for (const id of topic.articleIds) {
-        expect(seen.has(id)).toBe(false);
-        seen.add(id);
-      }
-    }
-  });
-
-  it("intra-topic article order is most-recent first", () => {
-    if (!result.ok) return;
-    const byId = new Map(articles.map((a) => [a.id, a]));
-    for (const topic of result.value.topics) {
-      const times = topic.articleIds.map((id) => byId.get(id)!.publishedAt);
-      for (let i = 1; i < times.length; i++) {
-        expect(times[i - 1]).toBeGreaterThanOrEqual(times[i]);
+      for (const story of topic.stories) {
+        for (const id of story.articleIds) {
+          expect(seen.has(id)).toBe(false);
+          seen.add(id);
+        }
       }
     }
   });
@@ -156,10 +147,13 @@ describe("generateReport — happy path", () => {
     if (!result.ok) return;
     const openai = result.value.topics.find((t) => t.term === "openai");
     expect(openai?.displayTerm).toBe("OpenAI");
+    const court = result.value.topics.find((t) => t.term === "supreme court");
+    expect(court?.displayTerm).toBe("Supreme Court");
   });
 
-  it("reports corpus stats and chosen window", () => {
+  it("reports schema version, corpus stats and chosen window", () => {
     if (!result.ok) return;
+    expect(result.value.schemaVersion).toBe(2);
     expect(result.value.corpusSize).toBe(articles.length);
     expect(result.value.corpusInWindow).toBeGreaterThan(0);
     expect(result.value.window).toBe("7d");

--- a/tests/core/signal/stories.test.ts
+++ b/tests/core/signal/stories.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { groupIntoStories } from "@/core/signal/stories.ts";
+import type { Article } from "@/types/index.ts";
+
+const NOW = new Date("2026-05-21T12:00:00Z").getTime();
+const DAY = 24 * 60 * 60 * 1000;
+
+function makeArticle(id: string, feedId: string, title: string, ageDays = 0): Article {
+  const publishedAt = NOW - ageDays * DAY;
+  return {
+    id,
+    feedId,
+    guid: id,
+    title,
+    link: `https://example.com/${id}`,
+    content: "",
+    summary: "",
+    author: "",
+    publishedAt,
+    read: false,
+    createdAt: publishedAt,
+  };
+}
+
+function soloMembers(reps: Article[]): Map<string, Article[]> {
+  return new Map(reps.map((r) => [r.id, [r]]));
+}
+
+describe("groupIntoStories", () => {
+  it("merges representatives with similar headlines into one story", () => {
+    const reps = [
+      makeArticle("a", "f1", "Mayor resigns amid corruption scandal"),
+      makeArticle("b", "f2", "Mayor resigns over corruption scandal"),
+    ];
+    const stories = groupIntoStories(reps, soloMembers(reps));
+    expect(stories).toHaveLength(1);
+    expect(stories[0].feedCount).toBe(2);
+    expect(stories[0].articleIds).toHaveLength(2);
+  });
+
+  it("keeps unrelated headlines as separate stories", () => {
+    const reps = [
+      makeArticle("a", "f1", "Apple ships new headset"),
+      makeArticle("b", "f2", "Tariffs rattle global markets"),
+    ];
+    const stories = groupIntoStories(reps, soloMembers(reps));
+    expect(stories).toHaveLength(2);
+  });
+
+  it("counts every outlet that ran an exact-duplicate story", () => {
+    const rep = makeArticle("a", "f1", "Breaking: summit ends without deal");
+    const members = new Map<string, Article[]>([
+      [
+        "a",
+        [
+          rep,
+          makeArticle("a2", "f2", "Breaking: summit ends without deal"),
+          makeArticle("a3", "f3", "Breaking: summit ends without deal"),
+        ],
+      ],
+    ]);
+    const stories = groupIntoStories([rep], members);
+    expect(stories).toHaveLength(1);
+    expect(stories[0].feedCount).toBe(3);
+    expect(stories[0].articleIds).toHaveLength(3);
+  });
+
+  it("orders stories by outlet count, then recency", () => {
+    const reps = [
+      makeArticle("solo", "f1", "Council debates zoning rules", 0),
+      makeArticle("wide", "f2", "Election results spark recount fight", 1),
+    ];
+    const members = new Map<string, Article[]>([
+      ["solo", [reps[0]]],
+      [
+        "wide",
+        [reps[1], makeArticle("wide2", "f3", "Election results spark recount fight", 1)],
+      ],
+    ]);
+    const stories = groupIntoStories(reps, members);
+    // Multi-outlet story leads despite the solo story being newer.
+    expect(stories[0].id).toBe("wide");
+    expect(stories[0].feedCount).toBe(2);
+  });
+
+  it("orders article ids within a story most-recent first", () => {
+    const rep = makeArticle("new", "f1", "Quake hits coastal city", 0);
+    const members = new Map<string, Article[]>([
+      ["new", [rep, makeArticle("old", "f2", "Quake hits coastal city", 3)]],
+    ]);
+    const stories = groupIntoStories([rep], members);
+    expect(stories[0].articleIds).toEqual(["new", "old"]);
+  });
+});

--- a/tests/e2e/signal.spec.ts
+++ b/tests/e2e/signal.spec.ts
@@ -21,7 +21,7 @@ test.describe("Signal — sidebar + locked state", () => {
   test("locked tile renders when the corpus is below the gate", async ({ feedPage: page }) => {
     await page.goto("/signal");
     // Default fresh app has zero articles; signal goes straight to locked.
-    await expect(page.getByText(/Signal needs noise to filter/i)).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(`0 / ${SIGNAL_CORPUS_GATE}`)).toBeVisible();
+    await expect(page.getByText(/more articles to unlock/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(`0 of ${SIGNAL_CORPUS_GATE} articles in your store`)).toBeVisible();
   });
 });

--- a/tests/pages/signal-page.test.tsx
+++ b/tests/pages/signal-page.test.tsx
@@ -9,7 +9,7 @@ import { useFeedStore } from "@/stores/feed-store.ts";
 import { useLicenseStore } from "@/stores/license-store.ts";
 import { isSelfHosted } from "@/core/features/self-hosted.ts";
 import { isPaidTierActive } from "@/core/features/paid-tier-active.ts";
-import { SIGNAL_CORPUS_GATE } from "@/core/signal/types.ts";
+import { SIGNAL_CORPUS_GATE, SIGNAL_REPORT_SCHEMA_VERSION } from "@/core/signal/types.ts";
 import type { Article, Feed } from "@/types/index.ts";
 
 vi.mock("@/core/features/self-hosted.ts", () => ({ isSelfHosted: vi.fn(() => false) }));
@@ -17,6 +17,23 @@ vi.mock("@/core/features/paid-tier-active.ts", () => ({ isPaidTierActive: vi.fn(
 
 const NOW = new Date("2026-05-21T12:00:00Z").getTime();
 const DAY = 24 * 60 * 60 * 1000;
+
+// 12 distinct OpenAI headlines — each becomes its own story (low mutual
+// title overlap), so the cluster has many stories to page through.
+const OPENAI_HEADLINES = [
+  "OpenAI ships a release",
+  "OpenAI hires a team",
+  "OpenAI cuts prices",
+  "OpenAI faces a lawsuit",
+  "OpenAI updates safety policy",
+  "OpenAI hosts a developer event",
+  "OpenAI buys a startup",
+  "OpenAI rolls back a feature",
+  "OpenAI funds a grant",
+  "OpenAI beats revenue forecast",
+  "OpenAI expands cloud capacity",
+  "OpenAI opens an office",
+];
 
 function makeFeed(id: string, title?: string): Feed {
   return {
@@ -47,6 +64,45 @@ function makeArticle(id: string, feedId: string, title: string, ageDays: number)
   };
 }
 
+/**
+ * A corpus with one OpenAI topic: 12 distinct stories, one of them
+ * syndicated verbatim across three outlets, plus entity-free noise so the
+ * total clears the gate.
+ */
+function seedReadyCorpus() {
+  const feeds: Feed[] = Array.from({ length: 4 }, (_, i) => makeFeed(`f${i + 1}`, `Outlet ${i + 1}`));
+  const articlesByFeedId: Record<string, Article[]> = { f1: [], f2: [], f3: [], f4: [] };
+  let id = 0;
+  OPENAI_HEADLINES.forEach((title, i) => {
+    const feedId = `f${(i % 4) + 1}`;
+    articlesByFeedId[feedId].push(makeArticle(`o-${id++}`, feedId, title, i % 4));
+  });
+  // Same story across three outlets → a multi-outlet story.
+  ["f1", "f2", "f3"].forEach((feedId) => {
+    articlesByFeedId[feedId].push(makeArticle(`s-${id++}`, feedId, "OpenAI launches atlas browser", 1));
+  });
+  // Entity-free noise (all lowercase, no proper nouns).
+  for (let i = 0; i < 95; i++) {
+    const feedId = `f${(i % 4) + 1}`;
+    articlesByFeedId[feedId].push(makeArticle(`n-${id++}`, feedId, `memo${i} note${i} item${i}`, i % 4));
+  }
+  useFeedStore.setState({ feeds });
+  useArticleStore.setState({ articlesByFeedId });
+}
+
+function mockViewport(isDesktop: boolean) {
+  window.matchMedia = ((query: string) => ({
+    matches: isDesktop && query.includes("1024"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
 function LocationProbe() {
   const location = useLocation();
   return (
@@ -75,17 +131,10 @@ describe("SignalPage", () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(NOW);
     localStorage.clear();
-    useSignalStore.setState({
-      status: "idle",
-      report: null,
-      corpusSize: 0,
-      error: null,
-    });
+    mockViewport(false); // mobile by default
+    useSignalStore.setState({ status: "idle", report: null, corpusSize: 0, error: null });
     useFeedStore.setState({ feeds: [] });
     useArticleStore.setState({ articlesByFeedId: {} });
-    // Default gate environment: paid tier dormant (so the gate is open
-    // for everyone) and not self-hosted. The tier-gate suite below flips
-    // these to exercise the locked path.
     useLicenseStore.setState({ tier: "free", verifying: false });
     vi.mocked(isSelfHosted).mockReturnValue(false);
     vi.mocked(isPaidTierActive).mockReturnValue(false);
@@ -106,11 +155,9 @@ describe("SignalPage", () => {
 
     renderAt();
     await waitFor(() => expect(useSignalStore.getState().status).toBe("locked"));
-    // Forward-looking framing: "53 more articles to unlock", not "47 / 100".
     expect(screen.getByText(/53/)).toBeInTheDocument();
     expect(screen.getByText(/more articles to unlock/i)).toBeInTheDocument();
     expect(screen.getByText(/47 of 100 articles in your store/i)).toBeInTheDocument();
-    // Three CTAs surfaced.
     expect(screen.getByRole("button", { name: /Add feeds/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Browse the catalog/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Import OPML/i })).toBeInTheDocument();
@@ -120,7 +167,7 @@ describe("SignalPage", () => {
     const feeds = [makeFeed("solo")];
     const articlesByFeedId: Record<string, Article[]> = { solo: [] };
     for (let i = 0; i < SIGNAL_CORPUS_GATE + 5; i++) {
-      articlesByFeedId.solo.push(makeArticle(`a-${i}`, "solo", `Unique title ${i}`, i % 5));
+      articlesByFeedId.solo.push(makeArticle(`a-${i}`, "solo", `unique title ${i}`, i % 5));
     }
     useFeedStore.setState({ feeds });
     useArticleStore.setState({ articlesByFeedId });
@@ -131,56 +178,57 @@ describe("SignalPage", () => {
     expect(screen.getByRole("button", { name: /Add more feeds/i })).toBeInTheDocument();
   });
 
-  it("renders topic headers and article rows when the engine produces topics", async () => {
-    const feeds: Feed[] = Array.from({ length: 4 }, (_, i) => makeFeed(`f${i + 1}`, `Outlet ${i + 1}`));
-    const articlesByFeedId: Record<string, Article[]> = {};
-    const variants = [
-      "OpenAI ships GPT release",
-      "OpenAI hires research team",
-      "OpenAI partners Microsoft",
-      "OpenAI cuts API prices",
-      "OpenAI opens Tokyo office",
-      "OpenAI updates safety policy",
-      "OpenAI hosts developer event",
-      "OpenAI launches Atlas browser",
-    ];
-    let id = 0;
-    for (let i = 0; i < SIGNAL_CORPUS_GATE + 20; i++) {
-      const feedId = `f${(i % 4) + 1}`;
-      const title =
-        i % 5 === 0 ? variants[i % variants.length] : `Unique${i} subject${i} item${i}`;
-      if (!articlesByFeedId[feedId]) articlesByFeedId[feedId] = [];
-      articlesByFeedId[feedId].push(makeArticle(`a-${id++}`, feedId, title, i % 5));
-    }
-    useFeedStore.setState({ feeds });
-    useArticleStore.setState({ articlesByFeedId });
-
+  it("renders an entity topic heading, story rows, and the window label", async () => {
+    seedReadyCorpus();
     renderAt();
     await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
 
-    // Topic title renders as a real heading in original casing — no chip.
     expect(screen.getByRole("heading", { level: 2, name: "OpenAI" })).toBeInTheDocument();
-    // At least one article row from the openai variants is shown.
-    expect(screen.getByText(/OpenAI ships GPT release/)).toBeInTheDocument();
-    // Meta line in the topic header reads "N articles · M outlets"
+    expect(screen.getByText("OpenAI ships a release")).toBeInTheDocument();
     expect(screen.getByText(/articles\s*·\s*\d+\s*outlets/i)).toBeInTheDocument();
-    // Header meta line includes the window label.
     expect(screen.getByText(/last 7 days/i)).toBeInTheDocument();
   });
 
-  it("Refresh button bypasses the cache", async () => {
-    const feeds: Feed[] = Array.from({ length: 4 }, (_, i) => makeFeed(`f${i + 1}`));
-    const articlesByFeedId: Record<string, Article[]> = {};
-    for (let i = 0; i < SIGNAL_CORPUS_GATE + 20; i++) {
-      const feedId = `f${(i % 4) + 1}`;
-      if (!articlesByFeedId[feedId]) articlesByFeedId[feedId] = [];
-      articlesByFeedId[feedId].push(
-        makeArticle(`a-${i}`, feedId, `OpenAI Atlas note ${i}`, i % 5),
-      );
-    }
-    useFeedStore.setState({ feeds });
-    useArticleStore.setState({ articlesByFeedId });
+  it("badges a story covered by multiple outlets and expands to list them", async () => {
+    seedReadyCorpus();
+    renderAt();
+    await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
 
+    expect(screen.getByText(/covered by 3 outlets/i)).toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /show all 3 outlets/i }));
+    // Each outlet's name appears in the expanded list.
+    expect(screen.getByText("Outlet 1")).toBeInTheDocument();
+    expect(screen.getByText("Outlet 2")).toBeInTheDocument();
+    expect(screen.getByText("Outlet 3")).toBeInTheDocument();
+  });
+
+  it("on desktop, clicking a story opens the reader directly", async () => {
+    mockViewport(true);
+    seedReadyCorpus();
+    renderAt();
+    await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("OpenAI ships a release"));
+    await waitFor(() => expect(screen.getByText("READER")).toBeInTheDocument());
+  });
+
+  it("on mobile, tapping a story opens a preview then 'Open in reader' navigates", async () => {
+    mockViewport(false);
+    seedReadyCorpus();
+    renderAt();
+    await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("OpenAI ships a release"));
+    const open = await screen.findByRole("button", { name: /open in reader/i });
+    await user.click(open);
+    await waitFor(() => expect(screen.getByText("READER")).toBeInTheDocument());
+  });
+
+  it("Refresh button bypasses the cache", async () => {
+    seedReadyCorpus();
     renderAt();
     await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
     const first = useSignalStore.getState().report?.generatedAt;
@@ -191,98 +239,42 @@ describe("SignalPage", () => {
     await waitFor(() => expect(useSignalStore.getState().report?.generatedAt).not.toBe(first));
   });
 
-  it("clicking an article navigates to its reader route", async () => {
-    const feeds: Feed[] = Array.from({ length: 4 }, (_, i) => makeFeed(`f${i + 1}`));
-    const articlesByFeedId: Record<string, Article[]> = { f1: [], f2: [], f3: [], f4: [] };
-    let id = 0;
-    // 30 OpenAI articles spread across all 4 feeds.
-    for (let i = 0; i < 30; i++) {
-      const feedId = `f${(i % 4) + 1}`;
-      articlesByFeedId[feedId].push(
-        makeArticle(`o-${id++}`, feedId, `OpenAI Atlas update ${i}`, i % 5),
-      );
-    }
-    // 90 unique-noise articles so total >= gate.
-    for (let i = 0; i < 90; i++) {
-      const feedId = `f${(i % 4) + 1}`;
-      articlesByFeedId[feedId].push(
-        makeArticle(`n-${id++}`, feedId, `Unique${i} item${i}`, i % 5),
-      );
-    }
-    useFeedStore.setState({ feeds });
-    useArticleStore.setState({ articlesByFeedId });
-
-    renderAt();
-    await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
-    const link = screen.getAllByText(/OpenAI Atlas update/)[0];
-    const user = userEvent.setup();
-    await user.click(link);
-    await waitFor(() => expect(screen.getByText("READER")).toBeInTheDocument());
-  });
-
-  it("reveals additional articles when '+ N more' is clicked", async () => {
-    const feeds: Feed[] = Array.from({ length: 4 }, (_, i) => makeFeed(`f${i + 1}`));
-    const articlesByFeedId: Record<string, Article[]> = { f1: [], f2: [], f3: [], f4: [] };
-    // 14 OpenAI articles spread across 4 feeds — the cluster will claim
-    // them all (cap ≈ ceil((14+90)/10)+5 = 16), exposing > 6 in articleIds.
-    for (let i = 0; i < 14; i++) {
-      const feedId = `f${(i % 4) + 1}`;
-      articlesByFeedId[feedId].push(
-        makeArticle(`o-${i}`, feedId, `OpenAI Atlas update ${i}`, i % 5),
-      );
-    }
-    for (let i = 0; i < 90; i++) {
-      const feedId = `f${(i % 4) + 1}`;
-      articlesByFeedId[feedId].push(
-        makeArticle(`n-${i}`, feedId, `Unique${i} item${i}`, i % 5),
-      );
-    }
-    useFeedStore.setState({ feeds });
-    useArticleStore.setState({ articlesByFeedId });
-
+  it("reveals additional stories when '+ N more' is clicked", async () => {
+    seedReadyCorpus();
     renderAt();
     await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
 
-    // Default: 6 OpenAI rows visible.
-    const initialRows = screen.getAllByText(/OpenAI Atlas update/);
-    expect(initialRows.length).toBe(6);
-    // "+ 8 more" affordance for the remaining articles in the cluster.
+    // Default shows the first 6 story heads (each headline starts "OpenAI ...").
+    const headRegex = /OpenAI\s+\S/;
+    expect(screen.getAllByText(headRegex).length).toBe(6);
     const moreButton = screen.getByRole("button", { name: /\+ \d+ more/i });
     const user = userEvent.setup();
     await user.click(moreButton);
-    const expandedRows = screen.getAllByText(/OpenAI Atlas update/);
-    expect(expandedRows.length).toBe(14);
+    // 12 distinct + 1 syndicated = 13 stories in the cluster.
+    expect(screen.getAllByText(headRegex).length).toBe(13);
   });
 
   it("loads from localStorage on mount without recomputing when the cache is fresh", async () => {
-    const feeds: Feed[] = Array.from({ length: 4 }, (_, i) => makeFeed(`f${i + 1}`));
-    const articlesByFeedId: Record<string, Article[]> = {};
-    for (let i = 0; i < SIGNAL_CORPUS_GATE + 20; i++) {
-      const feedId = `f${(i % 4) + 1}`;
-      if (!articlesByFeedId[feedId]) articlesByFeedId[feedId] = [];
-      articlesByFeedId[feedId].push(
-        makeArticle(`a-${i}`, feedId, `OpenAI Atlas note ${i}`, i % 5),
-      );
-    }
-    useFeedStore.setState({ feeds });
-    useArticleStore.setState({ articlesByFeedId });
-
-    // Prime the cache directly.
+    seedReadyCorpus();
     localStorage.setItem(
       SIGNAL_REPORT_CACHE_KEY,
       JSON.stringify({
         report: {
+          schemaVersion: SIGNAL_REPORT_SCHEMA_VERSION,
           topics: [
             {
               term: "primed",
               displayTerm: "Primed",
-              articleIds: [],
+              stories: [],
+              totalStories: 0,
               totalArticlesInCluster: 0,
               feedCount: 2,
             },
           ],
           window: "7d",
-          corpusSize: SIGNAL_CORPUS_GATE + 20,
+          corpusSize: useArticleStore.getState().articlesByFeedId
+            ? Object.values(useArticleStore.getState().articlesByFeedId).reduce((n, l) => n + l.length, 0)
+            : 0,
           corpusInWindow: SIGNAL_CORPUS_GATE,
           feedsInWindow: 4,
           generatedAt: NOW - 60 * 1000,
@@ -295,40 +287,45 @@ describe("SignalPage", () => {
     expect(useSignalStore.getState().report?.topics[0]?.term).toBe("primed");
   });
 
-  describe("tier gating", () => {
-    function seedUnlockedCorpus() {
-      const feeds: Feed[] = Array.from({ length: 4 }, (_, i) => makeFeed(`f${i + 1}`));
-      const articlesByFeedId: Record<string, Article[]> = {};
-      for (let i = 0; i < SIGNAL_CORPUS_GATE + 20; i++) {
-        const feedId = `f${(i % 4) + 1}`;
-        if (!articlesByFeedId[feedId]) articlesByFeedId[feedId] = [];
-        articlesByFeedId[feedId].push(
-          makeArticle(`a-${i}`, feedId, `OpenAI Atlas note ${i}`, i % 5),
-        );
-      }
-      useFeedStore.setState({ feeds });
-      useArticleStore.setState({ articlesByFeedId });
-    }
+  it("discards a cached report written by an incompatible schema version", async () => {
+    seedReadyCorpus();
+    localStorage.setItem(
+      SIGNAL_REPORT_CACHE_KEY,
+      JSON.stringify({
+        report: {
+          schemaVersion: SIGNAL_REPORT_SCHEMA_VERSION - 1,
+          topics: [{ term: "stale", displayTerm: "Stale", stories: [], totalStories: 0, totalArticlesInCluster: 0, feedCount: 2 }],
+          window: "7d",
+          corpusSize: 120,
+          corpusInWindow: 120,
+          feedsInWindow: 4,
+          generatedAt: NOW - 60 * 1000,
+        },
+      }),
+    );
 
+    renderAt();
+    await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
+    // The stale topic must NOT be served; a fresh report replaces it.
+    expect(useSignalStore.getState().report?.topics[0]?.term).not.toBe("stale");
+  });
+
+  describe("tier gating", () => {
     it("shows the upgrade prompt for a Free user once the paid tier is live", async () => {
       vi.mocked(isPaidTierActive).mockReturnValue(true);
       useLicenseStore.setState({ tier: "free" });
-      seedUnlockedCorpus();
+      seedReadyCorpus();
 
       renderAt();
-      // Gate short-circuits before any report computation.
-      await waitFor(() =>
-        expect(screen.getByText(/Unlock Signal/i)).toBeInTheDocument(),
-      );
+      await waitFor(() => expect(screen.getByText(/Unlock Signal/i)).toBeInTheDocument());
       expect(screen.getByRole("button", { name: /Upgrade to Personal/i })).toBeInTheDocument();
-      // The report UI must NOT render.
-      expect(screen.queryByText(/OpenAI Atlas note/)).not.toBeInTheDocument();
+      expect(screen.queryByText("OpenAI ships a release")).not.toBeInTheDocument();
     });
 
     it("does NOT gate a Personal user — the report renders", async () => {
       vi.mocked(isPaidTierActive).mockReturnValue(true);
       useLicenseStore.setState({ tier: "personal" });
-      seedUnlockedCorpus();
+      seedReadyCorpus();
 
       renderAt();
       await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
@@ -339,17 +336,7 @@ describe("SignalPage", () => {
       vi.mocked(isPaidTierActive).mockReturnValue(true);
       vi.mocked(isSelfHosted).mockReturnValue(true);
       useLicenseStore.setState({ tier: "free" });
-      seedUnlockedCorpus();
-
-      renderAt();
-      await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
-      expect(screen.queryByText(/Unlock Signal/i)).not.toBeInTheDocument();
-    });
-
-    it("does NOT gate when the paid tier is dormant (pre-launch)", async () => {
-      vi.mocked(isPaidTierActive).mockReturnValue(false);
-      useLicenseStore.setState({ tier: "free" });
-      seedUnlockedCorpus();
+      seedReadyCorpus();
 
       renderAt();
       await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
@@ -359,7 +346,7 @@ describe("SignalPage", () => {
     it("Upgrade button routes to the subscription settings tab", async () => {
       vi.mocked(isPaidTierActive).mockReturnValue(true);
       useLicenseStore.setState({ tier: "free" });
-      seedUnlockedCorpus();
+      seedReadyCorpus();
 
       renderAt();
       await waitFor(() =>


### PR DESCRIPTION
Reworks the Signal surface around three improvements:

1. Entity-only clustering. Topics now anchor strictly on proper nouns and
   compound nouns ("OpenAI", "Iran War"), never bare common nouns. Detection
   is corpus-wide capitalization consensus (no ML): src/core/signal/entities.ts
   builds a proper-noun lexicon (capitalized in ≥70% of non-initial
   occurrences, or only ever capitalized) excluding Title-Cased headlines from
   the casing tally, then extracts confirmed proper nouns and contiguous
   capitalized runs as cluster keys. A phrase boost makes a compound outrank
   its constituent so the bleed-over guard drops the fragmented unigram.

2. Same-story-across-feeds. The engine no longer discards syndicated copies;
   groupExactDuplicates keeps a representative plus its members, and
   src/core/signal/stories.ts merges similar headlines within a topic into a
   story badged "Covered by N outlets". Scoring still runs on representatives
   so syndication volume doesn't distort cluster strength.

3. Preview-then-read. Each story row peeks on hover (desktop HoverCard) or tap
   (mobile Sheet) via a shared ArticlePreview before opening the full item in
   the reader; navigation carries state.from so back returns to /signal.

Report shape changes (Topic.stories, schemaVersion); the store discards
caches written under an older schema version.

Key files: src/core/signal/{entities,stories,frequency-engine,types,tokenize}.ts,
src/stores/signal-store.ts, src/pages/signal-page.tsx,
src/components/signal/{story-row,article-preview}.tsx,
src/components/ui/hover-card.tsx, plus their tests.