### PR TITLE
fix(sync): preserve unpushed local changes across reload

### DIFF
--- a/docs/features/008-zero-knowledge-sync.md
+++ b/docs/features/008-zero-knowledge-sync.md
@@ -63,6 +63,15 @@ Feature: Zero-knowledge cloud sync
     And then refreshes all feeds (including newly imported ones)
     And pushes the updated vault back to the server
 
+  Scenario: Unpushed local change survives a reload
+    Given a sync-enabled user who renamed a feed
+    And the 5s debounced push has not fired yet
+    When they reload the app (dropping the in-memory debounce timer)
+    Then a persisted "pending push" marker records the unsynced change
+    And the next pull() flushes that change to the server BEFORE importVault
+    And the rename is preserved instead of being reverted to the cloud copy
+    And if the flush cannot reach the server, the pull aborts (local kept)
+
   Scenario: Local-only user enables sync later
     Given a local-only user
     When they click Enable sync in the Data & Storage dialog
@@ -133,11 +142,11 @@ Same passphrase always produces same vault ID and same encryption key. No extern
 ### Flow
 
 1. **Push**: `exportAll()` from IndexedDB -> serialize to `VaultData` -> `encryptVault()` with AES-GCM-256 -> PUT `/api/sync` with vault ID + ciphertext
