### PR TITLE
fix(favicon): keep loaded favicons stable when an unrelated failure is cleared

### DIFF
--- a/docs/plans/refresh-efficiency.md
+++ b/docs/plans/refresh-efficiency.md
@@ -1,0 +1,67 @@
+# Plan: Refresh efficiency + configurable interval
+
+## Goal
+
+Two threads, both surfaced by issue #117:
+
+1. **Configurable refresh interval** — let users set how often auto-refresh runs (5 min / 30 min / 1 h / 6 h / daily / never). Currently hardcoded to `AUTO_REFRESH_INTERVAL_MS = 30 * 60 * 1000`.
+2. **Cut per-refresh cost** — every tick of `refreshAll()` does more work than it needs to. Self-hosted users on a 100 req/min/IP budget feel this first (sporadic `/api/sync` 429s during refresh storms), but every user pays in bandwidth, decrypt cost, and encrypted-vault write churn.
+
+## What `refreshAll()` does today (every 30 min)
+
+`src/stores/feed-store.ts:548-570`. Per tick:
+
+1. `retryFailedFavicons()` — bumps the favicon-cache generation counter. Subscribers now no-op when their strategy index hasn't changed (post #117 fix), so this is cheap. ✅
+2. If sync user: `syncStore.pull()` — **unconditional** full vault GET, decrypt, merge. No `If-Modified-Since` / `ETag` / vault-version short-circuit.
+3. `reloadFeeds(set)` — full IndexedDB read of `feeds` + `folders`, decrypt every row, rebuild in-memory list.
+4. `refreshAllFeeds()` — fans out one `/api/feed` request per feed. **No conditional GET** (`proxyFetch` doesn't send / forward `If-None-Match` / `If-Modified-Since`; the proxy doesn't honor 304s). Every feed re-downloads its full XML body every tick even when unchanged.
+5. `reloadFeeds(set)` — again (same full read).
+6. `schedulePush()` — debounced 5 s sync push. The vault gets re-encrypted and PUT even if the only changes were freshness timestamps (`lastFetchedAt` / `lastSuccessfulFetchAt`) with no user-meaningful edits.
+7. `void schedulePrefetch(get().feeds)` — fire-and-forget full-text extraction for prefetch-enabled feeds.
+
+For a sync user with 60 feeds: 1 vault GET + 60 feed proxy requests + 1 vault PUT, every 30 min. The sync GET/PUT each carry the full multi-KB encrypted vault. The 60 feed fetches re-download bodies the publisher could have told us are unchanged.
+
+## Inefficiency findings (ranked by impact / cost)
+
+### A — No conditional GET on feed fetch *(biggest win, medium effort)*
+The proxy at `/api/feed` (`src/core/proxy/proxy-handler.ts`) doesn't forward `If-None-Match` / `If-Modified-Since` headers from the client, and `refreshFeed` (`src/core/feeds/feed-service.ts:356`) doesn't supply them. Adding per-feed `etag` + `lastModified` columns + forwarding the conditional headers turns most refreshes into 304s for publishers that support it (most major sites do). Bandwidth and parse cost go to near-zero on unchanged feeds.
+
+### B — Unconditional vault pull *(big win for sync users, small effort)*
+`/api/sync` already supports `HEAD` (returns vault metadata). A `pull()` that first `HEAD`s and only `GET`s when the vault's `updatedAt` is newer than `lastPullAt` skips the body 99% of the time when the user is on one device. The `HEAD` is a few bytes.
+
+### C — Push only when user-meaningful state actually changed *(medium win, larger effort)*
+`schedulePush()` fires whenever feed rows are touched, and freshness timestamps count as a touch. Splitting `Feed` into "synced shape" (url/title/folderId/prefs/rules) vs "device-local freshness" (lastFetchedAt/lastSuccessfulFetchAt/lastError) means a refresh that only changes freshness doesn't push. The two halves can stay in the same table; we just exclude the freshness fields from the vault payload and re-derive them locally on pull. Needs an ADR — back-compat with v3 vaults is fiddly.
+
+### D — `reloadFeeds` runs twice per refresh *(small win, trivial effort)*
+Two full IndexedDB reads of feeds+folders per tick. The first (after `pull`) is needed because the merge may have changed rows; the second (after `refreshAllFeeds`) only needs the freshness columns. Could collapse to one read if (C) lands, or update in-memory rows from the refresh result directly.
+
+### E — Fan-out backpressure *(small win, small effort)*
+60 concurrent `/api/feed` requests hit a self-hosted server that allows 100/min. Already grouped by host in `refreshAllFeeds` (`src/core/feeds/group-by-host.ts`) but not throttled per-process. A small concurrency cap (e.g. 8 in-flight) keeps the user's other API calls (sync, favicon, paywall) within budget. Pairs well with (A) since 304s are cheap once we have them.
+
+### F — Cross-device coordination *(speculative, low priority)*
+Two devices each running their own 30 min timer means the vault PUT/GET pair fires up to 2 × per window. A vault-side `lastRefreshAllAt` device hint lets the second device skip its scheduled refresh if another device pushed recently. Probably not worth it until we see real-user reports.
+
+## Step 1 (this plan's first PR) — Configurable interval
+
+Smallest unit of progress and the thing DoubtfulYeti592 asked for.
+
+- Add `refreshIntervalMinutes: number` to `UserPreferences` (`src/types/index.ts`). Allowed values from a `REFRESH_INTERVAL_OPTIONS` const: `[5, 15, 30, 60, 360, 1440, 0]` where `0` = manual only.
+- Default = 30 (current behavior).
+- `use-auto-refresh.ts` reads from `usePreferencesStore` and resubscribes the interval when the preference changes.
+- Settings → Reading: a Select component listing the options ("Every 5 minutes", …, "Every day", "Manual only").
+- License gate: keep on the free tier (it's an *opt out* of polling — privacy-positive, no reason to paywall it).
+- Tests: store hydration → hook uses new interval; setting to 0 disables the timer; focus-when-stale still works using the configured threshold.
+
+## Step 2+ (follow-up PRs)
+
+Land (A), then (B), in that order. (C) needs an ADR before code. (D) and (E) ride along with whichever PR is next in the same files.
+
+## Out of scope
+
+- Per-feed refresh intervals. Possible later but multiplies UI complexity and isn't asked for.
+- WebPush / background-sync API. Wrong privacy trade-off (third-party push service).
+- Active feed prioritization (read-often feeds refresh more frequently). Interesting but speculative; revisit after (A)+(B) ship and we see real-world refresh-cost data.
+
+## Owner
+
+Unassigned. Issue #117 thread is the breadcrumb.

--- a/src/components/feeds/feed-favicon.tsx
+++ b/src/components/feeds/feed-favicon.tsx
@@ -67,8 +67,16 @@ export function FeedFavicon({
 
   if (seenGeneration !== generation) {
     setSeenGeneration(generation);
-    setPathIndex(origin ? getFaviconStrategyIndex(origin) : 0);
-    setLoaded(false);
+    // Only restart resolution when THIS origin's cached strategy changed.
+    // Successful favicons share the generation bump but shouldn't drop their
+    // loaded state — otherwise a single cleared failure elsewhere makes every
+    // mounted favicon flash to the RSS placeholder and re-hit /api/favicon on
+    // each refresh-all. See issue #117.
+    const next = origin ? getFaviconStrategyIndex(origin) : 0;
+    if (next !== pathIndex) {
+      setPathIndex(next);
+      setLoaded(false);
+    }
   }
 
   if (!origin || pathIndex < 0 || pathIndex >= STRATEGIES.length) {

--- a/src/core/favicon/favicon-cache.ts
+++ b/src/core/favicon/favicon-cache.ts
@@ -56,9 +56,13 @@ function persistCache() {
 
 /**
  * Generation counter bumped whenever the cache changes in a way that should
- * make mounted favicons re-evaluate (currently: a retry clears failures).
- * Components subscribe via `useSyncExternalStore` so a refresh re-attempts
- * favicons that are already on screen, not just ones mounted afterwards.
+ * prompt mounted favicons to re-check their cached strategy (currently: a
+ * retry that clears failure entries). Components subscribe via
+ * `useSyncExternalStore` so a refresh re-attempts favicons that are already
+ * on screen, not just ones mounted afterwards. Subscribers must compare the
+ * new strategy index against their current one and no-op when unchanged —
+ * otherwise a single cleared failure makes every working favicon flash and
+ * refetch (issue #117).
  */
 let generation = 0;
 const listeners = new Set<() => void>();

--- a/tests/components/feeds/feed-favicon.test.tsx
+++ b/tests/components/feeds/feed-favicon.test.tsx
@@ -119,4 +119,28 @@ describe("FeedFavicon", () => {
     expect(img).toBeTruthy();
     expect(img!.getAttribute("src")).toBe("/api/favicon?domain=example.com");
   });
+
+  // Regression: refresh-all clears another origin's failure entry, which used
+  // to bump the global generation and force EVERY mounted favicon to drop its
+  // `loaded` state — making working favicons flash to the RSS placeholder and
+  // re-hit /api/favicon on every refresh. See issue #117.
+  it("keeps an already-loaded favicon visible when an unrelated origin's failure is cleared", () => {
+    // Site A: loads successfully.
+    const { container } = render(<FeedFavicon siteUrl="https://a.example.com" />);
+    const img = container.querySelector("img")!;
+    fireEvent.load(img);
+    expect(img.classList.contains("hidden")).toBe(false);
+    expect(container.querySelector("svg")).toBeNull();
+
+    // Site B (rendered elsewhere) had previously failed; clearing it bumps
+    // the favicon-cache generation.
+    setFaviconCacheEntry("https://b.example.com", -1, Date.now());
+    act(() => retryFailedFavicons());
+
+    // Site A must stay visible — same img, still loaded, no flash to RSS.
+    const after = container.querySelector("img")!;
+    expect(after).toBe(img);
+    expect(after.classList.contains("hidden")).toBe(false);
+    expect(container.querySelector("svg")).toBeNull();
+  });
 });


### PR DESCRIPTION
**What** — Every auto-refresh (and every `r`) made all favicons briefly flash
to the RSS placeholder and re-request `/api/favicon`, even ones that had
already loaded. On self-hosted servers this also spent the shared per-IP
rate-limit budget, surfacing as sporadic "Sync push failed (429)" errors
because `/api/sync` competed with the favicon storm for the same bucket.

**Why** — `retryFailedFavicons()` clears failed cache entries and bumps the
shared generation counter. Every mounted `<FeedFavicon>` subscribes via
`useSyncExternalStore`; on bump it reset `loaded=false` unconditionally,
regardless of whether THIS origin's cached strategy actually changed. The
single cleared failure for site B forced site A to re-render as if it had
never loaded.

**Fix** — `<FeedFavicon>` now compares `getFaviconStrategyIndex(origin)`
against its current `pathIndex` after a generation bump and only resets
`pathIndex` / `loaded` when they actually differ. Origins that had never
failed (or whose successful strategy is still cached) keep their loaded
image. Origins that previously gave up (`pathIndex < 0`) still retry
correctly because the cleared entry returns 0 from the cache lookup.

**Prevention** — Regression test
`tests/components/feeds/feed-favicon.test.tsx` asserts that a loaded
`<FeedFavicon>` keeps the same `<img>` element and stays unhidden when
`retryFailedFavicons()` clears an unrelated origin. The contract for
generation-bump subscribers is now documented in `favicon-cache.ts`:
subscribers must no-op when their strategy index hasn't changed.

Refs #117.