### PR TITLE
test(import-recovery): fix strict-mode violation on "Queued for retry"

### DIFF
--- a/tests/e2e/import-recovery.spec.ts
+++ b/tests/e2e/import-recovery.spec.ts
@@ -85,7 +85,9 @@ test.describe("Import recovery — placeholder for rate-limited URLs", () => {
     await expect(
       page.getByText(/1 feed added.*1 queued for retry/i),
     ).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText(/Queued for retry/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Queued for retry \(\d+\)/i }),
+    ).toBeVisible();
 
     // Both feeds — the OK one and the placeholder — landed in the sidebar.
     // Navigate to /feeds and assert.


### PR DESCRIPTION
The E2E assertion at line 88 used getByText(/Queued for retry/i), which
now resolves to two elements — the summary paragraph ("1 feed added, 1
queued for retry") and the collapsible section trigger ("Queued for retry
(1)") — causing a Playwright strict-mode violation.

Target the collapsible trigger by button role with a count-bearing name
(/Queued for retry \(\d+\)/i) so the assertion is unambiguous and actually
verifies the queued-for-retry section renders, distinct from the summary
line already checked on the preceding assertion.

https://claude.ai/code/session_01DxRHqiWXHMdkNUFHDz65G8