### PR TITLE
fix(mobile): stop iOS zoom on input focus + native-app feel baseline

### DIFF
--- a/docs/features/010-mobile-navigation.md
+++ b/docs/features/010-mobile-navigation.md
@@ -118,6 +118,23 @@ Feature: Mobile navigation
 | `tests/lib/recent-feeds.test.ts` | Recency ordering, cap, dedupe |
 | `tests/stores/feed-store.test.ts` | `selectFeed` records recency; `removeFeed` prunes it |
 
+## Native-app feel (CSS + meta tag baseline)
+
+These are app-wide rules, not navigation-specific, but they live alongside the mobile work because they're how the mobile web app stops feeling like a web page. All defined in `src/index.css` and `index.html`.
+
+| Rule | Where | What it does |
+|------|-------|--------------|
+| `font-size: 16px` on `input, textarea, select, [contenteditable="true"]` at `max-width: 767px` | `src/index.css` (unlayered, after the `.dark` block) | Prevents iOS Safari's auto-zoom on input focus. Our `html { font-size: 14px }` makes Tailwind's `text-base` resolve to 14px, which trips Safari's `font-size < 16px → zoom in` heuristic. The rule sits OUTSIDE `@layer base` because utility classes (`text-base`, `text-sm`) live in `@layer utilities` and would otherwise win the cascade. |
+| `-webkit-text-size-adjust: 100%` | `html` in `@layer base` | Pins the text scale in iOS landscape — without it the OS reflows fonts and breaks the tuned scale. |
+| `-webkit-tap-highlight-color: transparent` | `body` in `@layer base` | Removes the gray flash iOS draws on every tap. The single biggest "I'm a web page" tell. |
+| `overscroll-behavior-y: none` | `html, body` in `@layer base` | Kills the document-root rubber-band overscroll on iOS and Chrome Android's pull-to-refresh — neither belongs in an app shell. |
+| `touch-action: manipulation` | `button, [role="button"], a, summary, [role="tab"], [role="menuitem"], label` in `@layer base` | Removes the 300ms double-tap-zoom delay on interactive elements so rapid taps feel instant. Form controls are excluded so text-selection / caret gestures stay intact. |
+| `apple-mobile-web-app-capable=yes` + `mobile-web-app-capable=yes` | `index.html` | Standalone launch from Add-to-Home-Screen (drops the URL bar / tab strip). |
+| `apple-mobile-web-app-status-bar-style=black-translucent` | `index.html` | App paints behind the iOS status bar; combined with the existing `env(safe-area-inset-top)` body padding, content stays clear. |
+| `apple-mobile-web-app-title=FeedZero` | `index.html` | Sets the home-screen icon label on iOS. |
+
+Test guards (Tier 2 structural): `tests/index-html-viewport.test.ts` (PWA meta tags) and `tests/index-css-native-feel.test.ts` (CSS rules + the *unlayered* placement of the iOS-zoom rule).
+
 ## Design Decisions
 
 - **Ref-based skip flag** — Using a ref (`skipAutoSelectRef`) instead of state avoids re-renders while still persisting across the async article load cycle. The ref is reset only when `articleId` appears in the URL, ensuring the skip persists through multiple effect runs.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
         <title>FeedZero</title>
         <meta name="description" content="Privacy-first RSS reader. Zero distractions. Zero friction. Zero tracking." />
         <meta name="theme-color" content="#ffffff" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta name="apple-mobile-web-app-title" content="FeedZero" />
         <meta property="og:title" content="FeedZero" />
         <meta property="og:description" content="Privacy-first RSS reader. Zero distractions. Zero friction. Zero tracking." />
         <meta property="og:type" content="website" />

--- a/src/index.css
+++ b/src/index.css
@@ -141,6 +141,13 @@
         font-family: var(--font-sans);
         font-size: 14px;
         line-height: 1.5;
+        /* Prevent iOS landscape orientation from auto-bumping font sizes
+           and breaking the carefully-tuned text scale. */
+        -webkit-text-size-adjust: 100%;
+        text-size-adjust: 100%;
+        /* Kill the document-root rubber-band overscroll and Chrome Android
+           pull-to-refresh — neither belongs in an app-shell experience. */
+        overscroll-behavior-y: none;
     }
 
     body {
@@ -154,6 +161,43 @@
         padding-bottom: env(safe-area-inset-bottom);
         padding-left: env(safe-area-inset-left);
         padding-right: env(safe-area-inset-right);
+        /* Remove the gray "tap flash" iOS Safari draws on every tap — the
+           single biggest "this is a web page, not an app" tell on iOS. */
+        -webkit-tap-highlight-color: transparent;
+        overscroll-behavior-y: none;
+    }
+
+    /* Remove the 300ms double-tap-zoom delay on interactive elements so
+       rapid taps (e.g. article-list navigation) feel instant. We exclude
+       form controls so the browser's input gestures (text-selection,
+       caret placement) stay intact. */
+    button,
+    [role="button"],
+    a,
+    summary,
+    [role="tab"],
+    [role="menuitem"],
+    label {
+        touch-action: manipulation;
+    }
+
+}
+
+/* iOS Safari auto-zooms a focused form control when its computed font-size
+   is below 16px. Our html font-size is 14px (so Tailwind's text-base = 1rem
+   = 14px), which trips the heuristic on every input. Pinning a literal 16px
+   on touch viewports stops the zoom without touching the desktop text scale.
+
+   This rule sits OUTSIDE @layer base on purpose: Tailwind utilities live in
+   @layer utilities, which beats @layer base, so a base-layer rule would lose
+   to the `text-base` / `text-sm` utilities the shadcn Input/Textarea apply.
+   Unlayered CSS wins the cascade against every layered rule. */
+@media (max-width: 767px) {
+    input,
+    textarea,
+    select,
+    [contenteditable="true"] {
+        font-size: 16px;
     }
 }
 

