### PR TITLE
fix(signal): preview content fallback + iOS sheet clearance

### DIFF
--- a/docs/features/020-signal.md
+++ b/docs/features/020-signal.md
@@ -162,7 +162,8 @@ Feature: Signal — cross-feed topic surface
 | `tests/core/signal/frequency-engine-window.test.ts` | Adaptive window picks the smallest with ≥50 articles, falls back to "all" when every window is sparse. |
 | `tests/core/signal/frequency-engine-edge.test.ts` | Common nouns never anchor a topic, syndicated story collapses to one multi-outlet story, single-feed corpus → empty, body-only entity detection, deterministic across input order, non-English does not crash, dominant-entity cap. |
 | `tests/stores/signal-store.test.ts` | Locked / loading / ready transitions, empty-ready handling, cache TTL hit, force-reload bypasses cache, window change invalidates cache, ±10% corpus drift invalidates cache, persistence across state reset. |
-| `tests/pages/signal-page.test.tsx` | Locked tile, empty-ready message, entity topic heading + story rows, multi-outlet badge + expand, desktop click → reader, mobile tap → preview → reader, Refresh re-runs, cache priming, schema-version invalidation. |
+| `tests/pages/signal-page.test.tsx` | Locked tile, empty-ready message, entity topic heading + story rows, multi-outlet badge + expand, desktop click → reader, mobile tap → preview → reader, mobile sheet safe-area clearance, Refresh re-runs, cache priming, schema-version invalidation. |
+| `tests/components/signal/article-preview.test.tsx` | Feed-content head, summary fallback, persisted/cached extraction fallback, explicit "Load preview" affordance, loading + failed states. |
 | `tests/e2e/signal.spec.ts` | Sidebar Sparkles entry navigates to `/signal`, locked tile renders with the gate copy when the corpus is empty. |
 | `tests/core/features/tier-matrix.test.ts` | `signal` is shipped, Personal+ available, Free unavailable; round-trips through `GATED_FEATURE_IDS`. |
 
@@ -210,8 +211,16 @@ Feature: Signal — cross-feed topic surface
   syndication volume doesn't distort cluster strength.
 - **Peek before read.** A topic row is a triage surface, not a destination.
   Hover (desktop) / tap (mobile) shows a teaser; the click commits to the
-  reader. Reusing `ArticleContent`, `HoverCard`, and `Sheet` keeps it to one
-  small component with no new primitives beyond the HoverCard wrapper.
+  reader. Reusing `HoverCard` and `Sheet` keeps it to one small component
+  plus the HoverCard wrapper. The mobile bottom sheet rounds its top and pads
+  `env(safe-area-inset-bottom)` so it clears the iOS home indicator.
+- **The preview degrades gracefully when the feed body is absent.** The sync
+  vault strips `content`/`summary` to stay small (`sync-service.ts`), so a
+  synced article has no feed body. The teaser falls back through
+  `content → summary → extractedContent → extraction-store cache`; when all
+  are empty it offers an explicit "Load preview" button. Fetching is never
+  automatic — a hover must not hit the network — so the network call only
+  fires on a deliberate tap, matching the privacy contract.
 - **Cross-feed diversity is the signal.** Score = `articles × log(1 + feeds)`.
   Multiplying by log-feeds means a story appearing in 10 outlets
   outranks one outlet posting 10 times, which matches the

