### PR TITLE
test(import-recovery): wait out the boot refresh before pressing "r"

### DIFF
--- a/tests/e2e/import-recovery.spec.ts
+++ b/tests/e2e/import-recovery.spec.ts
@@ -103,6 +103,19 @@ test.describe("Import recovery — placeholder for rate-limited URLs", () => {
     const failedIndicator = page.getByTestId("failed-feed-indicator");
     await expect(failedIndicator).toHaveCount(1);
 
+    // The local-user boot path fires a refreshAll() (app.tsx) the moment the
+    // DB is ready, and navigating to /feeds above re-triggered it. That boot
+    // refresh runs while the mock is still in the "rate-limited" phase, so it
+    // legitimately leaves the placeholder failed. But refreshAll() no-ops
+    // while another refresh is in flight (feed-store guard), so pressing "r"
+    // before the boot refresh settles would have our keypress swallowed — the
+    // feed would never get re-fetched in the recovered phase. Wait for the
+    // in-flight refresh to finish (the sidebar Refresh button re-enables)
+    // before flipping the phase, so the keypress drives a real refresh.
+    await expect(
+      page.getByRole("button", { name: "Refresh", exact: true }),
+    ).toBeEnabled({ timeout: 15000 });
+
     // Phase 2: flip the mock so rate-limited.* now returns 200. Hit "r"
     // to refresh all feeds. The placeholder upgrades in place: indicator
     // clears, title backfills.


### PR DESCRIPTION
## Summary

- Fixes the intermittent CI failure in `tests/e2e/import-recovery.spec.ts` where the phase-2 assertion (`getByText("Rate-Limited Feed")`) timed out after pressing `r`.
- Root cause is a race, not a product bug: the local-user boot path fires `refreshAll()` the moment the DB is ready (`src/app.tsx:165`). Navigating to `/feeds` re-triggers it during the `"rate-limited"` phase. `refreshAll()` no-ops while another refresh is in flight (the `isRefreshingAll` guard in `feed-store.ts:549`), so pressing `r` before the boot refresh settled got swallowed, and the placeholder was never re-fetched in the `"recovered"` phase.
- Fix: before flipping the mock to the recovered phase and pressing `r`, wait for the in-flight boot refresh to finish via its user-observable signal — the sidebar **Refresh** button re-enabling (`disabled={isRefreshingAll}`). The keypress then drives a real refresh. Test-only change, no production code touched.

## Test plan

- [x] `npx playwright test tests/e2e/import-recovery.spec.ts --project=desktop` — passes
- [x] Reproduced original failure: `git stash` + `--repeat-each=6` → 3/6 failed
- [x] Verified fix: `--repeat-each=4` → 4/4 passed; one additional single run → 1/1 passed
- [x] `npx tsc --noEmit` clean
- [x] CI green on the PR (shard 4/6 was the failing one)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6Gho2muorhuFy9SrwGdXF)_