### PR TITLE
fix(favicon): add white backing in dark mode so dark favicons stay visible

### DIFF
--- a/src/components/feeds/feed-favicon.tsx
+++ b/src/components/feeds/feed-favicon.tsx
@@ -100,7 +100,7 @@ export function FeedFavicon({
         className={`${className} shrink-0 ${
           avatar
             ? "rounded-full bg-white object-cover p-px"
-            : "rounded-sm ring-1 ring-border/50"
+            : "rounded-sm ring-1 ring-border/50 dark:bg-white dark:p-px"
         } ${loaded ? "" : "hidden"}`}
         onLoad={() => {
           recordFaviconSuccess(origin, pathIndex);

--- a/tests/components/feeds/feed-favicon.test.tsx
+++ b/tests/components/feeds/feed-favicon.test.tsx
@@ -96,6 +96,26 @@ describe("FeedFavicon", () => {
     expect(img.className).toContain("ring-1");
   });
 
+  // Some favicons are dark-on-transparent (TechCrunch, GitHub octocat dark variants).
+  // Without a backing, they blend into the dark theme background. Default variant
+  // must get a white pill in dark mode so any icon stays visible.
+  it("paints a white backing in dark mode so dark favicons stay visible", () => {
+    const { container } = render(<FeedFavicon siteUrl="https://example.com" />);
+    const img = container.querySelector("img")!;
+    expect(img.className).toContain("dark:bg-white");
+    expect(img.className).toContain("dark:p-px");
+  });
+
+  it("avatar variant keeps its always-on white backing (unaffected by dark-mode default)", () => {
+    const { container } = render(
+      <FeedFavicon siteUrl="https://example.com" avatar />,
+    );
+    const img = container.querySelector("img")!;
+    expect(img.className).toContain("bg-white");
+    expect(img.className).toContain("p-px");
+    expect(img.className).not.toContain("dark:bg-white");
+  });
+
   it("retries after cached failure once TTL expires", () => {
     setFaviconCacheEntry("https://stale.example.com", -1, 0);
 


### PR DESCRIPTION
What
Favicons that are dark-on-transparent (TechCrunch, GitHub octocat dark
variants, etc.) blended into the dark theme background — the favicon
"disappeared" leaving only the subtle border ring.

Why
The default FeedFavicon variant only applied `rounded-sm ring-1
ring-border/50`. The ring is `oklch(0.917 0.007 285.823)` at 50% opacity
which is near-invisible against the dark background, and the favicon
image itself sat directly on the dark surface with no light backing.
Only `avatar` mode (used on the Signal splash hero) had `bg-white p-px`.

Fix
Add `dark:bg-white dark:p-px` to the default variant in
`src/components/feeds/feed-favicon.tsx`. Light mode is unchanged; dark
mode gets the same small white pill the avatar variant already uses, so
any color icon stays visible.

Prevention
Two new assertions in `tests/components/feeds/feed-favicon.test.tsx`:
one locks in the `dark:bg-white` / `dark:p-px` classes on the default
variant, the other locks the avatar variant's always-on backing (no
`dark:` prefix, so it doesn't regress).