### PR TITLE
fix(boot): time out the sync pull so a hung /api/sync stops blocking isDbReady

### DIFF
--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -5,7 +5,7 @@ import {
   destroy,
 } from "../core/storage/key-manager.ts";
 import { dedupeArticles } from "../core/storage/db.ts";
-import { LOCAL_STORAGE } from "../utils/constants.ts";
+import { BOOT_PULL_TIMEOUT_MS, LOCAL_STORAGE } from "../utils/constants.ts";
 import { useSyncStore } from "./sync-store.ts";
 import { usePreferencesStore } from "./preferences-store.ts";
 import { persistPreferences } from "./persist-preferences.ts";
@@ -107,6 +107,43 @@ async function runDedupeMigrationOnce(): Promise<void> {
   }
 }
 
+/**
+ * Race the sync pull against a watchdog. Resolves either when the pull
+ * settles or when `BOOT_PULL_TIMEOUT_MS` elapses, whichever comes first.
+ * Returning early on timeout lets boot proceed with the local DB; the
+ * pull stays in-flight in the background and `useSyncStore.pull()`'s
+ * own `inFlightPull` dedup means a downstream `refreshAll()` will await
+ * the same promise rather than firing a second pull.
+ *
+ * Background completion triggers a `loadFeeds` so the sidebar reflects
+ * any data the pull eventually imported. Only fires when the pull
+ * actually finishes — if it never does, the background side stays a
+ * pending promise (which the runtime GCs on tab close).
+ */
+async function pullWithBootWatchdog(): Promise<void> {
+  const pull = useSyncStore.getState().pull();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const watchdog = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), BOOT_PULL_TIMEOUT_MS);
+  });
+  const outcome = await Promise.race([pull.then(() => "settled" as const), watchdog]);
+  if (timer !== undefined) clearTimeout(timer);
+  if (outcome === "timeout") {
+    // Best-effort: if the pull eventually completes after we've given up
+    // on it, refresh the in-memory feed list so the UI catches up to the
+    // imported vault. Failures are ignored — the user can manually
+    // refresh if needed.
+    void pull
+      .then(async () => {
+        const { useFeedStore } = await import("./feed-store.ts");
+        await useFeedStore.getState().loadFeeds();
+      })
+      .catch(() => {
+        /* noop — pull's own error handling already set sync status */
+      });
+  }
+}
+
 // Dedup concurrent boot-time calls. AppInit's effect 1 fires twice in
 // React StrictMode (dev), and could plausibly fire from a remount in
 // other contexts (fast refresh, suspense). Without this guard, a second
@@ -191,8 +228,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
       // clear+bulkPut sequences interleave, leaving a window where feeds
       // appear absent. See tests/e2e/sync-100-feeds.spec.ts for the
       // reproducer.
