### PR TITLE
feat(signal): richer previews, multi-source visual cues, top stories digest

### DIFF
--- a/src/components/signal/article-preview.tsx
+++ b/src/components/signal/article-preview.tsx
@@ -2,6 +2,7 @@ import { BookOpen, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button.tsx";
 import { formatRelative } from "@/lib/format-relative.ts";
 import { decodeEntities } from "@/lib/decode-entities.ts";
+import { pickTeaser } from "@/lib/pick-teaser.ts";
 import type { Article } from "@/types/index.ts";
 
 interface ArticlePreviewProps {
@@ -12,12 +13,20 @@ interface ArticlePreviewProps {
 }
 
 /**
+ * Approximate cap for the extracted-text fallback. Five `line-clamp` lines
+ * at ~50–60 chars per line is roughly this; the CSS clamp handles overflow,
+ * but capping the string keeps the layout predictable when extractedContent
+ * is enormous.
+ */
+const TEASER_CHAR_LIMIT = 280;
+
+/**
  * Compact peek at an article — title, source, a plain-text teaser, and the
  * two ways to act on it. Shown in a HoverCard (desktop) or Sheet (mobile)
  * so the reader can triage from Signal without leaving the page.
  */
 export function ArticlePreview({ article, feedTitle, now, onOpen }: ArticlePreviewProps) {
-  const teaser = toPlainText(article.content || article.summary || "");
+  const teaser = pickTeaser(article, TEASER_CHAR_LIMIT);
   return (
     <div className="flex flex-col gap-3">
       <div className="space-y-1">
@@ -47,9 +56,4 @@ export function ArticlePreview({ article, feedTitle, now, onOpen }: ArticlePrevi
       </div>
     </div>
   );
-}
-
-function toPlainText(html: string): string {
-  const stripped = html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
-  return decodeEntities(stripped);
 }

--- a/src/components/signal/story-row.tsx
+++ b/src/components/signal/story-row.tsx
@@ -23,6 +23,9 @@ import type { Article, Feed } from "@/types/index.ts";
 const ROW_CLASS =
   "flex w-full flex-col gap-1 py-3 text-left transition-colors hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none";
 
+const MULTI_BADGE_CLASS =
+  "inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary";
+
 interface StoryRowProps {
   story: Story;
   articleMap: Map<string, Article>;
@@ -45,13 +48,16 @@ export function StoryRow({ story, articleMap, feedMap, now }: StoryRowProps) {
   const multi = story.feedCount >= 2;
 
   return (
-    <li>
+    <li className={cn(multi && "border-l-2 border-l-primary pl-3")}>
       <PreviewLink article={head} feedTitle={headFeed} now={now}>
         <span className="text-sm text-foreground">{decodeEntities(head.title)}</span>
-        <span className="text-xs text-muted-foreground">
-          {multi ? `Covered by ${story.feedCount} outlets` : headFeed}
-          {" · "}
-          {formatRelative(head.publishedAt, now)}
+        <span className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          {multi ? (
+            <span className={MULTI_BADGE_CLASS}>{`Covered by ${story.feedCount} outlets`}</span>
+          ) : (
+            <span>{headFeed}</span>
+          )}
+          <span>{formatRelative(head.publishedAt, now)}</span>
         </span>
       </PreviewLink>
 
@@ -75,8 +81,10 @@ export function StoryRow({ story, articleMap, feedMap, now }: StoryRowProps) {
                 return (
                   <li key={id}>
                     <PreviewLink article={member} feedTitle={feedTitle} now={now}>
-                      <span className="text-sm text-foreground">{feedTitle}</span>
+                      <span className="text-sm text-foreground">{decodeEntities(member.title)}</span>
                       <span className="text-xs text-muted-foreground">
+                        {feedTitle}
+                        {" · "}
                         {formatRelative(member.publishedAt, now)}
                       </span>
                     </PreviewLink>

--- a/src/lib/pick-teaser.ts
+++ b/src/lib/pick-teaser.ts
@@ -1,0 +1,50 @@
+import { decodeEntities } from "./decode-entities.ts";
+import type { Article } from "@/types/index.ts";
+
+/**
+ * Pick the best plain-text teaser for an article preview surface.
+ *
+ * Precedence:
+ *   1. Feed-provided `content` or `summary` — usually a hand-written
+ *      blurb the publisher meant to be a preview.
+ *   2. First sentence(s) of `extractedContent`, capped to `charLimit` —
+ *      a graceful fallback when the feed didn't ship a blurb but the
+ *      background prefetch grabbed the full body. Better an excerpted
+ *      lede than "No preview available."
+ *
+ * Returns `""` when nothing is available; callers render their own
+ * empty-state copy.
+ */
+export function pickTeaser(article: Article, charLimit: number): string {
+  const fromBlurb = toPlainText(article.content) || toPlainText(article.summary);
+  if (fromBlurb) return fromBlurb;
+  const body = toPlainText(article.extractedContent);
+  if (!body) return "";
+  return clipToSentences(body, charLimit);
+}
+
+function toPlainText(html: string | undefined): string {
+  if (!html) return "";
+  const stripped = html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+  return decodeEntities(stripped);
+}
+
+const SENTENCE_BREAK = /(?<=[.!?])\s+/u;
+
+/**
+ * Pack whole sentences into a budget. If even the first sentence blows
+ * the budget, hard-truncate with an ellipsis — a clipped lede beats
+ * nothing.
+ */
+function clipToSentences(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const sentences = text.split(SENTENCE_BREAK);
+  let acc = "";
+  for (const s of sentences) {
+    const candidate = acc ? `${acc} ${s}` : s;
+    if (candidate.length > limit) break;
+    acc = candidate;
+  }
+  if (acc) return acc;
+  return text.slice(0, limit).trimEnd() + "…";
+}

--- a/src/pages/signal-page.tsx
+++ b/src/pages/signal-page.tsx
@@ -8,6 +8,7 @@ import {
   SIGNAL_ARTICLES_PER_TOPIC,
   SIGNAL_CORPUS_GATE,
   type SignalReport,
+  type Story,
   type Topic,
   type WindowChoice,
 } from "@/core/signal/types.ts";
@@ -167,6 +168,7 @@ function ReadyView({
   });
 
   const hasTopics = report.topics.length > 0;
+  const topStories = useMemo(() => collectTopStories(report.topics), [report.topics]);
   const generatedLabel = formatRelative(report.generatedAt);
 
   return (
@@ -208,6 +210,14 @@ function ReadyView({
           <EmptyState onAddFeeds={() => navigate("/explore")} />
         ) : (
           <div className="flex flex-col gap-8">
+            {topStories.length >= TOP_STORIES_MIN ? (
+              <TopStoriesBlock
+                stories={topStories}
+                articleMap={articleMap}
+                feedMap={feedMap}
+                now={report.generatedAt}
+              />
+            ) : null}
             {report.topics.map((topic) => (
               <TopicBlock
                 key={topic.term}
@@ -221,6 +231,69 @@ function ReadyView({
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * The Top stories digest only renders when at least this many stories
+ * have multiple sources. One multi-source story isn't a "digest" — it's a
+ * single row already visible in its topic — so the bar starts at two.
+ */
+const TOP_STORIES_MIN = 2;
+
+/**
+ * Collect stories with at least two sources across every topic, deduped
+ * by id (the rare case where the same article is claimed by multiple
+ * topics) and ordered outlet-count-desc — most-corroborated first.
+ * Stories within a topic are already most-recent-first, which carries
+ * through stable sort.
+ */
+function collectTopStories(topics: Topic[]): Story[] {
+  const seen = new Set<string>();
+  const out: Story[] = [];
+  for (const topic of topics) {
+    for (const story of topic.stories) {
+      if (story.feedCount >= 2 && !seen.has(story.id)) {
+        seen.add(story.id);
+        out.push(story);
+      }
+    }
+  }
+  out.sort((a, b) => b.feedCount - a.feedCount);
+  return out;
+}
+
+function TopStoriesBlock({
+  stories,
+  articleMap,
+  feedMap,
+  now,
+}: {
+  stories: Story[];
+  articleMap: Map<string, Article>;
+  feedMap: Map<string, Feed>;
+  now: number;
+}) {
+  return (
+    <section>
+      <header className="mb-1.5">
+        <h2 className="text-lg font-semibold leading-tight">Top stories</h2>
+        <p className="text-xs text-muted-foreground">
+          {`${stories.length} stories multiple outlets are running right now`}
+        </p>
+      </header>
+      <ul className="divide-y divide-border">
+        {stories.map((story) => (
+          <StoryRow
+            key={story.id}
+            story={story}
+            articleMap={articleMap}
+            feedMap={feedMap}
+            now={now}
+          />
+        ))}
+      </ul>
+    </section>
   );
 }
 

--- a/tests/lib/pick-teaser.test.ts
+++ b/tests/lib/pick-teaser.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { pickTeaser } from "../../src/lib/pick-teaser.ts";
+import type { Article } from "../../src/types/index.ts";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+  return {
+    id: "a1",
+    feedId: "f1",
+    guid: "g1",
+    title: "T",
+    link: "https://example.com/a/1",
+    content: "",
+    summary: "",
+    author: "",
+    publishedAt: 1,
+    read: false,
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+describe("pickTeaser", () => {
+  it("uses the feed-provided content blurb when present", () => {
+    const article = buildArticle({ content: "<p>A short summary.</p>" });
+    expect(pickTeaser(article, 280)).toBe("A short summary.");
+  });
+
+  it("falls back to summary when content is empty", () => {
+    const article = buildArticle({ summary: "<p>Alt blurb.</p>" });
+    expect(pickTeaser(article, 280)).toBe("Alt blurb.");
+  });
+
+  it("ignores extractedContent when the feed blurb is present (preserves curated wording)", () => {
+    const article = buildArticle({
+      content: "<p>Curated blurb.</p>",
+      extractedContent: "<p>Full article body, do not show.</p>",
+    });
+    expect(pickTeaser(article, 200)).toBe("Curated blurb.");
+  });
+
+  it("falls back to the first sentence of extractedContent when the feed blurb is missing", () => {
+    const article = buildArticle({
+      extractedContent:
+        "<p>This is the lede sentence. Then more body text follows.</p>",
+    });
+    const result = pickTeaser(article, 40);
+    expect(result).toBe("This is the lede sentence.");
+  });
+
+  it("packs additional sentences when they fit under the limit", () => {
+    const article = buildArticle({
+      extractedContent: "<p>One. Two. Three. Four. Five. Six. Seven.</p>",
+    });
+    const result = pickTeaser(article, 30);
+    expect(result.length).toBeLessThanOrEqual(30);
+    expect(result.startsWith("One.")).toBe(true);
+    expect(result).toContain("Two.");
+  });
+
+  it("hard-truncates with an ellipsis when the first sentence exceeds the limit", () => {
+    const longSentence =
+      "This single sentence is significantly longer than the requested character limit";
+    const article = buildArticle({
+      extractedContent: `<p>${longSentence}</p>`,
+    });
+    const result = pickTeaser(article, 30);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(31);
+  });
+
+  it("returns an empty string when no source has content", () => {
+    expect(pickTeaser(buildArticle(), 200)).toBe("");
+  });
+
+  it("decodes HTML entities in the chosen source", () => {
+    const article = buildArticle({ content: "<p>It&rsquo;s here.</p>" });
+    expect(pickTeaser(article, 200)).toBe("It’s here.");
+  });
+
+  it("strips HTML from the extracted-content fallback", () => {
+    const article = buildArticle({
+      extractedContent:
+        "<article><h1>Heading</h1><p>The <em>real</em> first sentence.</p></article>",
+    });
+    expect(pickTeaser(article, 200)).toMatch(/Heading\s+The real first sentence\./);
+  });
+});

--- a/tests/pages/signal-page.test.tsx
+++ b/tests/pages/signal-page.test.tsx
@@ -65,6 +65,37 @@ function makeArticle(id: string, feedId: string, title: string, ageDays: number)
 }
 
 /**
+ * A corpus with two multi-outlet stories so the Top stories digest
+ * (which only renders when at least two stories have >1 source) lights up.
+ */
+function seedCorpusWithMultipleTopStories() {
+  const feeds: Feed[] = Array.from({ length: 4 }, (_, i) => makeFeed(`f${i + 1}`, `Outlet ${i + 1}`));
+  const articlesByFeedId: Record<string, Article[]> = { f1: [], f2: [], f3: [], f4: [] };
+  let id = 0;
+  // Story 1: OpenAI launches atlas browser — 3 outlets
+  ["f1", "f2", "f3"].forEach((feedId) => {
+    articlesByFeedId[feedId].push(makeArticle(`a-${id++}`, feedId, "OpenAI launches atlas browser", 1));
+  });
+  // Story 2: OpenAI partners with chipmakers — 2 outlets
+  ["f1", "f2"].forEach((feedId) => {
+    articlesByFeedId[feedId].push(makeArticle(`b-${id++}`, feedId, "OpenAI partners with chipmakers", 2));
+  });
+  // 12 distinct single-outlet OpenAI stories so the topic still has many
+  // rows beneath the top-stories digest.
+  OPENAI_HEADLINES.forEach((title, i) => {
+    const feedId = `f${(i % 4) + 1}`;
+    articlesByFeedId[feedId].push(makeArticle(`o-${id++}`, feedId, title, i % 4));
+  });
+  // Entity-free noise to clear the gate.
+  for (let i = 0; i < 95; i++) {
+    const feedId = `f${(i % 4) + 1}`;
+    articlesByFeedId[feedId].push(makeArticle(`n-${id++}`, feedId, `memo${i} note${i} item${i}`, i % 4));
+  }
+  useFeedStore.setState({ feeds });
+  useArticleStore.setState({ articlesByFeedId });
+}
+
+/**
  * A corpus with one OpenAI topic: 12 distinct stories, one of them
  * syndicated verbatim across three outlets, plus entity-free noise so the
  * total clears the gate.
@@ -189,18 +220,30 @@ describe("SignalPage", () => {
     expect(screen.getByText(/last 7 days/i)).toBeInTheDocument();
   });
 
-  it("badges a story covered by multiple outlets and expands to list them", async () => {
+  it("badges a story covered by multiple outlets and expands to list each member's title + outlet", async () => {
     seedReadyCorpus();
     renderAt();
     await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
 
-    expect(screen.getByText(/covered by 3 outlets/i)).toBeInTheDocument();
+    // The multi-outlet badge is rendered with the primary accent color so
+    // the eye finds it before reading.
+    const badge = screen.getByText(/covered by 3 outlets/i);
+    expect(badge.className).toMatch(/text-primary/);
+
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /show all 3 outlets/i }));
-    // Each outlet's name appears in the expanded list.
-    expect(screen.getByText("Outlet 1")).toBeInTheDocument();
-    expect(screen.getByText("Outlet 2")).toBeInTheDocument();
-    expect(screen.getByText("Outlet 3")).toBeInTheDocument();
+
+    // Each outlet still surfaces by name in the meta line.
+    expect(screen.queryAllByText(/Outlet 1/).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(/Outlet 2/).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(/Outlet 3/).length).toBeGreaterThan(0);
+
+    // The article title appears for every member in the expanded list,
+    // plus once in the head row — four occurrences total. Previously the
+    // expanded list only showed the feed name, so a reader couldn't tell
+    // whether two outlets actually ran the same headline.
+    const titleMatches = screen.getAllByText("OpenAI launches atlas browser");
+    expect(titleMatches.length).toBe(4);
   });
 
   it("on desktop, clicking a story opens the reader directly", async () => {
@@ -212,6 +255,33 @@ describe("SignalPage", () => {
     const user = userEvent.setup();
     await user.click(screen.getByText("OpenAI ships a release"));
     await waitFor(() => expect(screen.getByText("READER")).toBeInTheDocument());
+  });
+
+  it("preview falls back to the first sentence of extractedContent when content/summary are empty", async () => {
+    mockViewport(false);
+    // Start from the seedReadyCorpus shape, then enrich the first OpenAI
+    // headline with extractedContent. Feed-provided content/summary stay
+    // empty so the preview must reach into the body for its teaser.
+    seedReadyCorpus();
+    const grouped = { ...useArticleStore.getState().articlesByFeedId };
+    grouped.f1 = grouped.f1.map((article) =>
+      article.title === "OpenAI ships a release"
+        ? {
+            ...article,
+            extractedContent:
+              "<p>The first sentence is the lede. Then the body continues.</p>",
+          }
+        : article,
+    );
+    useArticleStore.setState({ articlesByFeedId: grouped });
+
+    renderAt();
+    await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("OpenAI ships a release"));
+    expect(await screen.findByText(/The first sentence is the lede\./)).toBeInTheDocument();
+    expect(screen.queryByText(/no preview available/i)).toBeNull();
   });
 
   it("on mobile, tapping a story opens a preview then 'Open in reader' navigates", async () => {
@@ -237,6 +307,39 @@ describe("SignalPage", () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /refresh/i }));
     await waitFor(() => expect(useSignalStore.getState().report?.generatedAt).not.toBe(first));
+  });
+
+  describe("Top stories digest", () => {
+    it("renders a 'Top stories' section above the topic blocks when 2+ stories have multiple sources", async () => {
+      seedCorpusWithMultipleTopStories();
+      renderAt();
+      await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
+
+      const topStoriesHeading = screen.getByRole("heading", { level: 2, name: /top stories/i });
+      expect(topStoriesHeading).toBeInTheDocument();
+
+      // The Top stories section sits above the topic heading in the DOM,
+      // because it's a digest the reader should land on first.
+      const topicHeading = screen.getByRole("heading", { level: 2, name: "OpenAI" });
+      expect(
+        topStoriesHeading.compareDocumentPosition(topicHeading)
+          & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+
+      // Each multi-outlet story title appears twice — once in the digest,
+      // once in its topic block.
+      expect(screen.getAllByText("OpenAI launches atlas browser").length).toBeGreaterThanOrEqual(2);
+      expect(screen.getAllByText("OpenAI partners with chipmakers").length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("does NOT render the 'Top stories' section when there is only one multi-outlet story", async () => {
+      // seedReadyCorpus has exactly one multi-outlet story ("OpenAI launches atlas browser").
+      seedReadyCorpus();
+      renderAt();
+      await waitFor(() => expect(useSignalStore.getState().status).toBe("ready"));
+
+      expect(screen.queryByRole("heading", { level: 2, name: /top stories/i })).toBeNull();
+    });
   });
 
   it("reveals additional stories when '+ N more' is clicked", async () => {


### PR DESCRIPTION
Four UX upgrades to the Signal surface so the reader can triage faster:

1. Preview fallback to article body. When a feed ships no `content` or
   `summary`, the hover/sheet preview now uses the first sentences of
   `article.extractedContent` (capped at 280 chars) instead of showing
   "No preview available." Pulled into `src/lib/pick-teaser.ts` so the
   precedence — feed blurb → extracted lede — is one testable function.

2. Article titles in expanded sources. The multi-outlet "Show all N
   outlets" list previously rendered only the feed name per row; readers
   couldn't see whether the outlets actually ran the same headline. Now
   each row shows the member article's title, with the feed name + time
   relegated to the meta line.

3. Color cue for multi-source rows. Stories with feedCount ≥ 2 now get a
   primary-color left border on the row and a pilled "Covered by N
   outlets" badge in `bg-primary/10 text-primary`, so the eye finds the
   corroborated stories before reading.

4. Top stories digest. A new "Top stories" section renders above the
   topic blocks when at least two stories have multiple sources. Stories
   are deduped across topics and ordered by outlet count desc — most-
   corroborated first.

Key files:
- src/lib/pick-teaser.ts (new) — feed-blurb → extracted-lede helper.
- src/components/signal/article-preview.tsx — uses pickTeaser.
- src/components/signal/story-row.tsx — multi-source border + badge,
  member title in expanded list.
- src/pages/signal-page.tsx — TopStoriesBlock + collectTopStories helper.

Tests: 9 new unit tests for pickTeaser + 3 new SignalPage tests
covering top-stories appearance/non-appearance and the
extractedContent preview fallback.