--- a/tests/index-css-native-feel.test.ts
+++ b/tests/index-css-native-feel.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Structural assertions for the native-app feel rules in src/index.css.
+ *
+ * Why this is a content-grep test instead of a computed-style test:
+ * happy-dom does not evaluate media queries, `-webkit-*` vendor properties,
+ * or `touch-action` against a viewport; jsdom does not implement them at
+ * all. A real-browser E2E test cannot observe these either — the iOS-only
+ * focus zoom is a property of MobileSafari's heuristic, not the DOM. The
+ * next-best regression guard is asserting the CSS source contains the
+ * rules that produce the fix.
+ *
+ * If a future "let's clean up index.css" edit drops these, every mobile
+ * input regresses to the iOS focus-zoom (the original 2026-05-23 user
+ * report) and every tap regresses to the gray-flash + 300ms delay.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const INDEX_CSS = readFileSync(
+  resolve(__dirname, "..", "src", "index.css"),
+  "utf-8",
+);
+
+describe("index.css — iOS zoom on input focus prevention", () => {
+  it("forces form controls to 16px on viewports below the md breakpoint", () => {
+    // The root html font-size is 14px, so Tailwind's text-base (1rem)
+    // resolves to 14px and trips iOS Safari's "zoom in on focus when
+    // input font-size < 16px" heuristic. The CSS rule pins a literal
+    // 16px on input/textarea/select/contenteditable below md (768px).
+    //
+    // Accepts any equivalent ordering of selectors in the rule body.
+    const mobileInputRule =
+      /@media\s*\(max-width:\s*767px\)[\s\S]*?(?:input|textarea|select|contenteditable)[\s\S]*?font-size:\s*16px/;
+    expect(INDEX_CSS).toMatch(mobileInputRule);
+  });
+
+  it("covers input, textarea, select and contenteditable in the same rule", () => {
+    // Each of these can trigger the iOS zoom. The rule must list them all
+    // so a contenteditable comment field or a native <select> doesn't
+    // regress.
+    expect(INDEX_CSS).toMatch(/input/);
+    expect(INDEX_CSS).toMatch(/textarea/);
+    expect(INDEX_CSS).toMatch(/select/);
+    expect(INDEX_CSS).toMatch(/\[contenteditable/);
+  });
+
+  it("places the mobile-input rule OUTSIDE @layer base so it beats Tailwind utilities", () => {
+    // Tailwind v4 puts utility classes (text-base, text-sm) into
+    // @layer utilities, which beats @layer base in the cascade. The
+    // shadcn Input/Textarea apply `text-base md:text-sm` — so a base-
+    // layer 16px rule would lose to those utilities and the zoom
+    // regression would silently come back.
+    //
+    // Unlayered CSS wins the cascade against EVERY layered rule, which
+    // is the only stable place for this rule. This test guards against
+    // a future "let's wrap everything in @layer base for tidiness" edit.
+    const baseLayerMatch = INDEX_CSS.match(/@layer base\s*\{[\s\S]*?\n\}/);
+    expect(baseLayerMatch).not.toBeNull();
+    const baseLayerBody = baseLayerMatch?.[0] ?? "";
+    expect(baseLayerBody).not.toMatch(/@media\s*\(max-width:\s*767px\)/);
+  });
+});
+
+describe("index.css — native-app feel base rules", () => {
+  it("disables -webkit-text-size-adjust so iOS landscape doesn't reflow type", () => {
+    // Without this, rotating an iPhone to landscape bumps up font sizes
+    // automatically and the carefully-tuned text scale breaks.
+    expect(INDEX_CSS).toMatch(
+      /-webkit-text-size-adjust:\s*100%/,
+    );
+  });
+
+  it("removes the iOS tap highlight (gray flash on every tap)", () => {
+    // The single biggest "this is a web page, not an app" tell on iOS.
+    expect(INDEX_CSS).toMatch(
+      /-webkit-tap-highlight-color:\s*transparent/,
+    );
+  });
+
+  it("disables document-root overscroll (pull-to-refresh rubber-band)", () => {
+    // Native apps don't bounce the whole document when you scroll past
+    // the top/bottom. `overscroll-behavior-y: none` on html/body kills
+    // both the rubber-band AND Chrome Android's pull-to-refresh.
+    expect(INDEX_CSS).toMatch(
+      /overscroll-behavior(-y)?:\s*none/,
+    );
+  });
+
+  it("declares touch-action: manipulation on interactive elements", () => {
+    // Removes the 300ms double-tap-zoom delay that iOS Safari applies
+    // to clicks on buttons/links. Crucial for any UI that taps in
+    // rapid succession (e.g. j/k-like article navigation taps).
+    expect(INDEX_CSS).toMatch(
+      /touch-action:\s*manipulation/,
+    );
+  });
+});

--- a/tests/index-html-viewport.test.ts
+++ b/tests/index-html-viewport.test.ts
@@ -35,3 +35,37 @@ describe("index.html viewport meta", () => {
     expect(INDEX_HTML).toMatch(/viewport-fit=cover/);
   });
 });
