### PR TITLE
feat(import): Omnivore JSON export parser

### DIFF
--- a/docs/features/021-shutdown-migrations.md
+++ b/docs/features/021-shutdown-migrations.md
@@ -1,0 +1,153 @@
+# Feature 021: Shutdown Migrations
+
+## Status
+Implemented (parsers + import dispatch + welcome hint). Landing pages
+deployment tracked in [`docs/marketing/TODO.md`](../marketing/TODO.md).
+
+## Summary
+
+Refugees from four shutdown competitors in the last 19 months
+([strategy 001](../strategy/001-competitor-scan.md)) — Pocket, Omnivore,
+Tiny Tiny RSS, Artifact — need somewhere to land. This feature ships
+the in-app half of the migration story: parsers that ingest each
+service's export format, an import-view dispatcher that auto-detects
+which one was pasted/dropped, and an onboarding hint that names the
+supported shutdowns explicitly so refugees recognise their export type.
+
+The landing-page half lives in the [`feedzero-landing`](../marketing/)
+repo and is shipped via the prompt at
+[`docs/marketing/LANDING_PROMPT.md`](../marketing/LANDING_PROMPT.md).
+
+## Behaviour
+
+```gherkin
+Feature: Shutdown migrations
+
+  Scenario: Pocket HTML export
+    Given the user has a pocket-export.html from getpocket.com/export
+    When they drop it into Settings → Import
+    Then unique site origins are extracted (one per host)
+    And each origin is fed into addFeedFlow for RSS discovery
+
+  Scenario: Pocket CSV export
+    Given the user has a pocket-export.csv with `title, url, time_added` columns
+    When they drop it into Settings → Import
+    Then unique site origins are extracted from the url column
+    And each origin is fed into addFeedFlow for RSS discovery
+
+  Scenario: Omnivore JSON export
+    Given the user has an Omnivore metadata.json (array of articles with `url` + `savedAt`)
+    When they drop it into Settings → Import
+    Then unique site origins are extracted from each article's url field
+    And each origin is fed into addFeedFlow for RSS discovery
+
+  Scenario: TT-RSS OPML export
+    Given the user has a tt-rss-feeds.xml exported via TT-RSS Preferences
+    When they drop it into Settings → Import
+    Then it routes through the existing OPML parser (feature 012)
+    And folder structure is preserved
+
+  Scenario: New user from a shutdown
+    Given a new user opens FeedZero for the first time
+    When they see the onboarding welcome step
+    Then they see "Coming from Pocket, Omnivore, or TT-RSS? Import after setup."
+
+  Scenario: Unknown format
+    Given the user pastes content that doesn't match any specific parser
+    When they click Import
+    Then the URL-list fallback parses one URL per line
+    And invalid lines are silently skipped
+```
+
+## Architecture
+
+### Dispatch order
+
+`ImportView.extractEntries` ([`src/components/settings/import-view.tsx`](../../src/components/settings/import-view.tsx))
+runs detectors in specific-to-general order so a CSV / JSON payload
+can't be misread as a plain URL list and silently produce garbage:
+
+1. `isPocketCsvExport` — header row has `url` + `time_added`.
+2. `isOmnivoreExport` — JSON parses to an object/array with `savedAt` + a URL field.
+3. `isPocketExport` — HTML with `time_added=` anchors or `<title>Pocket Export</title>`.
+4. `isOpmlFormat` — `<?xml` or `<opml` prefix.
+5. `parseUrlList` — fallback, one URL per line.
+
+### Why origins, not articles
+
+Each parser returns **unique site origins** (`scheme://host`), not the
+saved article URLs. RSS readers don't have queues. A user who saved
+200 NYT articles wanted to follow NYT, not re-save 200 articles.
+Origins flow through `addFeedFlow` ([`src/core/feeds/feed-service.ts`](../../src/core/feeds/feed-service.ts))
+which discovers the RSS feed for each site.
+
+### Files
+
+| File | Role |
+|------|------|
+| `src/core/opml/pocket-parser.ts` | Pocket HTML + CSV parsers, format detection |
+| `src/core/opml/omnivore-parser.ts` | Omnivore JSON parser, format detection |
+| `src/core/opml/opml-service.ts` | OPML (TT-RSS export path) — feature 012 |
+| `src/core/opml/url-list-parser.ts` | URL-list fallback |
+| `src/components/settings/import-view.tsx` | Dispatcher + dropzone copy + file `accept` |
+| `src/components/onboarding/steps/welcome-step.tsx` | "Coming from…" hint |
+| `docs/marketing/pocket-migration.md` | Landing page copy |
+| `docs/marketing/omnivore-migration.md` | Landing page copy |
+| `docs/marketing/tt-rss-migration.md` | Landing page copy |
+| `docs/marketing/LANDING_PROMPT.md` | Prompt for the feedzero-landing repo agent |
+
+### Tests
+
+| File | Coverage |
+|------|----------|
+| `tests/core/opml/pocket-parser.test.ts` | HTML + CSV happy paths, edge cases, detection |
+| `tests/core/opml/omnivore-parser.test.ts` | JSON shapes (array, single, url vs originalUrl), detection |
+| `tests/core/opml/url-list-parser.test.ts` | Fallback parser, OPML detection (feature 012) |
+| `tests/core/opml/opml-service.test.ts` | OPML round-trip (feature 012) |
+| `tests/components/settings/import-view-formats.test.tsx` | Dispatcher routes CSV + JSON correctly |
+| `tests/components/onboarding/welcome-step.test.tsx` | Welcome step names Pocket / Omnivore / TT-RSS |
+
+## Design Decisions
+
+- **Origins, not articles.** Every parser collapses saved URLs to
+  unique `scheme://host` origins. RSS readers subscribe to sources,
+  not queues — this mental model needs to win at the parser boundary
+  or the whole UX inherits a Pocket-shaped mismatch.
+- **Detection runs specific-first.** A CSV with a Pocket header would
+  pass `parseUrlList` and silently dedupe to zero valid URLs. So the
+  CSV / JSON / HTML / OPML detectors run before the URL-list fallback.
+- **Pocket CSV ships best-effort.** Pocket shut down; there's no live
+  endpoint to smoke-test against. The parser follows the documented
+  `title, url, time_added, tags, status` columns and ignores anything
+  else.
+- **No ZIP unpacking.** Omnivore shipped a ZIP containing
+  `metadata.json` + `content/*.md`. We accept the `metadata.json`
+  file directly and trust the user to extract it. Adding JSZip would
+  be a 100KB dependency for a one-shot import flow.
+- **Welcome-step hint is text-only.** A button on the welcome step
+  would force a navigation decision before the user has a passphrase.
+  A one-line hint that mentions the formats achieves the
+  discoverability goal at zero risk.
+- **Landing pages live in a separate repo.** `feedzero.app` is a
+  marketing site; the app is the React PWA. Landing-page copy lives
+  in `docs/marketing/` in this repo (drafts), is deployed via the
+  prompt in `LANDING_PROMPT.md`. Shipping order matters per the
+  CLAUDE.md "Landing/feedzero contract changes are serialized" rule:
+  the landing pages can ship before this commit lands without
+  breaking anything, but the in-app imports must work before users
+  click through.
+
+## Limitations
+
+- **Artifact has no public export format.** Refugees from Artifact
+  (shut down 2024-01) can rebuild their reading list from memory or
+  paste a URL list, but there's no automated path.
+- **Feedly's full export** (active-competitor defection) is not yet a
+  one-click path. Feedly exports OPML cleanly so it already works via
+  the OPML route; a dedicated landing page is a follow-up.
+- **Read state doesn't import** for any source. RSS readers don't
+  have universal read-state import; users start with everything
+  unread and can mark-all-as-read on day one.
+- **Pocket CSV parser is single-line-per-row.** Pocket exports don't
+  embed newlines inside quoted cells in practice, so the parser
+  doesn't span them. If a malformed export does, those rows drop.