-2. **Pull**: GET `/api/sync?vaultId=<hex>` -> `decryptVault()` -> `importAll()` into IndexedDB. `importAll`'s clear+bulkPut runs in a single Dexie `rw` transaction so concurrent callers serialize at the storage layer and never expose the mid-clear empty state.
+2. **Pull**: GET `/api/sync?vaultId=<hex>` -> `decryptVault()` -> `importAll()` into IndexedDB. `importAll`'s clear+bulkPut runs in a single Dexie `rw` transaction so concurrent callers serialize at the storage layer and never expose the mid-clear empty state. **Flush-before-import:** if a `feedzero:sync-pending-push` marker is set (a local change whose debounced push never fired — e.g. a rename made just before a reload dropped the timer), `pull()` pushes local to the server first, then imports. Otherwise `importAll`'s replace-all would silently revert the unsynced change to the stale cloud copy. A failed flush aborts the pull (local data is kept).
 3. **Delete**: DELETE `/api/sync?vaultId=<hex>` -> removes encrypted blob from server
 4. **Startup (sync user)**: `initializeReturningUser` awaits the initial `pull()` before flipping `isDbReady=true`. This makes `AppInit`'s `isDbReady` effect run on settled state; no race between init's pull and the boot-time loadFeeds. Also: concurrent `pull()` callers share a single in-flight promise (sync-store's `inFlightPull`), and the boot effect skips `refreshAll` for sync users since init's pull already brought in cloud state.
 5. **Refresh all (sync user)**: Pull vault -> reload feeds from DB -> refresh all feeds -> reload feeds -> push
-6. **After mutations**: Debounced push (5s after last change)
+6. **After mutations**: Set the `sync-pending-push` marker, then debounced push (5s after last change). The marker outlives a reload that drops the timer; a successful push clears it.
 7. **Disable sync**: Delete server vault -> clear localStorage keys -> reset store to local-only
 8. **Logout**: Delete local DB -> clear all localStorage keys -> reset to onboarding (cloud vault preserved)
 9. **Check vault exists**: HEAD `/api/sync?vaultId=<hex>` -> returns true if 200, false if 404
@@ -210,7 +219,7 @@ All API handlers use the Web standard `Request -> Response` pattern. Three entry
 
 ## Limitations
 
-- No conflict resolution — last push wins
+- No conflict resolution — last push wins. The `sync-pending-push` flush makes "this device has the freshest local change" win over a stale cloud copy on pull, but a genuine cross-device conflict (both sides edited the same feed since the last sync) still resolves last-push-wins.
 - No incremental sync — full vault transferred each time
 - Vault size limited to 5MB
 - No passphrase change/rotation flow yet

--- a/src/stores/sync-store.ts
+++ b/src/stores/sync-store.ts
@@ -24,6 +24,7 @@ import {
 } from "../core/storage/db.ts";
 import type { VaultData } from "../core/sync/types.ts";
 import { clearLicenseToken } from "../core/license/license-token-store.ts";
+import { LOCAL_STORAGE } from "../utils/constants.ts";
 import type { Result } from "../utils/result.ts";
 import { ok, err } from "../utils/result.ts";
 
@@ -31,6 +32,25 @@ export type SyncStatus = "local-only" | "syncing" | "synced" | "error";
 
 const DEBOUNCE_MS = 5000;
 const MAX_JITTER_MS = 30000;
+
+/**
+ * The debounced push timer lives only in memory, so a tab reload drops it
+ * and the queued change is never sent. This localStorage marker records
+ * "local has changes the cloud hasn't seen yet" so it outlives the reload;
+ * pull() flushes it before importVault would overwrite the change. Set when
+ * a push is scheduled, cleared when one succeeds.
+ */
+function markPendingPush(): void {
+  localStorage.setItem(LOCAL_STORAGE.SYNC_PENDING_PUSH, "1");
+}
+
+function clearPendingPush(): void {
+  localStorage.removeItem(LOCAL_STORAGE.SYNC_PENDING_PUSH);
+}
+
+function hasPendingPush(): boolean {
+  return localStorage.getItem(LOCAL_STORAGE.SYNC_PENDING_PUSH) !== null;
+}
 
 type SwitchMode = "replace" | "merge";
 
@@ -140,6 +160,7 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
     // (next session will have sync mode set, and can retry push)
     const result = await pushVault(credentials);
     if (result.ok) {
+      clearPendingPush();
       set({ status: "synced", lastSyncedAt: result.value, error: null });
     } else {
       set({ status: "error", error: result.error });
@@ -211,6 +232,7 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
 
     const result = await pushVault(credentials);
     if (result.ok) {
+      clearPendingPush();
       set({ status: "synced", lastSyncedAt: result.value, error: null });
     } else {
       set({ status: "error", error: result.error });
@@ -224,6 +246,23 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
 
     inFlightPull = (async () => {
       set({ status: "syncing", error: null });
+
+      // Flush any local change whose debounced push never fired (e.g. a
+      // rename made just before a tab reload dropped the timer). Otherwise
+      // the importVault below — which REPLACES all local data — would
+      // silently revert it to the stale cloud copy. If the flush can't
+      // reach the server, abort: better to keep the unsynced local change
+      // than to clobber it. Forced cloud-replacement bypasses this via
+      // forceResync, which calls pullVault directly.
+      if (hasPendingPush()) {
+        const flushResult = await pushVault(credentials);
+        if (!flushResult.ok) {
+          set({ status: "error", error: flushResult.error });
+          return;
+        }
+        clearPendingPush();
+      }
+
       const pullResult = await pullVault(credentials);
       if (!pullResult.ok) {
         set({ status: "error", error: pullResult.error });
@@ -253,8 +292,12 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
     }
 
     // Cancel any pending push so it can't fire after our import and
-    // overwrite cloud with stale local state.
+    // overwrite cloud with stale local state. forceResync is the explicit
+    // "discard local, take cloud" action, so the pending-push marker is
+    // dropped too — the local change the user chose to discard must not
+    // resurrect itself on the next pull's flush.
     clearPendingTimers();
+    clearPendingPush();
 
     set({ status: "syncing", error: null });
 
@@ -288,6 +331,9 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
     const { credentials } = get();
     if (!credentials) return;
 
+    // Record the intent durably before arming the in-memory timer, so a
+    // reload between now and the push still leaves a trail pull() can flush.
+    markPendingPush();
     clearPendingTimers();
     debounceTimer = setTimeout(() => {
       debounceTimer = null;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -159,6 +159,11 @@ export const LOCAL_STORAGE = {
    *  is per-device and never syncs); drives the mobile drawer quick-switch
    *  dock. */
   RECENT_FEED_IDS: "feedzero:recent-feed-ids",
+  /** Set when a local change has been persisted but its debounced cloud
+   *  push hasn't fired yet. Survives a tab reload (which drops the
+   *  in-memory debounce timer) so the next pull() can flush the change to
+   *  the cloud before importVault would otherwise overwrite it. */
+  SYNC_PENDING_PUSH: "feedzero:sync-pending-push",
 } as const;
 
 /**

--- a/tests/integration/sync-pending-push.test.ts
+++ b/tests/integration/sync-pending-push.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration test for the "unpushed local change survives a pull" contract.
+ *
+ * Sync writes are debounced (5s) + jittered (0–30s) in scheduleSyncPush.
+ * The debounce timer lives only in memory, so a tab reload — or any other
+ * trigger that fires pull() before the timer elapses (e.g. the periodic
+ * auto-refresh) — drops the pending push. The next pull() then runs
+ * importVault, which REPLACES all local data with the cloud copy. A feed
+ * the user just renamed but whose push never fired is silently reverted.
+ *
+ * This test models a shared cloud (push uploads the current local DB,
+ * pull downloads whatever was last pushed) so the temporal coupling is
+ * exercised end-to-end against the real db.ts + importVault/exportVault.
+ * Only the network transport (pushVault/pullVault) is mocked.
+ */
+import "fake-indexeddb/auto";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ok } from "../../src/utils/result.ts";
+import type { VaultData } from "../../src/core/sync/types.ts";
+import type { Feed } from "../../src/types/index.ts";
+
+const pushVaultMock = vi.fn();
+const pullVaultMock = vi.fn();
+
+vi.mock("../../src/core/sync/sync-service.ts", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/core/sync/sync-service.ts")
+  >("../../src/core/sync/sync-service.ts");
+  return {
+    ...actual,
+    pushVault: (...args: unknown[]) => pushVaultMock(...args),
+    pullVault: (...args: unknown[]) => pullVaultMock(...args),
+  };
+});
+
+import { useSyncStore } from "../../src/stores/sync-store.ts";
+import { useFeedStore } from "../../src/stores/feed-store.ts";
+import { useLicenseStore } from "../../src/stores/license-store.ts";
+import {
+  open,
+  close,
+  deleteDatabase,
+  addFeed as dbAddFeed,
+  getFeeds as dbGetFeeds,
+} from "../../src/core/storage/db.ts";
+import { LOCAL_STORAGE } from "../../src/utils/constants.ts";
+
+function makeFeed(id: string, title: string): Feed {
+  return {
+    id,
+    url: `https://${id}.example.com/feed.xml`,
+    title,
+    description: "",
+    siteUrl: `https://${id}.example.com`,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+describe("sync: unpushed local rename survives a pull", () => {
+  beforeEach(async () => {
+    useLicenseStore.setState({ tier: "personal", verifying: false });
+    await open("test-passphrase");
+    useFeedStore.setState({ feeds: [], feedsLoaded: false });
+    useSyncStore.setState({
+      credentials: { vaultId: "vault", vaultKey: {} as CryptoKey },
+      status: "synced",
+    });
+
+    // Shared cloud: push uploads the current local DB; pull returns it.
+    let cloud: VaultData = {
+      version: 1,
+      exportedAt: Date.now(),
+      feeds: [makeFeed("a", "Original")],
+      articles: [],
+    };
+    pushVaultMock.mockImplementation(async () => {
+      const feeds = await dbGetFeeds();
+      cloud = {
+        version: 1,
+        exportedAt: Date.now(),
+        feeds: feeds.ok ? feeds.value : [],
+        articles: [],
+      };
+      return ok(Date.now());
+    });
+    pullVaultMock.mockImplementation(async () => ok(cloud));
+  });
+
+  afterEach(async () => {
+    // Neutralize the leaked debounce timer from scheduleSyncPush: with no
+    // credentials, the eventual push() returns early.
+    useSyncStore.setState({ credentials: null });
+    close();
+    await deleteDatabase();
+    localStorage.removeItem(LOCAL_STORAGE.SYNC_PENDING_PUSH);
+    vi.clearAllMocks();
+  });
+
+  it("does not revert a rename whose debounced push never fired", async () => {
+    await dbAddFeed(makeFeed("a", "Original"));
+    await useFeedStore.getState().loadFeeds();
+
+    // User renames the feed. This persists to IndexedDB and schedules a
+    // debounced push — which we never let elapse (simulating a reload).
+    await useFeedStore.getState().renameFeed("a", "Renamed");
+
+    const afterRename = await dbGetFeeds();
+    expect(afterRename.ok && afterRename.value[0].title).toBe("Renamed");
+
+    // App reload / periodic refresh runs pull() before the push fired.
+    await useSyncStore.getState().pull();
+
+    const afterPull = await dbGetFeeds();
+    expect(afterPull.ok && afterPull.value[0].title).toBe("Renamed");
+  });
+
+  it("still adopts cloud changes when local has no pending push", async () => {
+    await dbAddFeed(makeFeed("a", "Original"));
+    await useFeedStore.getState().loadFeeds();
+
+    // No local mutation → no pending push. The cloud has a different
+    // feed (a change made on another device). A pull must adopt it.
+    pullVaultMock.mockImplementation(async () =>
+      ok({
+        version: 1,
+        exportedAt: Date.now(),
+        feeds: [makeFeed("b", "From Other Device")],
+        articles: [],
+      }),
+    );
+
+    await useSyncStore.getState().pull();
+
+    const afterPull = await dbGetFeeds();
+    expect(afterPull.ok && afterPull.value.map((f) => f.title)).toEqual([
+      "From Other Device",
+    ]);
+    expect(pushVaultMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
What: A sync user who renames a feed (or makes any local change) and
reloads the app before the 5s debounced push fires sees the change
silently reverted on the next boot. Reported as "renaming a feed title
is not persisted when reloading the app."

Why: The debounced push timer lives only in memory. A reload destroys it,
so the push never fires. On the next boot, initializeReturningUser (and
the periodic refreshAll) call pull() -> importVault, which REPLACES all
local data with the stale cloud copy — clobbering the locally-persisted
rename. Local-only users were unaffected; the change persisted correctly
to IndexedDB, which is why the existing renameFeed test stayed green.

Fix: Persist a `feedzero:sync-pending-push` marker whenever a push is
scheduled, cleared when one succeeds. pull() now flushes a pending push to
the server BEFORE importVault overwrites local data; a failed flush aborts
the pull so the unsynced change is kept rather than clobbered. forceResync
(explicit "discard local, take cloud") clears the marker. A clean local
state still adopts cloud changes on pull, so cross-device sync is intact.

Prevention: tests/integration/sync-pending-push.test.ts models a shared
cloud (push uploads local, pull downloads it) against the real db.ts +
importVault/exportVault, mocking only the network transport. It locks
both directions: an unpushed rename survives a pull, and a clean local
state still takes cloud changes (no spurious push). Docs updated in
docs/features/008-zero-knowledge-sync.md.

https://claude.ai/code/session_01RPwiMtMobSKgisEen8mdQw