+      //
+      // BUT: a pull that never settles must not trap the user on the
+      // "Loading…" splash. Race against a watchdog timer — on timeout we
+      // proceed with the (canary-validated) local DB; the pull stays
+      // in-flight and an eventual `loadFeeds` picks up its result if it
+      // ever lands. Boot-blocks-on-network was the production hang
+      // reported here.
       if (status.isSyncUser) {
-        await useSyncStore.getState().pull();
+        await pullWithBootWatchdog();
         if (useSyncStore.getState().status !== "error") {
           useSyncStore.setState({ status: "synced", lastSyncedAt: Date.now() });
         }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -191,6 +191,20 @@ export const ARTICLE_GROUPING = {
 export const AUTO_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
 
 /**
+ * Watchdog for the boot-time sync pull. The returning-user boot path
+ * awaits a vault pull before flipping `isDbReady` so consumers see a
+ * post-importAll DB (avoiding the clear+bulkPut race documented in
+ * `tests/e2e/sync-100-feeds.spec.ts`). If the pull never settles — a
+ * stalled edge function, a connection that opens but never delivers
+ * bytes, a TLS handshake that hangs — that wait would keep the user on
+ * "Loading…" indefinitely with no escape. 10s is the upper bound on
+ * "still feels like a slow network" before we give up and proceed with
+ * the local DB. The pull continues in the background and a follow-up
+ * `loadFeeds` picks up its data if it eventually lands.
+ */
+export const BOOT_PULL_TIMEOUT_MS = 10 * 1000;
+
+/**
  * How often an open tab re-verifies the license token against the server.
  * The boot-time check (app.tsx) and cross-tab storage events catch most
  * changes, but a tab left open for days never reboots — so a lapsed

--- a/tests/stores/app-store.test.ts
+++ b/tests/stores/app-store.test.ts
@@ -294,6 +294,42 @@ describe("app-store", () => {
 
       expect(useAppStore.getState().isDbReady).toBe(true);
     });
+
+    it("still initializes when the sync pull never resolves (boot must not hang on the network)", async () => {
+      // Reproduces the production hang: a returning sync user whose
+      // /api/sync request stalls indefinitely (slow upstream, dropped
+      // connection mid-response, edge function cold-start hang). Before
+      // the boot-time pull timeout, isDbReady stayed false forever and
+      // the user was stuck on "Loading…" with no escape.
+      vi.mocked(restore).mockResolvedValue({
+        status: "ready",
+        isSyncUser: true,
+        credentials: {
+          vaultId: "vault-id",
+          vaultKey: "mock-key" as unknown as CryptoKey,
+        },
+      });
+      // pullVaultIfChanged returns a promise that never resolves.
+      vi.mocked(pullVaultIfChanged).mockReturnValue(
+        new Promise(() => {
+          /* never resolves */
+        }),
+      );
+
+      vi.useFakeTimers();
+      try {
+        const initPromise = useAppStore.getState().initializeReturningUser();
+        // Advance past the boot-time pull watchdog (BOOT_PULL_TIMEOUT_MS,
+        // currently 10s). The pull stays in-flight in the background; boot
+        // proceeds with whatever local data the canary already validated.
+        await vi.advanceTimersByTimeAsync(15_000);
+        await initPromise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(useAppStore.getState().isDbReady).toBe(true);
+    });
   });
 
   describe("resetApp", () => {


### PR DESCRIPTION
What
A returning sync user opens the app and stays trapped on the "Loading…"
splash. The screenshot in the incident report shows mobile Safari on
my.feedzero.app with no UI other than the loading text.

Why
`initializeReturningUser` awaits `useSyncStore.pull()` BEFORE flipping
`isDbReady`. That blocking await is intentional — it avoids the
clear+bulkPut race between two concurrent pulls (see
tests/e2e/sync-100-feeds.spec.ts) — but it has no upper bound on how
long it will wait. If the sync request never resolves (slow upstream,
stalled edge function, TLS handshake that opens but never delivers
bytes), boot blocks forever and the user has no escape.

The hang has been reproducible since `await useSyncStore.getState().pull()`
landed in app-store, but PR #162 (preserve unpushed local changes
across reload) widened the surface: pull() now does a `pushVault()`
flush *before* `pullVaultIfChanged()` when `SYNC_PENDING_PUSH` is set,
so two sequential network calls can hang boot instead of one. With the
current production conditions a sync user on a slow connection is
landing on this failure mode.

Fix
Race `useSyncStore.pull()` against a 10s watchdog at boot. If the pull
settles in time, behavior is identical to before (sync data lands,
status flips to "synced", isDbReady follows). If it doesn't, we proceed
to `isDbReady: true` with the canary-validated local DB; the pull stays
in flight and a deferred `loadFeeds()` picks up its result if it ever
lands. The user sees their local data immediately and the cloud catches
up in the background.

`useSyncStore.pull()` already has `inFlightPull` dedup, so a downstream
`refreshAll()` for sync users awaits the same in-flight pull rather
than firing a fresh clear+bulkPut — the original race the blocking
await was designed to prevent stays prevented.

Prevention
- `tests/stores/app-store.test.ts` adds a fake-timers test: when
  `pullVaultIfChanged` returns a never-resolving promise,
  `initializeReturningUser` still flips `isDbReady` after the watchdog
  elapses. Locks the "boot must not block forever on the network"
  invariant against future regressions.
- `BOOT_PULL_TIMEOUT_MS` lives in `src/utils/constants.ts` next to
  `AUTO_REFRESH_INTERVAL_MS` / `LICENSE_RECHECK_INTERVAL_MS` so the
  boot timeouts are visible together.