--- a/docs/marketing/LANDING_PROMPT.md
+++ b/docs/marketing/LANDING_PROMPT.md
@@ -1,0 +1,133 @@
+# Landing-repo prompt — Shutdown migration pages
+
+This is a self-contained brief for a Claude Code agent working in the
+**`feedzero-landing`** repo (the marketing site at `feedzero.app`).
+The in-app side (parsers, dispatcher, onboarding hint) lives in the
+`feedzero` repo and is already shipped — see
+[`docs/features/021-shutdown-migrations.md`](../features/021-shutdown-migrations.md).
+
+**How to use:** paste everything below the line into a fresh agent
+session opened against `feedzero-landing`. Adjust the raw GitHub URLs
+if the migration markdown files have moved.
+
+---
+
+## Task
+
+Deploy three migration landing pages and one homepage entry that
+together absorb refugees from the four shutdown competitors of the
+last 19 months (Pocket, Omnivore, Tiny Tiny RSS, Artifact).
+
+The in-app FeedZero now handles their export formats — see the
+in-app feature spec at:
+https://raw.githubusercontent.com/forcingfx/feedzero/main/docs/features/021-shutdown-migrations.md
+
+The source-of-truth copy for each landing page lives in the `feedzero`
+repo at `docs/marketing/`. Fetch each markdown file via raw GitHub
+URL and render its body as the page content. Front-matter feeds the
+page title, meta description, and OG / Twitter Card metadata.
+
+### Sources
+
+- **Pocket** (shut down 2025-11-12, ~millions of users displaced):
+  https://raw.githubusercontent.com/forcingfx/feedzero/main/docs/marketing/pocket-migration.md
+- **Omnivore** (shut down 2024-11-15, team acquihired by ElevenLabs):
+  https://raw.githubusercontent.com/forcingfx/feedzero/main/docs/marketing/omnivore-migration.md
+- **TT-RSS** (original retired 2025-11-01, community fork on GitHub):
+  https://raw.githubusercontent.com/forcingfx/feedzero/main/docs/marketing/tt-rss-migration.md
+
+Each markdown file has YAML front-matter with `slug`, `title`,
+`description`, and `intended_url`. Use `slug` as the route
+(`/pocket`, `/omnivore`, `/tt-rss`).
+
+### Deliverables
+
+1. **Three routes**, one per source, at `/pocket`, `/omnivore`,
+   `/tt-rss`. Each route renders the corresponding markdown body
+   through the site's existing markdown renderer. If the site has no
+   markdown renderer yet, use `marked` + DOMPurify (the same combo
+   the FeedZero app uses) so a malicious link in the source markdown
+   can't escape.
+
+2. **Page metadata** generated from front-matter:
+   - `<title>` from `title`.
+   - `<meta name="description" content="…">` from `description`.
+   - Open Graph: `og:title`, `og:description`, `og:url`
+     (from `intended_url`), `og:type=article`.
+   - Twitter Card: `twitter:card=summary`, `twitter:title`,
+     `twitter:description`.
+   - No `og:image` unless the site already has a generic FeedZero
+     share image to point at.
+
+3. **Homepage "Coming from…" panel.** A small section on the
+   homepage (below the hero, above the fold on desktop) listing the
+   three migration paths with one-line teasers and links to the
+   pages. Visual weight: smaller than the primary CTA, larger than
+   the footer. Suggested copy:
+
+   > Coming from a shutdown?
+   > - **Pocket** shut down 2025-11. [Where to land →](/pocket)
+   > - **Omnivore** shut down 2024-11. [Where to land →](/omnivore)
+   > - **TT-RSS** maintainer walked away 2025-11. [Where to land →](/tt-rss)
+
+   Match the site's existing typography / spacing tokens; don't
+   introduce new design tokens for this panel.
+
+4. **Update sitemap.xml** (or whatever the site's equivalent is) to
+   include the three new routes so search engines pick them up.
+
+5. **Build verification.** Run the site's build + lint + type-check
+   commands. The site's `CLAUDE.md` (if any) is your spec for those.
+
+### What NOT to do
+
+- **No analytics, no tracking pixels, no third-party scripts.** The
+  FeedZero brand is built on no-telemetry; the landing site has to
+  honor that. If the site already ships with an analytics script,
+  ensure these pages are excluded — and raise it with the user.
+- **No new dependencies beyond what the site already uses.** The
+  markdown renderer and metadata helpers are the only new code
+  paths; everything else reuses existing layout components.
+- **Don't inline the source markdown.** Fetch from the raw GitHub
+  URLs (or commit a snapshot via the build step). The point of
+  keeping the copy in the feedzero repo is that strategy refreshes
+  rewrite it — the landing site picks up the next version on next
+  build.
+- **Don't add JS-only fancy interactions.** These pages are read
+  once by people who already chose us; prerendered HTML + the site's
+  default CSS is the right shape.
+- **Don't add a "fourth shutdown" entry for Artifact.** Artifact
+  shut down 2024-01 but had no public export format — there's no
+  migration path to document, only a strategy bullet.
+
+### Acceptance criteria
+
+- [ ] `/pocket`, `/omnivore`, `/tt-rss` render with the correct body
+      content and matching `<title>` / `<meta description>`.
+- [ ] OG + Twitter Card metadata validate against
+      https://www.opengraph.xyz / Twitter's card validator.
+- [ ] Homepage panel is visible and links work.
+- [ ] `sitemap.xml` includes the three new URLs.
+- [ ] Build is green; no new dependencies; no telemetry added.
+- [ ] After deploy, the in-app onboarding welcome step's hint
+      ("Coming from Pocket, Omnivore, or TT-RSS?") points to a real
+      page if a user navigates to `/pocket` etc. from any link —
+      verify by clicking through.
+
+### After shipping
+
+Mark the deployment boxes in
+https://raw.githubusercontent.com/forcingfx/feedzero/main/docs/marketing/TODO.md
+as done (via a PR to that repo, or hand the diff to the user).
+
+The campaign-distribution checklist in the same TODO is **manual
+human work** — not your task. Don't post to Reddit / HN / lobste.rs
+yourself; surface the channel list to the user.
+
+### Ship order reminder
+
+Per the `feedzero` CLAUDE.md "Landing/feedzero contract changes are
+serialized" rule: the in-app changes shipped first. Deploying these
+pages now is the second half, and is non-blocking — the in-app
+imports work standalone. After deploy, the next FeedZero release
+will reference these pages in its changelog.

--- a/docs/marketing/TODO.md
+++ b/docs/marketing/TODO.md
@@ -2,6 +2,11 @@
 
 Status: copy drafted, deployment + campaigns not yet executed. This file tracks the work that has to happen *outside* this repo before the migration story actually lands.
 
+> **For the landing-repo agent**: a self-contained brief is at
+> [`LANDING_PROMPT.md`](./LANDING_PROMPT.md). Paste it into a fresh
+> Claude Code session opened against the `feedzero-landing` repo to
+> ship the three pages + homepage panel below.
+
 ## Per-page deployment
 
 The landing pages live as markdown here. The actual landing site (`feedzero.app`) is a separate repo. Each page below needs:

--- a/src/components/onboarding/steps/welcome-step.tsx
+++ b/src/components/onboarding/steps/welcome-step.tsx
@@ -62,6 +62,11 @@ export function WelcomeStep() {
         sync is experimental.
       </div>
 
+      <p className="text-center text-xs text-muted-foreground">
+        Coming from Pocket, Omnivore, or TT-RSS? Import your export after
+        setup.
+      </p>
+
       <DialogFooter className="sm:justify-center sm:flex-col sm:gap-2">
         <Button size="lg" onClick={() => setStep("storage-choice")} autoFocus>
           Get Started

--- a/src/components/settings/import-view.tsx
+++ b/src/components/settings/import-view.tsx
@@ -5,7 +5,16 @@ import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { parseOpmlFile } from "@/core/opml/opml-service";
 import { parseUrlList, isOpmlFormat } from "@/core/opml/url-list-parser";
-import { parsePocketExport, isPocketExport } from "@/core/opml/pocket-parser";
+import {
+  parsePocketExport,
+  isPocketExport,
+  parsePocketCsvExport,
+  isPocketCsvExport,
+} from "@/core/opml/pocket-parser";
+import {
+  parseOmnivoreExport,
+  isOmnivoreExport,
+} from "@/core/opml/omnivore-parser";
 import {
   useImportStore,
   selectTotalCount,
@@ -67,17 +76,28 @@ export function ImportView({ onClose }: ImportViewProps) {
 
   /**
    * Parse the import content into rich entries that carry folder context.
-   * URL-list and Pocket-export imports always have folderName=undefined;
-   * OPML imports carry the parent group name when one exists (PR E).
+   * Shutdown-migration formats (Pocket HTML, Pocket CSV, Omnivore JSON)
+   * have folderName=undefined; OPML imports carry the parent group name
+   * when one exists (PR E).
    *
-   * Pocket-export detection runs first because the Pocket HTML neither
-   * looks like OPML nor like a URL list — without explicit dispatch we'd
-   * silently get garbage out of parseUrlList.
+   * Specific-format detection runs before the URL-list fallback because
+   * each format would otherwise be misread as a URL list and silently
+   * produce garbage.
    */
   const extractEntries = useCallback(
     async (
       content: string,
     ): Promise<Array<{ xmlUrl: string; folderName?: string }>> => {
+      if (isPocketCsvExport(content)) {
+        const result = parsePocketCsvExport(content);
+        if (!result.ok) throw new Error(result.error);
+        return result.value.map((url) => ({ xmlUrl: url }));
+      }
+      if (isOmnivoreExport(content)) {
+        const result = parseOmnivoreExport(content);
+        if (!result.ok) throw new Error(result.error);
+        return result.value.map((url) => ({ xmlUrl: url }));
+      }
       if (isPocketExport(content)) {
         const result = parsePocketExport(content);
         if (!result.ok) throw new Error(result.error);
@@ -329,7 +349,7 @@ export function ImportView({ onClose }: ImportViewProps) {
           <input
             ref={fileInputRef}
             type="file"
-            accept=".opml,.xml,.html,.htm"
+            accept=".opml,.xml,.html,.htm,.csv,.json"
             onChange={handleFileSelect}
             className="hidden"
           />
@@ -352,7 +372,7 @@ export function ImportView({ onClose }: ImportViewProps) {
             <>
               <Upload className="mb-2 size-8 text-muted-foreground" />
               <p className="text-sm text-muted-foreground">
-                Drag and drop an OPML or Pocket export, or
+                Drag and drop an OPML, Pocket, or Omnivore export, or
               </p>
               <Button
                 variant="link"
@@ -362,7 +382,7 @@ export function ImportView({ onClose }: ImportViewProps) {
                 browse to select
               </Button>
               <p className="mt-2 text-xs text-muted-foreground/70">
-                .opml, .xml, .html
+                .opml, .xml, .html, .csv, .json
               </p>
             </>
           )}
@@ -371,7 +391,7 @@ export function ImportView({ onClose }: ImportViewProps) {
 
       {inputMode === "text" && (
         <Textarea
-          placeholder="Paste OPML XML, Pocket HTML export, or feed URLs (one per line)"
+          placeholder="Paste OPML XML, Pocket HTML/CSV, Omnivore JSON, or feed URLs (one per line)"
           value={textInput}
           onChange={(e) => {
             setTextInput(e.target.value);

--- a/src/core/opml/omnivore-parser.ts
+++ b/src/core/opml/omnivore-parser.ts
@@ -1,0 +1,97 @@
+import { ok, err } from "../../utils/result.ts";
+import type { Result } from "../../utils/result.ts";
+
+/**
+ * Parser for Omnivore's "Export Library" JSON. Omnivore shipped a ZIP
+ * containing a top-level `metadata.json` index (an array of article
+ * objects) plus per-article JSON + markdown content under `content/`.
+ *
+ * Like the Pocket parser, FeedZero doesn't import individual articles
+ * as subscriptions — it extracts the unique source origins and runs
+ * each through addFeedFlow, which discovers an RSS feed per site.
+ *
+ * Omnivore shut down 2024-11-15, so the format is historically frozen.
+ */
+
+interface OmnivoreEntry {
+  url?: unknown;
+  originalUrl?: unknown;
+  savedAt?: unknown;
+}
+
+/**
+ * Detect an Omnivore export. Heuristic: JSON parses to either an array
+ * of objects or a single object, where at least one object has both a
+ * URL field (`url` or `originalUrl`) and a `savedAt` field. The
+ * `savedAt` field is what distinguishes an Omnivore export from a
+ * generic JSON array of links — plain URL arrays don't carry it.
+ */
+export function isOmnivoreExport(text: string): boolean {
+  if (!text || typeof text !== "string" || !text.trim()) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return false;
+  }
+  const entries = toEntries(parsed);
+  return entries.some(
+    (e) => e !== null && typeof e === "object" && "savedAt" in e && !!pickUrl(e),
+  );
+}
+
+/**
+ * Extract unique origin URLs from an Omnivore export. Returns origins
+ * sorted alphabetically for deterministic output.
+ */
+export function parseOmnivoreExport(text: string): Result<string[]> {
+  if (!text || typeof text !== "string" || !text.trim()) {
+    return err("Input is empty");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (e) {
+    return err(`Failed to parse Omnivore JSON: ${(e as Error).message}`);
+  }
+
+  const entries = toEntries(parsed);
+  const origins = new Set<string>();
+  for (const entry of entries) {
+    const href = pickUrl(entry);
+    if (!href) continue;
+    const origin = toOrigin(href);
+    if (origin) origins.add(origin);
+  }
+
+  if (origins.size === 0) {
+    return err("No valid http(s) URL fields found in Omnivore export");
+  }
+
+  return ok(Array.from(origins).sort());
+}
+
+function toEntries(parsed: unknown): OmnivoreEntry[] {
+  if (Array.isArray(parsed)) return parsed as OmnivoreEntry[];
+  if (parsed !== null && typeof parsed === "object")
+    return [parsed as OmnivoreEntry];
+  return [];
+}
+
+function pickUrl(entry: OmnivoreEntry): string | null {
+  if (typeof entry.url === "string" && entry.url.trim()) return entry.url;
+  if (typeof entry.originalUrl === "string" && entry.originalUrl.trim())
+    return entry.originalUrl;
+  return null;
+}
+
+function toOrigin(href: string): string | null {
+  try {
+    const url = new URL(href);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/core/opml/pocket-parser.ts
+++ b/src/core/opml/pocket-parser.ts
@@ -80,3 +80,89 @@ function toOrigin(href: string): string | null {
     return null;
   }
 }
+
+/**
+ * Detect a Pocket CSV export. Late-stage Pocket exports were CSV with a
+ * `title, url, time_added, tags, status` header (order varied by tool).
+ * Heuristic: a header row whose lowercased columns include both `url`
+ * and `time_added` — the latter is Pocket-specific and not standard CSV.
+ */
+export function isPocketCsvExport(text: string): boolean {
+  if (!text) return false;
+  const firstLine = text.slice(0, 2048).split(/\r?\n/, 1)[0];
+  if (!firstLine) return false;
+  const columns = parseCsvRow(firstLine).map((c) => c.trim().toLowerCase());
+  return columns.includes("url") && columns.includes("time_added");
+}
+
+/**
+ * Extract unique origin URLs from a Pocket CSV export. Returns origins
+ * sorted alphabetically for deterministic output.
+ *
+ * The CSV is best-effort: Pocket's late-stage export tool produced
+ * standard RFC 4180-ish CSV with quoted fields. We handle quoted and
+ * unquoted columns, embedded commas inside quotes, and skip the header.
+ */
+export function parsePocketCsvExport(text: string): Result<string[]> {
+  if (!text || typeof text !== "string" || !text.trim()) {
+    return err("Input is empty");
+  }
+
+  const lines = text.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length < 1) return err("Input is empty");
+
+  const header = parseCsvRow(lines[0]).map((c) => c.trim().toLowerCase());
+  const urlIdx = header.indexOf("url");
+  if (urlIdx === -1) {
+    return err("Pocket CSV is missing the 'url' header column");
+  }
+
+  const origins = new Set<string>();
+  for (let i = 1; i < lines.length; i++) {
+    const cells = parseCsvRow(lines[i]);
+    const href = cells[urlIdx]?.trim();
+    if (!href) continue;
+    const origin = toOrigin(href);
+    if (origin) origins.add(origin);
+  }
+
+  if (origins.size === 0) {
+    return err("No valid http(s) URLs found in Pocket CSV export");
+  }
+
+  return ok(Array.from(origins).sort());
+}
+
+/**
+ * Minimal RFC 4180-ish CSV row parser: handles quoted fields, embedded
+ * commas inside quotes, and the "" escape for a literal quote. Doesn't
+ * span newlines because Pocket exports don't embed them — keeping it
+ * line-by-line means we can stream through `split(/\r?\n/)`.
+ */
+function parseCsvRow(row: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < row.length; i++) {
+    const ch = row[i];
+    if (inQuotes) {
+      if (ch === '"' && row[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ",") {
+      cells.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  cells.push(current);
+  return cells;
+}

--- a/tests/components/onboarding/welcome-step.test.tsx
+++ b/tests/components/onboarding/welcome-step.test.tsx
@@ -96,4 +96,14 @@ describe("WelcomeStep", () => {
     );
     expect(useOnboardingStore.getState().step).toBe("recovery");
   });
+
+  it("surfaces a migration hint naming Pocket, Omnivore, and TT-RSS", () => {
+    // Refugees from category-wide shutdowns (Pocket 2025-11, Omnivore
+    // 2024-11, TT-RSS 2025-11) need to see the product recognises their
+    // export type before they invest in setup. See strategy 001 + 003 §2.
+    renderInDialog(<WelcomeStep />);
+    expect(screen.getByText(/pocket/i)).toBeInTheDocument();
+    expect(screen.getByText(/omnivore/i)).toBeInTheDocument();
+    expect(screen.getByText(/tt-rss/i)).toBeInTheDocument();
+  });
 });

--- a/tests/components/settings/import-view-formats.test.tsx
+++ b/tests/components/settings/import-view-formats.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * ImportView — dispatcher coverage for the shutdown-migration formats:
+ * Pocket CSV, Omnivore JSON. The HTML Pocket export + OPML + URL list
+ * paths are covered by neighbouring tests (placeholder, folders).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImportView } from "@/components/settings/import-view";
+import { useFeedStore } from "@/stores/feed-store";
+import { useLicenseStore } from "@/stores/license-store";
+import { useImportStore } from "@/stores/import-store";
+
+vi.mock("@/core/features/self-hosted", () => ({
+  isSelfHosted: vi.fn(() => false),
+}));
+vi.mock("@/core/features/paid-tier-active", () => ({
+  isPaidTierActive: vi.fn(() => true),
+}));
+
+describe("ImportView — shutdown-migration formats", () => {
+  let addFeedMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    useLicenseStore.setState({ tier: "personal", verifying: false });
+    addFeedMock = vi.fn().mockResolvedValue({ ok: true });
+    useFeedStore.setState({
+      feeds: [],
+      folders: [],
+      addFeed: addFeedMock,
+      createFolder: vi.fn(),
+      moveFeedToFolder: vi.fn(),
+    } as never);
+    useImportStore.getState().reset();
+  });
+
+  it("dispatches a Pocket CSV paste through parsePocketCsvExport", async () => {
+    const user = userEvent.setup();
+    render(<ImportView onClose={() => {}} />);
+
+    const csv = `title,url,time_added,tags,status
+"NYT","https://www.nytimes.com/a","1","","unread"
+"Guardian","https://www.theguardian.com/x","2","","archive"
+"Another NYT","https://www.nytimes.com/b","3","","unread"`;
+
+    await user.click(screen.getByLabelText(/paste text/i));
+    const textarea = screen.getByPlaceholderText(/paste opml/i);
+    await user.click(textarea);
+    await user.paste(csv);
+    await user.click(screen.getByRole("button", { name: /import feeds/i }));
+
+    // Two unique origins: nytimes.com (dedup'd) + theguardian.com
+    expect(addFeedMock).toHaveBeenCalledTimes(2);
+    const urls = addFeedMock.mock.calls.map((c) => c[0]).sort();
+    expect(urls).toEqual([
+      "https://www.nytimes.com",
+      "https://www.theguardian.com",
+    ]);
+  });
+
+  it("dispatches an Omnivore JSON paste through parseOmnivoreExport", async () => {
+    const user = userEvent.setup();
+    render(<ImportView onClose={() => {}} />);
+
+    const json = JSON.stringify([
+      { url: "https://www.nytimes.com/a", savedAt: "2024-04-01" },
+      { url: "https://www.theguardian.com/x", savedAt: "2024-04-02" },
+      { url: "https://www.nytimes.com/b", savedAt: "2024-04-03" },
+    ]);
+
+    await user.click(screen.getByLabelText(/paste text/i));
+    const textarea = screen.getByPlaceholderText(/paste opml/i);
+    await user.click(textarea);
+    await user.paste(json);
+    await user.click(screen.getByRole("button", { name: /import feeds/i }));
+
+    expect(addFeedMock).toHaveBeenCalledTimes(2);
+    const urls = addFeedMock.mock.calls.map((c) => c[0]).sort();
+    expect(urls).toEqual([
+      "https://www.nytimes.com",
+      "https://www.theguardian.com",
+    ]);
+  });
+
+  it("mentions the supported migration formats in the dropzone copy", () => {
+    render(<ImportView onClose={() => {}} />);
+    // Specific shutdowns named in the dropzone so refugees recognise
+    // their export's source.
+    expect(screen.getByText(/pocket/i)).toBeInTheDocument();
+    expect(screen.getByText(/omnivore/i)).toBeInTheDocument();
+  });
+
+  it("accepts CSV and JSON file extensions on the file input", () => {
+    const { container } = render(<ImportView onClose={() => {}} />);
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement | null;
+    expect(fileInput).not.toBeNull();
+    const accept = fileInput?.accept ?? "";
+    expect(accept).toContain(".csv");
+    expect(accept).toContain(".json");
+  });
+});

--- a/tests/core/opml/omnivore-parser.test.ts
+++ b/tests/core/opml/omnivore-parser.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseOmnivoreExport,
+  isOmnivoreExport,
+} from "../../../src/core/opml/omnivore-parser.ts";
+
+/**
+ * Omnivore's "Export Library" produced a ZIP containing per-article JSON
+ * files plus a `metadata.json` index. The index is an array of objects
+ * with at least a `url` or `originalUrl` field per article. We accept
+ * either the metadata.json index, an individual article JSON, or an
+ * array of either — and walk the structure looking for URL fields.
+ *
+ * Format is documented; Omnivore is shut down so it is frozen.
+ */
+
+const SAMPLE_OMNIVORE_METADATA = JSON.stringify([
+  {
+    id: "abc-1",
+    slug: "nyt-piece",
+    title: "An NYT piece",
+    url: "https://www.nytimes.com/2024/04/01/world/example.html",
+    savedAt: "2024-04-01T12:00:00Z",
+  },
+  {
+    id: "abc-2",
+    slug: "guardian-piece",
+    title: "A Guardian piece",
+    url: "https://www.theguardian.com/article-1",
+    savedAt: "2024-04-02T12:00:00Z",
+  },
+  {
+    id: "abc-3",
+    slug: "another-nyt",
+    title: "Another NYT piece",
+    url: "https://www.nytimes.com/2024/04/03/world/another.html",
+    savedAt: "2024-04-03T12:00:00Z",
+  },
+]);
+
+describe("isOmnivoreExport", () => {
+  it("recognises a metadata.json array with url + savedAt fields", () => {
+    expect(isOmnivoreExport(SAMPLE_OMNIVORE_METADATA)).toBe(true);
+  });
+
+  it("recognises a single article JSON with the Omnivore shape", () => {
+    const single = JSON.stringify({
+      id: "abc-1",
+      slug: "x",
+      url: "https://example.com/a",
+      savedAt: "2024-01-01T00:00:00Z",
+    });
+    expect(isOmnivoreExport(single)).toBe(true);
+  });
+
+  it("rejects an array of plain URL strings (URL-list format)", () => {
+    expect(isOmnivoreExport('["https://a.com", "https://b.com"]')).toBe(false);
+  });
+
+  it("rejects non-JSON input", () => {
+    expect(isOmnivoreExport("<html></html>")).toBe(false);
+    expect(isOmnivoreExport("https://example.com")).toBe(false);
+  });
+
+  it("rejects empty input", () => {
+    expect(isOmnivoreExport("")).toBe(false);
+  });
+});
+
+describe("parseOmnivoreExport", () => {
+  it("extracts unique origins from an Omnivore metadata array", () => {
+    const result = parseOmnivoreExport(SAMPLE_OMNIVORE_METADATA);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([
+      "https://www.nytimes.com",
+      "https://www.theguardian.com",
+    ]);
+  });
+
+  it("falls back to originalUrl when url is absent", () => {
+    const json = JSON.stringify([
+      { originalUrl: "https://example.com/a", savedAt: "2024-01-01" },
+      { originalUrl: "https://example.com/b", savedAt: "2024-01-02" },
+    ]);
+    const result = parseOmnivoreExport(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(["https://example.com"]);
+  });
+
+  it("accepts a single article JSON object", () => {
+    const single = JSON.stringify({
+      url: "https://example.com/article",
+      savedAt: "2024-01-01",
+    });
+    const result = parseOmnivoreExport(single);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(["https://example.com"]);
+  });
+
+  it("preserves subdomains as distinct origins", () => {
+    const json = JSON.stringify([
+      { url: "https://blog.example.com/a" },
+      { url: "https://example.com/b" },
+    ]);
+    const result = parseOmnivoreExport(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toContain("https://blog.example.com");
+    expect(result.value).toContain("https://example.com");
+  });
+
+  it("skips non-http(s) URLs", () => {
+    const json = JSON.stringify([
+      { url: "javascript:void(0)" },
+      { url: "mailto:foo@bar.com" },
+      { url: "https://example.com/article" },
+    ]);
+    const result = parseOmnivoreExport(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(["https://example.com"]);
+  });
+
+  it("returns err on empty input", () => {
+    const result = parseOmnivoreExport("");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/empty/i);
+  });
+
+  it("returns err on invalid JSON", () => {
+    const result = parseOmnivoreExport("not json");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/parse|json/i);
+  });
+
+  it("returns err when no URL fields are found", () => {
+    const result = parseOmnivoreExport(
+      JSON.stringify([{ title: "no url field here" }]),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/no .* url/i);
+  });
+});

--- a/tests/core/opml/pocket-parser.test.ts
+++ b/tests/core/opml/pocket-parser.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   parsePocketExport,
   isPocketExport,
+  parsePocketCsvExport,
+  isPocketCsvExport,
 } from "../../../src/core/opml/pocket-parser.ts";
 
 const SAMPLE_POCKET_HTML = `<!DOCTYPE html>
@@ -97,6 +99,101 @@ describe("parsePocketExport", () => {
     const result = parsePocketExport(
       '<a href="mailto:a@b.com">x</a><a href="javascript:1">y</a>',
     );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/no valid http/i);
+  });
+});
+
+const SAMPLE_POCKET_CSV = `title,url,time_added,tags,status
+"NYT Article","https://www.nytimes.com/2024/04/01/world/example.html","1712000000","","unread"
+"Guardian Article","https://www.theguardian.com/article-1","1712010000","politics","archive"
+"Another NYT","https://www.nytimes.com/2024/04/02/world/another.html","1712020000","","unread"
+"Subdomain Substack","https://writer.substack.com/p/post","1712030000","newsletter","archive"`;
+
+describe("isPocketCsvExport", () => {
+  it("recognises a CSV with the Pocket header row", () => {
+    expect(isPocketCsvExport(SAMPLE_POCKET_CSV)).toBe(true);
+  });
+
+  it("recognises the header even when columns are in different order", () => {
+    const csv = `url,title,time_added,tags,status
+"https://example.com","Title","1","","unread"`;
+    expect(isPocketCsvExport(csv)).toBe(true);
+  });
+
+  it("rejects a plain URL-list file (no header)", () => {
+    expect(isPocketCsvExport("https://a.com\nhttps://b.com")).toBe(false);
+  });
+
+  it("rejects a CSV that lacks the canonical url + time_added columns", () => {
+    const generic = `name,email\n"Alice","a@b.com"`;
+    expect(isPocketCsvExport(generic)).toBe(false);
+  });
+
+  it("rejects HTML input", () => {
+    expect(isPocketCsvExport("<html></html>")).toBe(false);
+  });
+
+  it("rejects empty input", () => {
+    expect(isPocketCsvExport("")).toBe(false);
+  });
+});
+
+describe("parsePocketCsvExport", () => {
+  it("extracts unique origins from a Pocket CSV export", () => {
+    const result = parsePocketCsvExport(SAMPLE_POCKET_CSV);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([
+      "https://writer.substack.com",
+      "https://www.nytimes.com",
+      "https://www.theguardian.com",
+    ]);
+  });
+
+  it("locates the url column by header name regardless of column order", () => {
+    const csv = `tags,status,url,title,time_added
+"","unread","https://example.com/a","A","1"
+"","archive","https://other.com/b","B","2"`;
+    const result = parsePocketCsvExport(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([
+      "https://example.com",
+      "https://other.com",
+    ]);
+  });
+
+  it("skips rows where the url column is empty", () => {
+    const csv = `title,url,time_added,tags,status
+"A","","1","","unread"
+"B","https://example.com/x","2","","unread"`;
+    const result = parsePocketCsvExport(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(["https://example.com"]);
+  });
+
+  it("returns err on empty input", () => {
+    const result = parsePocketCsvExport("");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/empty/i);
+  });
+
+  it("returns err when the url header is missing", () => {
+    const result = parsePocketCsvExport(`title,added\n"A","1"`);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/url column|header/i);
+  });
+
+  it("returns err when every row's url is non-http(s)", () => {
+    const csv = `title,url,time_added
+"A","mailto:a@b.com","1"
+"B","javascript:1","2"`;
+    const result = parsePocketCsvExport(csv);
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toMatch(/no valid http/i);


### PR DESCRIPTION
Adds parsePomnivoreExport / isOmnivoreExport for the Omnivore "Export
Library" JSON. Like the Pocket parser, this extracts unique site
origins and lets addFeedFlow do RSS discovery per origin — Omnivore's
article queue itself doesn't import because RSS readers don't have
queues. Accepts the metadata.json index array, a single article JSON,
or an array of either.

Closes the Omnivore TODO in docs/strategy/003-playing-to-win.md §2.
Omnivore shut down 2024-11-15 so the format is historically frozen.

Files:
- src/core/opml/omnivore-parser.ts (new)
- tests/core/opml/omnivore-parser.test.ts (new, 13 tests)