--- a/src/components/signal/article-preview.tsx
+++ b/src/components/signal/article-preview.tsx
@@ -1,5 +1,6 @@
-import { BookOpen, ExternalLink } from "lucide-react";
+import { BookOpen, ExternalLink, FileText, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button.tsx";
+import { useExtractionStore } from "@/stores/extraction-store.ts";
 import { formatRelative } from "@/lib/format-relative.ts";
 import { decodeEntities } from "@/lib/decode-entities.ts";
 import type { Article } from "@/types/index.ts";
@@ -15,9 +16,23 @@ interface ArticlePreviewProps {
  * Compact peek at an article — title, source, a plain-text teaser, and the
  * two ways to act on it. Shown in a HoverCard (desktop) or Sheet (mobile)
  * so the reader can triage from Signal without leaving the page.
+ *
+ * Feed bodies are stripped from the sync vault (see `sync-service.ts`), so a
+ * synced article often has no `content`/`summary`. When that happens we fall
+ * back to any already-extracted text, and otherwise offer a one-tap load.
+ * Fetching is never automatic (a hover must not hit the network) — the user
+ * opts in by pressing the button, matching the privacy contract.
  */
 export function ArticlePreview({ article, feedTitle, now, onOpen }: ArticlePreviewProps) {
-  const teaser = toPlainText(article.content || article.summary || "");
+  const extractedCache = useExtractionStore((s) => s.cache[article.link]);
+  const status = useExtractionStore((s) => s.getStatus(article.link));
+  const extractInBackground = useExtractionStore((s) => s.extractInBackground);
+
+  const feedBody = article.content || article.summary || article.extractedContent || "";
+  const teaser = toPlainText(feedBody || extractedCache || "");
+  const loading = status === "extracting";
+  const failed = status === "failed";
+
   return (
     <div className="flex flex-col gap-3">
       <div className="space-y-1">
@@ -28,11 +43,34 @@ export function ArticlePreview({ article, feedTitle, now, onOpen }: ArticlePrevi
           {formatRelative(article.publishedAt, now)}
         </p>
       </div>
+
       {teaser ? (
         <p className="line-clamp-5 text-sm leading-relaxed text-muted-foreground">{teaser}</p>
+      ) : loading ? (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          Loading preview…
+        </p>
       ) : (
-        <p className="text-sm italic text-muted-foreground">No preview available.</p>
+        <div className="flex flex-col items-start gap-2">
+          <p className="text-sm text-muted-foreground">
+            {failed
+              ? "Couldn't load a preview. Open the article to read it."
+              : "This feed didn't include a preview."}
+          </p>
+          {!failed ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => extractInBackground(article.link)}
+            >
+              <FileText className="size-3.5" />
+              Load preview
+            </Button>
+          ) : null}
+        </div>
       )}
+
       <div className="flex items-center gap-2">
         <Button size="sm" onClick={onOpen}>
           <BookOpen className="size-3.5" />

--- a/src/components/signal/story-row.tsx
+++ b/src/components/signal/story-row.tsx
@@ -132,7 +132,10 @@ function PreviewLink({
         {children}
       </button>
       <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent side="bottom" className="max-h-[80vh] overflow-y-auto p-4">
+        <SheetContent
+          side="bottom"
+          className="max-h-[85vh] overflow-y-auto rounded-t-2xl p-4 pb-[calc(env(safe-area-inset-bottom)+1.5rem)]"
+        >
           <SheetTitle className="sr-only">Article preview</SheetTitle>
           <SheetDescription className="sr-only">
             Peek at this article and open it in the reader.

--- a/tests/components/signal/article-preview.test.tsx
+++ b/tests/components/signal/article-preview.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { ArticlePreview } from "@/components/signal/article-preview.tsx";
+import { useExtractionStore } from "@/stores/extraction-store.ts";
+import type { Article } from "@/types/index.ts";
+
+const NOW = new Date("2026-05-21T12:00:00Z").getTime();
+
+function makeArticle(overrides: Partial<Article> = {}): Article {
+  return {
+    id: "a1",
+    feedId: "f1",
+    guid: "a1",
+    title: "Council approves the budget",
+    link: "https://example.com/a1",
+    content: "",
+    summary: "",
+    author: "",
+    publishedAt: NOW,
+    read: false,
+    createdAt: NOW,
+    ...overrides,
+  };
+}
+
+function renderPreview(article: Article) {
+  return render(
+    <MemoryRouter>
+      <ArticlePreview article={article} feedTitle="Outlet" now={NOW} onOpen={() => {}} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ArticlePreview", () => {
+  beforeEach(() => {
+    useExtractionStore.setState({ cache: {}, statusMap: {}, paywallMap: {} });
+  });
+
+  it("shows the feed content head when the feed includes a body", () => {
+    renderPreview(makeArticle({ content: "<p>The council voted to approve the new budget.</p>" }));
+    expect(screen.getByText(/council voted to approve the new budget/i)).toBeInTheDocument();
+    expect(screen.queryByText(/didn't include a preview/i)).toBeNull();
+  });
+
+  it("falls back to the feed summary when content is empty", () => {
+    renderPreview(makeArticle({ summary: "<p>A short summary of the story.</p>" }));
+    expect(screen.getByText(/a short summary of the story/i)).toBeInTheDocument();
+  });
+
+  it("falls back to persisted extracted content for a synced article", () => {
+    renderPreview(makeArticle({ extractedContent: "<p>Full extracted article body here.</p>" }));
+    expect(screen.getByText(/full extracted article body here/i)).toBeInTheDocument();
+  });
+
+  it("uses the extraction store cache when present", () => {
+    const article = makeArticle();
+    useExtractionStore.setState({ cache: { [article.link]: "<p>Cached extracted text.</p>" } });
+    renderPreview(article);
+    expect(screen.getByText(/cached extracted text/i)).toBeInTheDocument();
+  });
+
+  it("offers an explicit Load preview action when no body is available", () => {
+    renderPreview(makeArticle());
+    expect(screen.getByText(/this feed didn't include a preview/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /load preview/i })).toBeInTheDocument();
+  });
+
+  it("clicking Load preview asks the extraction store to fetch the article", async () => {
+    const article = makeArticle();
+    const extractInBackground = vi.fn();
+    useExtractionStore.setState({ extractInBackground });
+    renderPreview(article);
+    await userEvent.click(screen.getByRole("button", { name: /load preview/i }));
+    expect(extractInBackground).toHaveBeenCalledWith(article.link);
+  });
+
+  it("shows a loading state while extraction is in flight", () => {
+    const article = makeArticle();
+    useExtractionStore.setState({ statusMap: { [article.link]: "extracting" } });
+    renderPreview(article);
+    expect(screen.getByText(/loading preview/i)).toBeInTheDocument();
+  });
+
+  it("shows a recoverable message and hides Load when extraction failed", () => {
+    const article = makeArticle();
+    useExtractionStore.setState({ statusMap: { [article.link]: "failed" } });
+    renderPreview(article);
+    expect(screen.getByText(/couldn't load a preview/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /load preview/i })).toBeNull();
+  });
+});

--- a/tests/pages/signal-page.test.tsx
+++ b/tests/pages/signal-page.test.tsx
@@ -227,6 +227,21 @@ describe("SignalPage", () => {
     await waitFor(() => expect(screen.getByText("READER")).toBeInTheDocument());
   });
 
+  it("on mobile, the preview sheet clears the iOS home indicator and rounds its top", async () => {
+    mockViewport(false);
+    seedReadyCorpus();
+    renderAt();
+    await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("OpenAI ships a release"));
+    await screen.findByRole("button", { name: /open in reader/i });
+    const sheet = document.querySelector('[data-slot="sheet-content"]');
+    expect(sheet).not.toBeNull();
+    expect(sheet!.className).toContain("rounded-t-2xl");
+    expect(sheet!.className).toContain("pb-[calc(env(safe-area-inset-bottom)+1.5rem)]");
+  });
+
   it("Refresh button bypasses the cache", async () => {
     seedReadyCorpus();
     renderAt();


### PR DESCRIPTION
Follow-up fixes to the Signal preview, stacked on `claude/signal-clustering-reading-ux-zWzUl`.

## 1. Preview always said "No preview available"

**Root cause:** the sync vault deliberately strips article `content`/`summary` to `""` to stay small (`src/core/sync/sync-service.ts`). On any synced device the feed body is therefore absent, so a preview that read only `content || summary` was always empty. The reader looks populated only because it extracts full text on open.

**Fix:** the teaser now falls back through `content → summary → extractedContent → extraction-store cache`. When all are empty it offers an explicit **"Load preview"** button (with loading/failed states). Fetching is never automatic — a hover must not hit the network — so the request only fires on a deliberate tap, matching the privacy contract.

## 2. iOS bottom drawer crowded by the home indicator

The mobile preview Sheet now rounds its top (`rounded-t-2xl`) and pads `env(safe-area-inset-bottom) + 1.5rem` so content clears the iOS home indicator and corner radius.

## Test plan
- [x] `tests/components/signal/article-preview.test.tsx` — feed-content head, summary fallback, persisted/cached extraction fallback, explicit load affordance, loading + failed states (8 tests).
- [x] `tests/pages/signal-page.test.tsx` — mobile sheet carries the safe-area + rounded-top classes; existing mobile-tap → preview → reader flow still passes (15 tests).
- [x] `npx tsc --noEmit` clean.
- [ ] Verify on a real iOS device (Playwright browsers can't be installed in the cloud environment).

https://claude.ai/code/session_01QzyESiWekDUN8tbsF4Did8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzyESiWekDUN8tbsF4Did8)_