### PR TITLE
fix(mobile): pad mobile drawer strip for iOS home indicator + corners

### DIFF
--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -64,7 +64,13 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
     <Drawer.Root open={open} onOpenChange={setOpen}>
       <div
         data-testid="drawer-handle-strip"
-        className="relative flex items-center gap-1 px-2 h-[60px] shrink-0 border-t bg-background"
+        // iOS safe-area clearance:
+        //   pb-[env(safe-area-inset-bottom)] + matching h-[calc()] keeps the
+        //   60px dock content area above the home indicator.
+        //   pl/pr-[max(0.75rem,env(safe-area-inset-left|right))] holds a
+        //   visual gutter from the rounded display corners in portrait and
+        //   clears the notch/camera cutout in landscape.
+        className="relative flex items-center gap-1 shrink-0 border-t bg-background pl-[max(0.75rem,env(safe-area-inset-left))] pr-[max(0.75rem,env(safe-area-inset-right))] h-[calc(60px+env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)]"
       >
         <div className="absolute left-1/2 -translate-x-1/2 top-1.5 w-10 h-1 rounded-full bg-muted-foreground/30" />
 

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -79,6 +79,34 @@ describe("MobileNavDrawer", () => {
     expect(container.ownerDocument.querySelector("[data-testid='drawer-handle-strip']")).not.toBeNull();
   });
 
+  describe("closed handle strip iOS clearance", () => {
+    // The strip sits at the bottom of the viewport on mobile (parent is
+    // `h-dvh` and the strip is the last child). Without safe-area handling,
+    // the iOS home indicator overlays the dock buttons and the device's
+    // rounded display corners clip the leftmost/rightmost favicons. These
+    // tests pin both: vertical clearance for the home indicator (and the
+    // iOS Safari toolbar shadow on dynamic-viewport switches) and
+    // horizontal clearance for landscape notch / rounded corners.
+
+    it("extends height with env(safe-area-inset-bottom) so dock buttons clear the iOS home indicator", () => {
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+      // The strip's content area must stay 60px (so taps still land on
+      // the dock buttons), but its total height grows by the home-indicator
+      // inset. A `pb-[env(safe-area-inset-bottom)]` paired with a height
+      // expression that includes the same env() is the recipe; here we
+      // assert structurally on the env() token's presence.
+      expect(strip.className).toMatch(/safe-area-inset-bottom/);
+    });
+
+    it("includes env(safe-area-inset-left) and env(safe-area-inset-right) so edge buttons clear rounded corners / landscape notch", () => {
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+      expect(strip.className).toMatch(/safe-area-inset-left/);
+      expect(strip.className).toMatch(/safe-area-inset-right/);
+    });
+  });
+
   describe("closed-state quick-switch dock", () => {
     it("shows the selected feed's favicons in the closed strip (no drawer open needed)", () => {
       useFeedStore.setState({


### PR DESCRIPTION
What
----
On iOS the bottom mobile drawer's closed handle strip sat flush against
the viewport edge: the home indicator overlay covered the lower half of
the dock buttons, and the device's rounded display corners clipped the
leftmost / rightmost favicons. In landscape, the notch and camera
cutout intruded on the edge buttons too.

Why
---
The closed strip used `h-[60px] px-2` with no safe-area handling. The
open drawer's scroll + footer already accounted for
`env(safe-area-inset-bottom)`, but the persistent always-visible strip
did not — so the offending case was the most common one (drawer closed,
user tapping a favicon).

Fix
---
Strip className now uses:
- `h-[calc(60px+env(safe-area-inset-bottom))]` with
  `pb-[env(safe-area-inset-bottom)]` — total height grows by the home
  indicator inset while the content area stays 60px (border-box keeps
  taps landing on the buttons).
- `pl-/pr-[max(0.75rem,env(safe-area-inset-left|right))]` — minimum
  0.75rem gutter from rounded corners in portrait, expands to the
  notch/camera inset in landscape.

Prevention
----------
New `closed handle strip iOS clearance` test block pins the className
tokens for `safe-area-inset-bottom/left/right`. happy-dom can't compute
the env() pixel values, so the regression guard is structural — same
shape as the existing browser-chrome occlusion guard in the open
drawer.

https://claude.ai/code/session_01VkF3Gv9ig21Ye4SoLaGep5