### PR TITLE
feat(mobile): quick-switch favicon dock in the closed bottom drawer

### DIFF
--- a/docs/features/010-mobile-navigation.md
+++ b/docs/features/010-mobile-navigation.md
@@ -54,6 +54,25 @@ Feature: Mobile navigation
     When viewing /feeds/:feedId/articles/:articleId
     Then the sidebar, article list, and reader are all visible
     And resizable panel handles allow layout adjustment
+
+  Rule: The closed bottom drawer is a quick-switch favicon dock
+
+  Scenario: Closed drawer surfaces recent feeds instead of the current feed name
+    Given the user is on mobile with the bottom drawer closed
+    Then the strip shows an anchored "All items" button
+    And the favicons of the most-recently-viewed feeds, newest first
+    And it does not repeat the current feed name (the header already shows it)
+
+  Scenario: Tapping a dock favicon switches feed without opening the drawer
+    Given the closed drawer dock shows a feed's favicon
+    When the user taps that favicon
+    Then the app navigates to that feed
+    And the drawer stays closed
+
+  Scenario: Overflow lives behind the full list
+    Given the user has more feeds than fit the dock cap
+    Then only the most-recently-viewed feeds (up to MOBILE_DOCK_FEED_CAP) show
+    And the chevron opens the full feed list for the rest
 ```
 
 ## Architecture
@@ -72,6 +91,9 @@ Feature: Mobile navigation
 |------|------|
 | `src/pages/feeds-page.tsx` | Main page component with mobile/desktop layout switching, Back button handler, and auto-select suppression logic |
 | `src/hooks/use-media-query.ts` | `useIsDesktop()` hook for responsive breakpoint detection |
+| `src/components/layout/mobile-nav-drawer.tsx` | Bottom drawer. Closed state = quick-switch favicon dock; open state = full feed list + Refresh/Settings footer |
+| `src/lib/recent-feeds.ts` | Pure `orderFeedsByRecency()` / `recordRecentFeed()` helpers + `MOBILE_DOCK_FEED_CAP` |
+| `src/stores/feed-store.ts` | Tracks `recentFeedIds` (device-local, persisted) — recorded in `selectFeed`, pruned in `removeFeed` |
 
 ### Tests
 
@@ -79,6 +101,9 @@ Feature: Mobile navigation
 |------|----------|
 | `tests/pages/feeds-page-behavior.test.tsx` | Back button navigation, auto-select suppression, URL state |
 | `tests/components/layout/feeds-page-layout.test.tsx` | Mobile vs desktop layout structure, Back button visibility |
+| `tests/components/layout/mobile-nav-drawer.test.tsx` | Closed-state quick-switch dock, open-state feed list/footer |
+| `tests/lib/recent-feeds.test.ts` | Recency ordering, cap, dedupe |
+| `tests/stores/feed-store.test.ts` | `selectFeed` records recency; `removeFeed` prunes it |
 
 ## Design Decisions
 
@@ -87,6 +112,8 @@ Feature: Mobile navigation
 - **Stack-based navigation** — Mobile navigation follows the standard iOS/Android pattern: Article → Article List → Feed List. This matches user mental models for drill-down interfaces.
 
 - **Auto-select only on feed switch** — Auto-selecting the first article when switching feeds improves UX by showing content immediately. But auto-select is suppressed after Back navigation because the user explicitly wanted to see the article list (to pick a different article).
+
+- **Closed drawer is a dock, not a label** — The closed strip previously showed the selected feed's name next to a generic icon, duplicating the header. Since the drawer's job is cross-feed navigation, the closed state now previews *where you can go* — an anchored "All items" plus your most-recently-viewed feed favicons — rather than echoing *where you are*. Recency (`recentFeedIds`) is device-local and never syncs: it's a per-device interaction trail, and metering it server-side would contradict the privacy principles.
 
 ## Limitations
 

--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -3,13 +3,9 @@ import { useNavigate } from "react-router";
 import { ChevronUp, Layers, RefreshCw, Settings } from "lucide-react";
 import { Drawer } from "vaul";
 import { useFeedStore } from "@/stores/feed-store.ts";
-import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
-import {
-  ALL_FEEDS_ID,
-  STARRED_FEED_ID,
-  isFilterFeedId,
-  fromFilterFeedId,
-} from "@/utils/constants.ts";
+import { ALL_FEEDS_ID } from "@/utils/constants.ts";
+import { orderFeedsByRecency, MOBILE_DOCK_FEED_CAP } from "@/lib/recent-feeds.ts";
+import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
 import { SidebarMenu, SidebarProvider } from "@/components/ui/sidebar.tsx";
 import { SidebarBody } from "@/components/layout/sidebar-body.tsx";
 import { NewFolderInput } from "@/components/sidebar/new-folder-input.tsx";
@@ -46,23 +42,16 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
     goToSettings(navigate);
   }
 
-  const smartFilters = useSmartFilterStore((s) => s.filters);
-  const activeFeed = feeds.find((f) => f.id === selectedFeedId);
-  const activeFilterId =
-    selectedFeedId && isFilterFeedId(selectedFeedId)
-      ? fromFilterFeedId(selectedFeedId)
-      : null;
-  const activeFilter = activeFilterId
-    ? smartFilters.find((f) => f.id === activeFilterId)
-    : null;
-  const handleLabel =
-    selectedFeedId === ALL_FEEDS_ID
-      ? "All items"
-      : selectedFeedId === STARRED_FEED_ID
-        ? "Starred"
-        : activeFilter
-          ? activeFilter.name
-          : activeFeed?.title ?? "Feeds";
+  const recentFeedIds = useFeedStore((s) => s.recentFeedIds);
+  // The closed strip is a quick-switch dock, not a status line: showing the
+  // current feed name here just echoed the header. Instead, surface the
+  // feeds the user actually hops between — All-items plus their most
+  // recently viewed feeds, capped so the open-list chevron stays reachable.
+  const dockFeeds = orderFeedsByRecency(feeds, recentFeedIds).slice(
+    0,
+    MOBILE_DOCK_FEED_CAP,
+  );
+  const allActive = selectedFeedId === ALL_FEEDS_ID;
 
   return (
     // No `snapPoints` here: with a single snap point and an inline height,
@@ -73,23 +62,63 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
     // mode keeps vaul's standard "scroll until top, then drag to dismiss"
     // pattern, which is exactly what we want.
     <Drawer.Root open={open} onOpenChange={setOpen}>
-      <Drawer.Trigger asChild>
-        <div
-          data-testid="drawer-handle-strip"
-          role="button"
-          tabIndex={0}
-          aria-label="Open feed list"
-          className="flex items-center gap-2 px-4 h-[60px] shrink-0 border-t bg-background cursor-pointer"
-          onKeyDown={(e) => e.key === "Enter" && setOpen(true)}
-        >
-          <div className="absolute left-1/2 -translate-x-1/2 top-1.5 w-10 h-1 rounded-full bg-muted-foreground/30" />
-          <Layers className="size-4 shrink-0 text-muted-foreground" />
-          <span className="flex-1 text-sm font-medium truncate">{handleLabel}</span>
-          <ChevronUp
-            className={`size-4 shrink-0 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`}
-          />
+      <div
+        data-testid="drawer-handle-strip"
+        className="relative flex items-center gap-1 px-2 h-[60px] shrink-0 border-t bg-background"
+      >
+        <div className="absolute left-1/2 -translate-x-1/2 top-1.5 w-10 h-1 rounded-full bg-muted-foreground/30" />
+
+        {/* Quick-switch dock: All-items + most-recently-viewed feed
+            favicons. Tapping switches feeds directly (the drawer is
+            already closed); the chevron opens the full list. */}
+        <div className="flex items-center gap-1 min-w-0 flex-1 overflow-hidden">
+          <button
+            type="button"
+            aria-label="All items"
+            aria-pressed={allActive}
+            onClick={() => onFeedSelect(ALL_FEEDS_ID)}
+            className={`flex items-center justify-center size-10 shrink-0 rounded-md ${
+              allActive
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:bg-accent/50"
+            }`}
+          >
+            <Layers className="size-5" />
+          </button>
+          {dockFeeds.map((feed) => {
+            const active = feed.id === selectedFeedId;
+            return (
+              <button
+                key={feed.id}
+                type="button"
+                aria-label={feed.title}
+                aria-pressed={active}
+                onClick={() => onFeedSelect(feed.id)}
+                className={`flex items-center justify-center size-10 shrink-0 rounded-md hover:bg-accent/50 ${
+                  active
+                    ? "ring-2 ring-primary ring-offset-1 ring-offset-background"
+                    : ""
+                }`}
+              >
+                <FeedFavicon siteUrl={feed.siteUrl} className="size-6" />
+              </button>
+            );
+          })}
         </div>
-      </Drawer.Trigger>
+
+        <Drawer.Trigger asChild>
+          <button
+            type="button"
+            aria-label="Open feed list"
+            className="flex items-center justify-center size-10 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
+          >
+            <ChevronUp
+              data-testid="drawer-open-chevron"
+              className={`size-5 transition-transform ${open ? "rotate-180" : ""}`}
+            />
+          </button>
+        </Drawer.Trigger>
+      </div>
 
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 bg-black/40 z-40" />

--- a/src/lib/recent-feeds.ts
+++ b/src/lib/recent-feeds.ts
@@ -1,0 +1,47 @@
+import type { Feed } from "@/types/index.ts";
+
+/**
+ * Max favicons rendered in the closed mobile-drawer quick-switch dock.
+ * Feeds past this count live behind the "open full list" chevron — the
+ * strip is only 60px tall and a fixed cap keeps the open-list trigger
+ * reachable on the narrowest phones.
+ */
+export const MOBILE_DOCK_FEED_CAP = 6;
+
+/** Upper bound on the persisted recency list. */
+export const RECENT_LIST_CAP = 20;
+
+/**
+ * Return the recency list with `feedId` promoted to most-recent (front),
+ * deduplicated, and capped. Pure — the store owns persistence.
+ */
+export function recordRecentFeed(recent: string[], feedId: string): string[] {
+  return [feedId, ...recent.filter((id) => id !== feedId)].slice(0, RECENT_LIST_CAP);
+}
+
+/**
+ * Order `feeds` most-recently-viewed first. Feeds present in `recentIds`
+ * lead, in recency order; feeds never viewed follow in their incoming
+ * order. Recency ids with no matching feed (deleted since last view) are
+ * dropped.
+ */
+export function orderFeedsByRecency(feeds: Feed[], recentIds: string[]): Feed[] {
+  const byId = new Map(feeds.map((f) => [f.id, f]));
+  const seen = new Set<string>();
+  const ordered: Feed[] = [];
+
+  for (const id of recentIds) {
+    const feed = byId.get(id);
+    if (feed && !seen.has(id)) {
+      ordered.push(feed);
+      seen.add(id);
+    }
+  }
+  for (const feed of feeds) {
+    if (!seen.has(feed.id)) {
+      ordered.push(feed);
+      seen.add(feed.id);
+    }
+  }
+  return ordered;
+}

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -31,8 +31,9 @@ import { retryFailedFavicons } from "../core/favicon/favicon-cache.ts";
 import { isPaidTierActive } from "../core/features/paid-tier-active.ts";
 import { checkFeedQuota, quotaErrorMessage } from "../core/features/quotas.ts";
 import { isFeatureEnabled, enforceFeature } from "./enforce-feature.ts";
-import { CHANGELOG_FEED_URL, LOCAL_STORAGE } from "../utils/constants.ts";
+import { CHANGELOG_FEED_URL, LOCAL_STORAGE, isAggregatedFeedId } from "../utils/constants.ts";
 import { pickNextFolderColor } from "../lib/folder-colors.ts";
+import { recordRecentFeed } from "../lib/recent-feeds.ts";
 import type {
   Feed,
   Folder,
@@ -91,6 +92,13 @@ interface FeedStore {
   feedSortMode: FeedSortMode;
   feedCustomOrder: string[];
   folderCustomOrder: string[];
+  /**
+   * Concrete feed ids in most-recently-viewed order, newest first.
+   * Device-local (recency never syncs); drives the mobile drawer's
+   * quick-switch favicon dock. Aggregated views (All / Starred / folder /
+   * smart-filter) are never recorded — they have no favicon.
+   */
+  recentFeedIds: string[];
   /** True once loadFeeds() has resolved at least once. Used by the
    *  /feeds → /explore-vs-/feeds/all routing decision to avoid firing
    *  with an empty store before the DB is read. */
@@ -185,6 +193,12 @@ function readJsonArray(key: string): string[] {
 
 function sortFoldersByName(folders: Folder[]): Folder[] {
   return [...folders].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function persistRecentFeedIds(ids: string[]): void {
+  try {
+    localStorage.setItem(LOCAL_STORAGE.RECENT_FEED_IDS, JSON.stringify(ids));
+  } catch { /* localStorage unavailable */ }
 }
 
 /** True when the current session may mutate per-feed rules. */
@@ -348,6 +362,7 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
   feedSortMode: readSortMode(),
   feedCustomOrder: readJsonArray(LOCAL_STORAGE.FEED_CUSTOM_ORDER),
   folderCustomOrder: readJsonArray(LOCAL_STORAGE.FOLDER_CUSTOM_ORDER),
+  recentFeedIds: readJsonArray(LOCAL_STORAGE.RECENT_FEED_IDS),
   folderOpenState: {},
   feedsLoaded: false,
   rulesEditorFeedId: null,
@@ -435,6 +450,11 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
     await reloadFeeds(set);
     const currentSelection = get().selectedFeedId;
     if (currentSelection === feedId) set({ selectedFeedId: null });
+    const recent = get().recentFeedIds.filter((id) => id !== feedId);
+    if (recent.length !== get().recentFeedIds.length) {
+      persistRecentFeedIds(recent);
+      set({ recentFeedIds: recent });
+    }
     schedulePush();
   },
 
@@ -473,7 +493,17 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
     if (value) void prefetchSingleFeedNow(feedId);
   },
 
-  selectFeed: (feedId) => set({ selectedFeedId: feedId }),
+  selectFeed: (feedId) => {
+    set({ selectedFeedId: feedId });
+    // Record concrete feeds for the quick-switch dock; aggregated views
+    // have no favicon to dock. selectFeed is the single chokepoint the
+    // URL-sync effect routes every feed view through, so this captures
+    // recency without a separate tracking call site.
+    if (isAggregatedFeedId(feedId)) return;
+    const recent = recordRecentFeed(get().recentFeedIds, feedId);
+    persistRecentFeedIds(recent);
+    set({ recentFeedIds: recent });
+  },
 
   refreshAll: async () => {
     if (get().isRefreshingAll) return;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -125,6 +125,10 @@ export const LOCAL_STORAGE = {
   GROUP_ARTICLE_FLOODS: "feedzero:group-article-floods",
   ARTICLE_SORT_MODE: "feedzero:article-sort-mode",
   DEDUPE_MIGRATION: "feedzero:dedupe-migration-v1",
+  /** Most-recently-viewed feed ids, newest first. Device-local (recency
+   *  is per-device and never syncs); drives the mobile drawer quick-switch
+   *  dock. */
+  RECENT_FEED_IDS: "feedzero:recent-feed-ids",
 } as const;
 
 /**

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Routes, Route, useLocation } from "react-router";
 import { MobileNavDrawer } from "@/components/layout/mobile-nav-drawer.tsx";
@@ -60,6 +60,7 @@ describe("MobileNavDrawer", () => {
     useFeedStore.setState({
       feeds: [],
       selectedFeedId: null,
+      recentFeedIds: [],
       isLoading: false,
       error: null,
       isRefreshingAll: false,
@@ -76,6 +77,100 @@ describe("MobileNavDrawer", () => {
   it("renders a handle strip that is always present in the DOM", () => {
     const { container } = renderDrawer();
     expect(container.ownerDocument.querySelector("[data-testid='drawer-handle-strip']")).not.toBeNull();
+  });
+
+  describe("closed-state quick-switch dock", () => {
+    it("shows the selected feed's favicons in the closed strip (no drawer open needed)", () => {
+      useFeedStore.setState({
+        feeds: [makeFeed("f1", "Hacker News"), makeFeed("f2", "The Verge")],
+        recentFeedIds: ["f1", "f2"],
+      });
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+      // Favicon buttons are labelled by feed title and present while closed.
+      expect(within(strip).getByRole("button", { name: "Hacker News" })).toBeInTheDocument();
+      expect(within(strip).getByRole("button", { name: "The Verge" })).toBeInTheDocument();
+    });
+
+    it("anchors an All-items quick button in the closed strip", () => {
+      useFeedStore.setState({ feeds: [makeFeed("f1", "Hacker News")] });
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+      expect(within(strip).getByRole("button", { name: "All items" })).toBeInTheDocument();
+    });
+
+    it("switches feed when a dock favicon is tapped, without opening the drawer", async () => {
+      const user = userEvent.setup();
+      const onFeedSelect = vi.fn();
+      useFeedStore.setState({ feeds: [makeFeed("f1", "Hacker News")], recentFeedIds: ["f1"] });
+      renderDrawer({ onFeedSelect });
+
+      const strip = screen.getByTestId("drawer-handle-strip");
+      await user.click(within(strip).getByRole("button", { name: "Hacker News" }));
+
+      expect(onFeedSelect).toHaveBeenCalledWith("f1");
+      // Drawer stays closed: the open-chevron must not be rotated.
+      expect(screen.getByTestId("drawer-open-chevron").className).not.toContain("rotate-180");
+    });
+
+    it("switches to All items when the anchored dock button is tapped", async () => {
+      const user = userEvent.setup();
+      const onFeedSelect = vi.fn();
+      useFeedStore.setState({ feeds: [makeFeed("f1", "Hacker News")] });
+      renderDrawer({ onFeedSelect });
+
+      const strip = screen.getByTestId("drawer-handle-strip");
+      await user.click(within(strip).getByRole("button", { name: "All items" }));
+
+      expect(onFeedSelect).toHaveBeenCalledWith("all");
+    });
+
+    it("orders dock favicons most-recently-viewed first", () => {
+      useFeedStore.setState({
+        feeds: [makeFeed("f1", "Alpha"), makeFeed("f2", "Bravo"), makeFeed("f3", "Charlie")],
+        recentFeedIds: ["f3", "f1"],
+      });
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+      const labels = within(strip)
+        .getAllByRole("button")
+        .map((b) => b.getAttribute("aria-label"));
+      // After the anchored "All items", recency order wins: f3, f1, then the
+      // never-viewed f2; the open-list chevron trails.
+      expect(labels).toEqual([
+        "All items",
+        "Charlie",
+        "Alpha",
+        "Bravo",
+        "Open feed list",
+      ]);
+    });
+
+    it("caps the number of dock favicons and leaves the rest behind the full list", () => {
+      useFeedStore.setState({
+        feeds: Array.from({ length: 20 }, (_, i) => makeFeed(`f${i}`, `Feed ${i}`)),
+      });
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+      const faviconButtons = within(strip)
+        .getAllByRole("button")
+        .filter((b) => /^Feed \d+$/.test(b.getAttribute("aria-label") ?? ""));
+      expect(faviconButtons.length).toBeLessThanOrEqual(6);
+      expect(faviconButtons.length).toBeGreaterThan(0);
+    });
+
+    it("marks the active feed's dock button as pressed", () => {
+      useFeedStore.setState({
+        feeds: [makeFeed("f1", "Hacker News")],
+        recentFeedIds: ["f1"],
+        selectedFeedId: "f1",
+      });
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+      expect(
+        within(strip).getByRole("button", { name: "Hacker News" }),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
   });
 
   it("renders 'All items' entry when drawer is open and there are feeds", async () => {
@@ -337,7 +432,7 @@ describe("MobileNavDrawer", () => {
 
     async function getDrawerScroll(): Promise<HTMLElement> {
       const { container } = renderDrawer();
-      await userEvent.click(screen.getByTestId("drawer-handle-strip"));
+      await userEvent.click(screen.getByRole("button", { name: "Open feed list" }));
       const scroll = await waitFor(() => {
         const s = container.ownerDocument.querySelector(
           "[data-testid='drawer-scroll']",
@@ -386,7 +481,7 @@ describe("MobileNavDrawer", () => {
     const doc = container.ownerDocument;
 
     // Starts collapsed — chevron points up (no rotate-180)
-    const chevronBefore = doc.querySelector("[data-testid='drawer-handle-strip'] svg:last-child");
+    const chevronBefore = doc.querySelector("[data-testid='drawer-open-chevron']");
     expect(chevronBefore?.getAttribute("class")).not.toContain("rotate-180");
 
     // Dispatch the toggle event
@@ -394,7 +489,7 @@ describe("MobileNavDrawer", () => {
 
     // Drawer should now be open — chevron rotates 180°
     await waitFor(() => {
-      const chevron = doc.querySelector("[data-testid='drawer-handle-strip'] svg:last-child");
+      const chevron = doc.querySelector("[data-testid='drawer-open-chevron']");
       expect(chevron?.getAttribute("class")).toContain("rotate-180");
     });
   });

--- a/tests/lib/recent-feeds.test.ts
+++ b/tests/lib/recent-feeds.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  recordRecentFeed,
+  orderFeedsByRecency,
+  MOBILE_DOCK_FEED_CAP,
+  RECENT_LIST_CAP,
+} from "../../src/lib/recent-feeds.ts";
+import type { Feed } from "../../src/types/index.ts";
+
+const feed = (id: string): Feed => ({
+  id,
+  url: `https://${id}.com/feed`,
+  title: id.toUpperCase(),
+  description: "",
+  siteUrl: `https://${id}.com`,
+  createdAt: 0,
+  updatedAt: 0,
+});
+
+describe("recordRecentFeed", () => {
+  it("prepends a newly viewed feed as most-recent", () => {
+    expect(recordRecentFeed(["a", "b"], "c")).toEqual(["c", "a", "b"]);
+  });
+
+  it("moves an already-seen feed to the front without duplicating it", () => {
+    expect(recordRecentFeed(["a", "b", "c"], "c")).toEqual(["c", "a", "b"]);
+  });
+
+  it("is a no-op on order when the feed is already most-recent", () => {
+    expect(recordRecentFeed(["a", "b"], "a")).toEqual(["a", "b"]);
+  });
+
+  it("caps the persisted list length", () => {
+    const long = Array.from({ length: RECENT_LIST_CAP + 5 }, (_, i) => `f${i}`);
+    const result = recordRecentFeed(long, "new");
+    expect(result).toHaveLength(RECENT_LIST_CAP);
+    expect(result[0]).toBe("new");
+  });
+});
+
+describe("orderFeedsByRecency", () => {
+  it("orders feeds most-recently-viewed first", () => {
+    const feeds = [feed("a"), feed("b"), feed("c")];
+    const ordered = orderFeedsByRecency(feeds, ["c", "a"]);
+    expect(ordered.map((f) => f.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("appends never-viewed feeds in their incoming order after recent ones", () => {
+    const feeds = [feed("a"), feed("b"), feed("c"), feed("d")];
+    const ordered = orderFeedsByRecency(feeds, ["d"]);
+    expect(ordered.map((f) => f.id)).toEqual(["d", "a", "b", "c"]);
+  });
+
+  it("drops recency ids that no longer correspond to a feed", () => {
+    const feeds = [feed("a"), feed("b")];
+    const ordered = orderFeedsByRecency(feeds, ["gone", "b"]);
+    expect(ordered.map((f) => f.id)).toEqual(["b", "a"]);
+  });
+
+  it("returns feeds in their original order when nothing has been viewed", () => {
+    const feeds = [feed("a"), feed("b")];
+    expect(orderFeedsByRecency(feeds, []).map((f) => f.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("MOBILE_DOCK_FEED_CAP", () => {
+  it("is a small positive cap so the closed dock never overflows the strip", () => {
+    expect(MOBILE_DOCK_FEED_CAP).toBeGreaterThan(0);
+    expect(MOBILE_DOCK_FEED_CAP).toBeLessThanOrEqual(8);
+  });
+});

--- a/tests/stores/feed-store.test.ts
+++ b/tests/stores/feed-store.test.ts
@@ -97,6 +97,7 @@ describe("feed-store", () => {
       feeds: [],
       folders: [],
       selectedFeedId: null,
+      recentFeedIds: [],
       isLoading: false,
       error: null,
     });
@@ -438,6 +439,17 @@ describe("feed-store", () => {
       expect(useFeedStore.getState().feeds).toEqual([]);
       expect(useFeedStore.getState().selectedFeedId).toBeNull();
     });
+
+    it("prunes the removed feed from the quick-switch recency list", async () => {
+      const feed = mockFeed("x", "X");
+      useFeedStore.setState({ feeds: [feed], recentFeedIds: ["x", "y"] });
+      vi.mocked(removeFeed).mockResolvedValue({ ok: true, value: true });
+      vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [] });
+
+      await useFeedStore.getState().removeFeed("x");
+
+      expect(useFeedStore.getState().recentFeedIds).toEqual(["y"]);
+    });
   });
 
   describe("renameFeed", () => {
@@ -488,6 +500,29 @@ describe("feed-store", () => {
     it("sets selectedFeedId", () => {
       useFeedStore.getState().selectFeed("abc");
       expect(useFeedStore.getState().selectedFeedId).toBe("abc");
+    });
+
+    it("records the viewed feed as most-recent for the quick-switch dock", () => {
+      useFeedStore.setState({ recentFeedIds: ["feed-2"] });
+      useFeedStore.getState().selectFeed("feed-1");
+      expect(useFeedStore.getState().recentFeedIds).toEqual(["feed-1", "feed-2"]);
+    });
+
+    it("persists the recency list so the dock survives a reload", () => {
+      useFeedStore.setState({ recentFeedIds: [] });
+      useFeedStore.getState().selectFeed("feed-1");
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        "feedzero:recent-feed-ids",
+        JSON.stringify(["feed-1"]),
+      );
+    });
+
+    it("does not record aggregated views (All / Starred / smart-filter) — they have no favicon", () => {
+      useFeedStore.setState({ recentFeedIds: [] });
+      useFeedStore.getState().selectFeed("all");
+      useFeedStore.getState().selectFeed("starred");
+      useFeedStore.getState().selectFeed("filter:abc-123");
+      expect(useFeedStore.getState().recentFeedIds).toEqual([]);
     });
   });
 


### PR DESCRIPTION
The closed drawer strip showed the selected feed's name next to a generic
Layers icon, duplicating the feed name already in the mobile header. The
drawer's job is cross-feed navigation, so the closed state now previews
where you can go rather than echoing where you are.

What changed:
- Closed strip is now a quick-switch dock: an anchored "All items" button
  plus the user's most-recently-viewed feed favicons (newest first),
  capped at MOBILE_DOCK_FEED_CAP. Tapping a favicon switches feed directly
  without opening the drawer; the chevron opens the full feed list.
- feed-store tracks recentFeedIds (device-local, persisted to
  localStorage) — recorded in selectFeed (the single feed-view chokepoint),
  pruned in removeFeed. Aggregated views (All/Starred/folder/filter) are
  never recorded since they have no favicon. Recency stays per-device and
  never syncs.
- New pure helpers in src/lib/recent-feeds.ts (orderFeedsByRecency,
  recordRecentFeed) keep ordering/cap logic unit-testable.

Key files: src/components/layout/mobile-nav-drawer.tsx, src/lib/recent-feeds.ts,
src/stores/feed-store.ts, src/utils/constants.ts, docs/features/010-mobile-navigation.md

https://claude.ai/code/session_01FQbYhEqiME3HsptPFvxm5R