+
+describe("index.html iOS PWA meta tags (native-app feel)", () => {
+  // Without these, "Add to Home Screen" on iOS still opens FeedZero inside
+  // the Safari chrome — the URL bar, tab bar and bottom toolbar all stay,
+  // which immediately reveals it's not a native app. The standalone meta
+  // tags + the manifest's "display":"standalone" together unlock a
+  // chrome-less fullscreen launch on both iOS and Android.
+
+  it("declares apple-mobile-web-app-capable=yes for standalone iOS launch", () => {
+    expect(INDEX_HTML).toMatch(
+      /<meta[^>]*name=["']apple-mobile-web-app-capable["'][^>]*content=["']yes["']/,
+    );
+  });
+
+  it("declares the legacy mobile-web-app-capable=yes for older Android browsers", () => {
+    expect(INDEX_HTML).toMatch(
+      /<meta[^>]*name=["']mobile-web-app-capable["'][^>]*content=["']yes["']/,
+    );
+  });
+
+  it("declares a status-bar style so the iOS status bar blends with the app", () => {
+    // black-translucent lets the app paint behind the status bar; combined
+    // with env(safe-area-inset-top) in body padding, content stays clear.
+    expect(INDEX_HTML).toMatch(
+      /<meta[^>]*name=["']apple-mobile-web-app-status-bar-style["'][^>]*content=["'](black-translucent|default|black)["']/,
+    );
+  });
+
+  it("declares an apple-mobile-web-app-title for the home-screen icon label", () => {
+    expect(INDEX_HTML).toMatch(
+      /<meta[^>]*name=["']apple-mobile-web-app-title["'][^>]*content=["']FeedZero["']/,
+    );
+  });
+});


### PR DESCRIPTION
What
  iOS Safari zoomed in on every form-control focus on FeedZero (text
  inputs, the feedback dialog textarea, the passphrase entry, the new-
  folder input, etc.), forcing the user to manually pinch back out.

Why
  Root html font-size is 14px, so Tailwind's `text-base` (1rem) resolves
  to 14px on inputs. iOS Safari auto-zooms any focused form control whose
  computed font-size is below 16px — by spec, not configurable client-
  side. Every Input/Textarea in the app was tripping the heuristic.

Fix
  Unlayered `@media (max-width: 767px) { input, textarea, select,
  [contenteditable=true] { font-size: 16px } }` in src/index.css. The
  rule sits OUTSIDE @layer base on purpose: Tailwind utilities live in
  @layer utilities, which beats @layer base in the cascade, so a base-
  layer rule would lose to the `text-base` / `text-sm` utilities the
  shadcn Input/Textarea apply. Unlayered CSS wins against every layered
  rule.

  While in the same area, ship the mobile-web baseline that makes the
  app feel like an app instead of a page:
    - `-webkit-text-size-adjust: 100%` on html (no landscape reflow)
    - `-webkit-tap-highlight-color: transparent` on body (kill the gray
      flash on every tap — single biggest "I'm a web page" tell on iOS)
    - `overscroll-behavior-y: none` on html/body (kill pull-to-refresh
      rubber-band at the document root)
    - `touch-action: manipulation` on buttons/links/labels/etc. (kill
      the 300ms double-tap-zoom delay on interactive elements)
    - apple-mobile-web-app-capable + mobile-web-app-capable + status-bar
      style + apple-mobile-web-app-title meta tags in index.html (proper
      standalone Add-to-Home-Screen launch on iOS and Android)

Prevention
  - `tests/index-css-native-feel.test.ts` (new) asserts each rule is
    present AND that the iOS-zoom rule is *unlayered* (so a future
    "tidy up by wrapping everything in @layer base" edit can't silently
    bring the zoom back).
  - `tests/index-html-viewport.test.ts` extended with assertions for
    the four new iOS PWA meta tags.
  - `docs/features/010-mobile-navigation.md` documents the native-feel
    baseline + the unlayered-cascade rationale so future contributors
    don't move the rule into @layer base.

Files
  src/index.css                          — native-feel rules + unlayered iOS zoom rule
  index.html                             — 4 PWA meta tags
  tests/index-css-native-feel.test.ts    — new structural tests
  tests/index-html-viewport.test.ts      — extended with PWA tags
  docs/features/010-mobile-navigation.md — native-feel baseline section

https://claude.ai/code/session_01EiScS9RQUhTc8Ks4TbLBUt