### PR TITLE
Argon2id for sync vault encryption (memory-hard KDF)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Full-text extraction (user-initiated): click "Extracted" → `/api/page` → `ex
 - **src/utils/result.ts** — `Result<T>` (`ok`/`err`) used everywhere instead of throwing. `andThen` chains; `fromPromise` wraps async.
 - **src/utils/constants.ts** — DB name, crypto params, `LOCAL_STORAGE` keys, default passphrase.
 - **src/core/storage/crypto.ts** — PBKDF2 + AES-GCM + HMAC-SHA256 via Web Crypto API.
+- **src/core/crypto/argon2.ts** — Argon2id wrapper around `hash-wasm`. Memory-hard KDF used to encrypt new sync vaults so a 4-word diceware passphrase (~51.7 bits) is no longer brute-forceable by GPU farms. Production params: 64 MiB / t=3 / p=1 (OWASP). The vault envelope stamps which KDF derived its key (`KdfSpec` in `src/core/sync/types.ts`) so recovery on a new device picks the matching derivation. Legacy PBKDF2 vaults auto-upgrade to Argon2id the first time the user types their passphrase on any device (recovery-step / switchToExistingCloud → `upgradeVaultKdf`).
 - **src/core/storage/db.ts** — Dexie storage. Content AES-GCM encrypted; index fields (url, feedId, guid) HMAC-SHA256 hashed so we can query without exposing plaintext. Call `open(passphrase)` or `openWithKeys(dbKeyJwk, hmacKeyJwk)` first.
 - **src/core/storage/key-material.ts** — `deriveAndStoreKeys`, `loadStoredKeys`, `clearStoredKeys`. Derives DB/HMAC/optional vault keys, persists JWK to localStorage. Raw passphrase is never persisted.
 - **src/core/storage/schema.ts** — `createFeed()` / `createArticle()` factories returning `Result`.
@@ -59,7 +60,7 @@ Full-text extraction (user-initiated): click "Extracted" → `/api/page` → `ex
 - **src/core/extractor/{defuddle-extractor,cleanup,markdown}.ts** — Defuddle impl; HTML cleanup; markdown→HTML via marked + DOMPurify.
 - **src/core/extractor/adapters/** — Site-specific adapters. `SiteAdapter` interface, `AdapterRegistry` (O(1) domain lookup). `github-adapter` extracts README; `default-adapter` uses Defuddle.
 - **src/core/sync/types.ts** — `VaultData`, `EncryptedVault`, `SyncStorageAdapter`.
-- **src/core/sync/vault-crypto.ts** — Deterministic `deriveVaultId` + `deriveVaultKey` via domain-separated PBKDF2; `encryptVault` / `decryptVault`.
+- **src/core/sync/vault-crypto.ts** — Deterministic `deriveVaultId` (PBKDF2, KDF-invariant by design — vault ID is a routing identifier, not a secret) + `deriveVaultKey` (dispatches on `KdfSpec`: legacy PBKDF2 or Argon2id); `encryptVault` / `decryptVault` (`encryptVault` stamps the spec on the envelope so recovery can find the matching KDF). `DEFAULT_NEW_VAULT_KDF` is Argon2id in prod, cheap params under Vitest.
 - **src/core/sync/sync-service.ts** — Client orchestrator: `exportVault`, `importVault`, `pushVault`, `pullVault`.
 - **src/core/sync/sync-handler.ts** — Shared server `Request → Response` handler. GET (pull) / PUT (push) / DELETE.
 - **src/core/sync/adapters/** — `memory`, `filesystem`, `vercel-blob`, `resolve-adapter`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "dexie": "^4.4.2",
         "dompurify": "^3.4.3",
         "feedsmith": "^2.9.4",
+        "hash-wasm": "^4.12.0",
         "hono": "^4.12.19",
         "lucide-react": "^1.16.0",
         "marked": "^17.0.1",
@@ -6475,6 +6476,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "dexie": "^4.4.2",
     "dompurify": "^3.4.3",
     "feedsmith": "^2.9.4",
+    "hash-wasm": "^4.12.0",
     "hono": "^4.12.19",
     "lucide-react": "^1.16.0",
     "marked": "^17.0.1",

--- a/src/components/onboarding/steps/recovery-step.tsx
+++ b/src/components/onboarding/steps/recovery-step.tsx
@@ -12,11 +12,12 @@ import {
 import { useOnboardingStore } from "@/stores/onboarding-store";
 import { useAppStore } from "@/stores/app-store";
 import { useSyncStore } from "@/stores/sync-store";
-import { initFresh } from "@/core/storage/key-manager";
+import { initFresh, updateStoredVaultKey } from "@/core/storage/key-manager";
 import {
   checkVaultExists,
   importVault,
   recoverVault,
+  upgradeVaultKdf,
 } from "@/core/sync/sync-service";
 
 type Phase = "idle" | "checking" | "restoring";
@@ -88,7 +89,7 @@ export function RecoveryStep() {
       return;
     }
 
-    const credentials = initResult.value.credentials;
+    let credentials = initResult.value.credentials;
 
     // 4. Import the pulled vault data and restore sync state.
     //    `initFresh` already opened a fresh DB with passphrase-derived
@@ -99,6 +100,20 @@ export function RecoveryStep() {
     //    old extra rekey call masked.
     if (credentials) {
       await importVault(vault);
+
+      // 5. Auto-upgrade the cloud envelope's KDF if it's still on the
+      //    legacy PBKDF2 spec. The decision per CLAUDE.md / migration
+      //    discussion: existing users get bumped to Argon2id the first
+      //    time they type their passphrase on a fresh device. Best-
+      //    effort — a push failure leaves the cloud at legacy, the
+      //    user keeps working with their PBKDF2 credentials, and the
+      //    next recovery attempt re-runs the upgrade.
+      const upgraded = await upgradeVaultKdf(trimmed, credentials, vault);
+      if (upgraded.ok && upgraded.value !== credentials) {
+        await updateStoredVaultKey(upgraded.value);
+        credentials = upgraded.value;
+      }
+
       useSyncStore.getState().restoreSync(credentials);
     }
 

--- a/src/components/onboarding/steps/recovery-step.tsx
+++ b/src/components/onboarding/steps/recovery-step.tsx
@@ -16,7 +16,7 @@ import { initFresh } from "@/core/storage/key-manager";
 import {
   checkVaultExists,
   importVault,
-  pullVault,
+  recoverVault,
 } from "@/core/sync/sync-service";
 
 type Phase = "idle" | "checking" | "restoring";
@@ -57,19 +57,31 @@ export function RecoveryStep() {
       return;
     }
 
-    // 2. Pull vault — vault is confirmed to exist, but pull still gates
-    //    the destructive op below in case of transient network failure.
+    // 2. Pull + decrypt the cloud envelope using the KDF it was stamped
+    //    with. `recoverVault` reads `envelope.kdf` so an Argon2id vault
+    //    written by another device decrypts here even though this
+    //    machine has never seen the spec — without that the wrong key
+    //    would silently fail to decrypt and the user would think their
+    //    passphrase was wrong.
     setPhase("restoring");
-    const pullResult = await pullVault(trimmed);
-    if (!pullResult.ok) {
+    const recoverResult = await recoverVault(trimmed);
+    if (!recoverResult.ok) {
       setError("Could not find a vault for this passphrase. Please check and try again.");
       setPhase("idle");
       return;
     }
+    const { vault, credentials: recoveredCredentials } = recoverResult.value;
 
-    // 3. Now that vault data is safely in hand, initialize local DB.
-    //    skipServerCleanup prevents deleting the vault we just pulled from.
-    const initResult = await initFresh(trimmed, { sync: true, skipServerCleanup: true });
+    // 3. Initialize a fresh local DB. Pass the recovered KDF spec so
+    //    `initFresh` derives a vault key that matches what's encrypting
+    //    the cloud envelope — otherwise the next push would re-encrypt
+    //    the cloud vault with a key from a different KDF, and the next
+    //    device's recovery would silently fail to decrypt.
+    const initResult = await initFresh(trimmed, {
+      sync: true,
+      skipServerCleanup: true,
+      vaultKdfSpec: recoveredCredentials.kdfSpec,
+    });
     if (!initResult.ok) {
       setError("Could not initialize. Please check your passphrase.");
       setPhase("idle");
@@ -86,7 +98,7 @@ export function RecoveryStep() {
     //    No separate "rekey" step needed — see #117 for the bug the
     //    old extra rekey call masked.
     if (credentials) {
-      await importVault(pullResult.value);
+      await importVault(vault);
       useSyncStore.getState().restoreSync(credentials);
     }
 

--- a/src/core/crypto/argon2.ts
+++ b/src/core/crypto/argon2.ts
@@ -1,0 +1,95 @@
+import { ok, err } from "../../../packages/core/src/utils/result";
+import type { Result } from "../../../packages/core/src/utils/result";
+
+/**
+ * Argon2id cost parameters. The triple (m, t, p) is stamped on every
+ * encrypted sync vault envelope so a vault written with one cost can
+ * still be opened on a device running with a different cost setting.
+ */
+export interface Argon2idParams {
+  /** Memory cost in KiB. 65536 = 64 MiB. */
+  memoryKib: number;
+  /** Number of passes over the memory. */
+  iterations: number;
+  /** Number of parallel lanes. */
+  parallelism: number;
+}
+
+/**
+ * OWASP-recommended Argon2id parameters for a 2020-era laptop. Roughly
+ * 700ms per derivation, dominated by the 64 MiB memory pass.
+ *
+ * https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
+ */
+export const ARGON2ID_PRODUCTION_PARAMS: Argon2idParams = {
+  memoryKib: 65536,
+  iterations: 3,
+  parallelism: 1,
+};
+
+/**
+ * OWASP minimum Argon2id parameters for memory-constrained devices
+ * (old mobile, `navigator.deviceMemory < 2`). ~300ms per derivation.
+ */
+export const ARGON2ID_MOBILE_PARAMS: Argon2idParams = {
+  memoryKib: 19456,
+  iterations: 2,
+  parallelism: 1,
+};
+
+/**
+ * Cheap params for the Vitest suite — round-trip correctness is
+ * independent of cost, and the production floor adds seconds per test
+ * for no value. Mirrors the PBKDF2_ITERATIONS test override in
+ * packages/core/src/utils/constants.ts.
+ */
+export const ARGON2ID_TEST_PARAMS: Argon2idParams = {
+  memoryKib: 256,
+  iterations: 1,
+  parallelism: 1,
+};
+
+const KEY_LENGTH_BYTES = 32;
+
+/**
+ * Derive an AES-GCM-256 CryptoKey from a passphrase via Argon2id.
+ *
+ * Argon2id is memory-hard — each guess costs `memoryKib` of RAM in
+ * addition to compute — which destroys the GPU/ASIC speedup that
+ * makes PBKDF2 brute-force cheap. The cost stamped on the envelope
+ * (see KdfSpec) lets a vault written with old params still decrypt
+ * after the production defaults are raised.
+ *
+ * Lazy-loads `hash-wasm` so the WASM blob is only fetched when key
+ * derivation actually runs (onboarding + recovery, ~once per device).
+ */
+export async function deriveArgon2idKey(
+  passphrase: string,
+  salt: Uint8Array,
+  params: Argon2idParams,
+  options?: { extractable?: boolean },
+): Promise<Result<CryptoKey>> {
+  try {
+    const { argon2id } = await import("hash-wasm");
+    const raw = (await argon2id({
+      password: passphrase,
+      salt,
+      parallelism: params.parallelism,
+      iterations: params.iterations,
+      memorySize: params.memoryKib,
+      hashLength: KEY_LENGTH_BYTES,
+      outputType: "binary",
+    })) as Uint8Array;
+
+    const key = await crypto.subtle.importKey(
+      "raw",
+      raw as BufferSource,
+      { name: "AES-GCM", length: 256 },
+      options?.extractable ?? false,
+      ["encrypt", "decrypt"],
+    );
+    return ok(key);
+  } catch (e) {
+    return err(`Argon2id key derivation failed: ${(e as Error).message}`);
+  }
+}

--- a/src/core/storage/key-manager.ts
+++ b/src/core/storage/key-manager.ts
@@ -7,7 +7,13 @@ import {
   exportCryptoKey,
   importCryptoKey,
 } from "./crypto.ts";
-import { deriveVaultId, deriveVaultKey } from "../sync/vault-crypto.ts";
+import {
+  deriveVaultId,
+  deriveVaultKey,
+  DEFAULT_NEW_VAULT_KDF,
+  LEGACY_KDF_SPEC,
+} from "../sync/vault-crypto.ts";
+import type { KdfSpec } from "../sync/types.ts";
 import {
   open,
   openWithKeys,
@@ -45,13 +51,22 @@ export async function assertKeyDataCoupling(): Promise<Result<void>> {
 }
 import type { SyncCredentials } from "../sync/sync-service.ts";
 
-/** Serializable key material stored in localStorage (JWK format). */
+/**
+ * Serializable key material stored in localStorage (JWK format).
+ *
+ * `vaultKdfSpec` records which KDF produced `vaultKeyJwk`. Absent on
+ * material written before the field existed; consumers default to
+ * legacy PBKDF2 so existing sync users keep stamping the same KDF on
+ * their pushes (no involuntary upgrade) until an explicit recovery
+ * triggers the auto-upgrade path.
+ */
 export interface StoredKeyMaterial {
   dbKeyJwk: JsonWebKey;
   hmacKeyJwk: JsonWebKey;
   dbSalt: number[];
   vaultId?: string;
   vaultKeyJwk?: JsonWebKey;
+  vaultKdfSpec?: KdfSpec;
 }
 
 export type RestoreStatus =
@@ -93,7 +108,14 @@ async function tryDeleteServerVault(): Promise<void> {
       length: CRYPTO.KEY_LENGTH,
     });
     const { deleteVault } = await import("../sync/sync-service.ts");
-    await deleteVault({ vaultId: storedKeys.vaultId, vaultKey });
+    // `deleteVault` only reads `vaultId`; the actual KDF spec is
+    // irrelevant for a DELETE. Stamping legacy here keeps the type
+    // honest without pretending we know which KDF the cloud vault used.
+    await deleteVault({
+      vaultId: storedKeys.vaultId,
+      vaultKey,
+      kdfSpec: storedKeys.vaultKdfSpec ?? LEGACY_KDF_SPEC,
+    });
   } catch {
     // Best-effort — vault is encrypted and unreadable without passphrase
   }
@@ -119,10 +141,18 @@ async function deriveAndExportDbKeys(
 
 async function deriveVaultMaterial(
   passphrase: string,
-): Promise<Result<{ vaultId: string; vaultKeyJwk: JsonWebKey; vaultKey: CryptoKey }>> {
+  kdfSpec: KdfSpec,
+): Promise<
+  Result<{
+    vaultId: string;
+    vaultKeyJwk: JsonWebKey;
+    vaultKey: CryptoKey;
+    kdfSpec: KdfSpec;
+  }>
+> {
   const [vaultIdResult, vaultKeyResult] = await Promise.all([
     deriveVaultId(passphrase),
-    deriveVaultKey(passphrase, { extractable: true }),
+    deriveVaultKey(passphrase, { extractable: true, kdfSpec }),
   ]);
   if (!vaultIdResult.ok) return vaultIdResult;
   if (!vaultKeyResult.ok) return vaultKeyResult;
@@ -131,6 +161,7 @@ async function deriveVaultMaterial(
     vaultId: vaultIdResult.value,
     vaultKeyJwk: await exportCryptoKey(vaultKeyResult.value),
     vaultKey: vaultKeyResult.value,
+    kdfSpec,
   });
 }
 
@@ -143,7 +174,20 @@ async function deriveVaultMaterial(
  */
 export async function initFresh(
   passphrase: string,
-  options?: { sync: boolean; skipServerCleanup?: boolean },
+  options?: {
+    sync: boolean;
+    skipServerCleanup?: boolean;
+    /**
+     * KDF used to derive the vault key. Defaults to
+     * `DEFAULT_NEW_VAULT_KDF` (Argon2id) for new sync signups. The
+     * recovery flow passes the spec it read off the cloud envelope so
+     * the locally-persisted JWK matches the cloud's encoding —
+     * otherwise the next push would re-encrypt the cloud vault with a
+     * key derived from a different KDF and a recovering second device
+     * would silently fail to decrypt.
+     */
+    vaultKdfSpec?: KdfSpec;
+  },
 ): Promise<Result<{ credentials: SyncCredentials | null }>> {
   try {
     // 1. Clean up any previous session
@@ -172,7 +216,8 @@ export async function initFresh(
     let credentials: SyncCredentials | null = null;
 
     if (options?.sync) {
-      const vaultResult = await deriveVaultMaterial(passphrase);
+      const kdfSpec = options.vaultKdfSpec ?? DEFAULT_NEW_VAULT_KDF;
+      const vaultResult = await deriveVaultMaterial(passphrase, kdfSpec);
       if (!vaultResult.ok) {
         // Roll back: close DB, clear everything
         await deleteDatabase();
@@ -181,10 +226,12 @@ export async function initFresh(
 
       material.vaultId = vaultResult.value.vaultId;
       material.vaultKeyJwk = vaultResult.value.vaultKeyJwk;
+      material.vaultKdfSpec = vaultResult.value.kdfSpec;
 
       credentials = {
         vaultId: vaultResult.value.vaultId,
         vaultKey: vaultResult.value.vaultKey,
+        kdfSpec: vaultResult.value.kdfSpec,
       };
     }
 
@@ -239,7 +286,15 @@ export async function restore(): Promise<RestoreStatus> {
         name: CRYPTO.ALGORITHM,
         length: CRYPTO.KEY_LENGTH,
       });
-      credentials = { vaultId: storedKeys.vaultId, vaultKey };
+      // vaultKdfSpec is absent on legacy material — those entries were
+      // produced by the PBKDF2 path before the field existed, so the
+      // legacy default is the correct fallback. New material always
+      // writes this field, so reading it back is the round-trip.
+      credentials = {
+        vaultId: storedKeys.vaultId,
+        vaultKey,
+        kdfSpec: storedKeys.vaultKdfSpec ?? LEGACY_KDF_SPEC,
+      };
     } catch {
       // Vault keys corrupted — still return ready, just without sync
     }
@@ -255,11 +310,13 @@ export async function restore(): Promise<RestoreStatus> {
  */
 export async function addVaultKeys(
   passphrase: string,
+  options?: { vaultKdfSpec?: KdfSpec },
 ): Promise<Result<SyncCredentials>> {
   const storedKeys = loadStoredKeys();
   if (!storedKeys) return err("No stored keys — cannot add vault keys");
 
-  const vaultResult = await deriveVaultMaterial(passphrase);
+  const kdfSpec = options?.vaultKdfSpec ?? DEFAULT_NEW_VAULT_KDF;
+  const vaultResult = await deriveVaultMaterial(passphrase, kdfSpec);
   if (!vaultResult.ok) return vaultResult;
 
   // Persist DB keys + vault keys together
@@ -267,6 +324,7 @@ export async function addVaultKeys(
     ...storedKeys,
     vaultId: vaultResult.value.vaultId,
     vaultKeyJwk: vaultResult.value.vaultKeyJwk,
+    vaultKdfSpec: vaultResult.value.kdfSpec,
   };
   storeKeys(material);
   localStorage.setItem(LOCAL_STORAGE.STORAGE_MODE, "sync");
@@ -274,6 +332,7 @@ export async function addVaultKeys(
   return ok({
     vaultId: vaultResult.value.vaultId,
     vaultKey: vaultResult.value.vaultKey,
+    kdfSpec: vaultResult.value.kdfSpec,
   });
 }
 
@@ -349,7 +408,7 @@ export async function destroyLocal(): Promise<void> {
  */
 export async function persistDerivedKeysFromOpenDb(
   passphrase: string,
-  options?: { sync: boolean },
+  options?: { sync: boolean; vaultKdfSpec?: KdfSpec },
 ): Promise<Result<{ credentials: SyncCredentials | null }>> {
   const saltResult = await getSalt();
   if (!saltResult.ok) return saltResult;
@@ -366,14 +425,17 @@ export async function persistDerivedKeysFromOpenDb(
   let credentials: SyncCredentials | null = null;
 
   if (options?.sync) {
-    const vaultResult = await deriveVaultMaterial(passphrase);
+    const kdfSpec = options.vaultKdfSpec ?? DEFAULT_NEW_VAULT_KDF;
+    const vaultResult = await deriveVaultMaterial(passphrase, kdfSpec);
     if (!vaultResult.ok) return vaultResult;
 
     material.vaultId = vaultResult.value.vaultId;
     material.vaultKeyJwk = vaultResult.value.vaultKeyJwk;
+    material.vaultKdfSpec = vaultResult.value.kdfSpec;
     credentials = {
       vaultId: vaultResult.value.vaultId,
       vaultKey: vaultResult.value.vaultKey,
+      kdfSpec: vaultResult.value.kdfSpec,
     };
   }
 

--- a/src/core/storage/key-manager.ts
+++ b/src/core/storage/key-manager.ts
@@ -337,6 +337,39 @@ export async function addVaultKeys(
 }
 
 /**
+ * Persist an upgraded vault key + spec to localStorage. Called by the
+ * recovery flow after `upgradeVaultKdf` has successfully re-encrypted
+ * the cloud envelope with a stronger KDF — the locally-stored JWK
+ * MUST match what's now encrypting the cloud, or the next pull would
+ * decrypt with the old key and fail. Caller is responsible for
+ * exporting the credentials' `vaultKey` as a JWK before passing the
+ * result through to `restoreSync`.
+ *
+ * Idempotent: if no keys are stored, returns ok without writing
+ * anything (the recovery flow has bigger problems in that case, but
+ * we don't want this best-effort upgrade to be the error vector).
+ */
+export async function updateStoredVaultKey(
+  credentials: SyncCredentials,
+): Promise<Result<void>> {
+  const storedKeys = loadStoredKeys();
+  if (!storedKeys) return ok(undefined);
+
+  try {
+    const material: StoredKeyMaterial = {
+      ...storedKeys,
+      vaultId: credentials.vaultId,
+      vaultKeyJwk: await exportCryptoKey(credentials.vaultKey),
+      vaultKdfSpec: credentials.kdfSpec,
+    };
+    storeKeys(material);
+    return ok(undefined);
+  } catch (e) {
+    return err(`Failed to persist upgraded vault key: ${(e as Error).message}`);
+  }
+}
+
+/**
  * Remove vault keys, keeping DB keys intact.
  * Called when disabling sync after server vault is confirmed deleted.
  */

--- a/src/core/storage/key-material.ts
+++ b/src/core/storage/key-material.ts
@@ -7,26 +7,46 @@ import {
   exportCryptoKey,
   generateSalt,
 } from "./crypto.ts";
-import { deriveVaultId, deriveVaultKey } from "../sync/vault-crypto.ts";
+import {
+  deriveVaultId,
+  deriveVaultKey,
+  DEFAULT_NEW_VAULT_KDF,
+} from "../sync/vault-crypto.ts";
+import type { KdfSpec } from "../sync/types.ts";
 
-/** Serializable key material stored in localStorage (JWK format). */
+/**
+ * Serializable key material stored in localStorage (JWK format).
+ *
+ * `vaultKdfSpec` records which KDF produced `vaultKeyJwk`. Entries
+ * written before this field existed lack it; readers treat `undefined`
+ * as legacy PBKDF2 so a returning user whose vault key was minted that
+ * way keeps using the matching spec on subsequent pushes.
+ */
 export interface StoredKeyMaterial {
   dbKeyJwk: JsonWebKey;
   hmacKeyJwk: JsonWebKey;
   dbSalt: number[];
   vaultId?: string;
   vaultKeyJwk?: JsonWebKey;
+  vaultKdfSpec?: KdfSpec;
 }
 
 /**
  * Derive all cryptographic keys from a passphrase, export them as JWKs,
  * and persist to localStorage. The raw passphrase is not stored.
  * If dbSalt is provided, reuses it; otherwise generates a new one.
+ *
+ * `vaultKdfSpec` overrides which KDF derives the vault key when
+ * `includeVaultKeys` is set. Defaults to `DEFAULT_NEW_VAULT_KDF`
+ * (Argon2id) so new sync signups encrypt their cloud vault with the
+ * memory-hard KDF; recovery flows pass the spec they read off the
+ * existing cloud envelope to keep the local key aligned with the
+ * cloud encoding.
  */
 export async function deriveAndStoreKeys(
   passphrase: string,
   dbSalt?: Uint8Array,
-  options?: { includeVaultKeys: boolean },
+  options?: { includeVaultKeys: boolean; vaultKdfSpec?: KdfSpec },
 ): Promise<Result<StoredKeyMaterial>> {
   try {
     const salt = dbSalt ?? generateSalt();
@@ -48,16 +68,19 @@ export async function deriveAndStoreKeys(
     };
 
     if (options?.includeVaultKeys) {
+      const vaultKdfSpec = options.vaultKdfSpec ?? DEFAULT_NEW_VAULT_KDF;
       const vaultIdResult = await deriveVaultId(passphrase);
       if (!vaultIdResult.ok) return vaultIdResult;
 
       const vaultKeyResult = await deriveVaultKey(passphrase, {
         extractable: true,
+        kdfSpec: vaultKdfSpec,
       });
       if (!vaultKeyResult.ok) return vaultKeyResult;
 
       material.vaultId = vaultIdResult.value;
       material.vaultKeyJwk = await exportCryptoKey(vaultKeyResult.value);
+      material.vaultKdfSpec = vaultKdfSpec;
     }
 
     localStorage.setItem(LOCAL_STORAGE.DERIVED_KEYS, JSON.stringify(material));

--- a/src/core/sync/sync-service.ts
+++ b/src/core/sync/sync-service.ts
@@ -7,14 +7,22 @@ import {
   deriveVaultKey,
   encryptVault,
   decryptVault,
+  readKdfSpec,
+  LEGACY_KDF_SPEC,
 } from "./vault-crypto.ts";
-import type { VaultData, EncryptedVault } from "./types.ts";
+import type { VaultData, EncryptedVault, KdfSpec } from "./types.ts";
 import { syncFetch } from "./sync-fetch.ts";
 
-/** Pre-derived sync credentials, avoiding the need to store the raw passphrase. */
+/**
+ * Pre-derived sync credentials, avoiding the need to store the raw
+ * passphrase. `kdfSpec` records which KDF produced `vaultKey` so
+ * `pushVault` can stamp the matching field on the envelope — a
+ * recovering device reads that field to re-derive the right key.
+ */
 export interface SyncCredentials {
   vaultId: string;
   vaultKey: CryptoKey;
+  kdfSpec: KdfSpec;
 }
 
 const MIN_BUCKET = 64 * 1024;
@@ -58,17 +66,32 @@ function nextPowerOf2(size: number, min: number): number {
 
 type SyncAuth = string | SyncCredentials;
 
+/**
+ * Resolve a passphrase-or-credentials union to full credentials.
+ *
+ * The string-auth path derives the legacy PBKDF2 pair (vault ID +
+ * vault key). It is intentionally NOT spec-aware — calling this with
+ * a passphrase against a vault encrypted with Argon2id would decrypt
+ * silently against the wrong key and fail with a confusing error.
+ * Production recovery flows MUST use `recoverVault` (which reads the
+ * envelope's KDF stamp); this path remains for test convenience
+ * against vaults written by the same string-auth path.
+ */
 async function resolveCredentials(
   auth: SyncAuth,
 ): Promise<Result<SyncCredentials>> {
   if (typeof auth !== "string") return ok(auth);
   const [vaultIdResult, vaultKeyResult] = await Promise.all([
     deriveVaultId(auth),
-    deriveVaultKey(auth),
+    deriveVaultKey(auth, { extractable: true, kdfSpec: LEGACY_KDF_SPEC }),
   ]);
   if (!vaultIdResult.ok) return vaultIdResult;
   if (!vaultKeyResult.ok) return vaultKeyResult;
-  return ok({ vaultId: vaultIdResult.value, vaultKey: vaultKeyResult.value });
+  return ok({
+    vaultId: vaultIdResult.value,
+    vaultKey: vaultKeyResult.value,
+    kdfSpec: LEGACY_KDF_SPEC,
+  });
 }
 
 async function resolveVaultId(auth: SyncAuth): Promise<Result<string>> {
@@ -143,7 +166,11 @@ export async function pushVault(
     if (!vaultResult.ok) return vaultResult;
     const { vaultId, vaultKey } = credsResult.value;
 
-    const encryptedResult = await encryptVault(vaultKey, vaultResult.value);
+    const encryptedResult = await encryptVault(
+      vaultKey,
+      vaultResult.value,
+      credsResult.value.kdfSpec,
+    );
     if (!encryptedResult.ok) return encryptedResult;
 
     const body = padPayload(
@@ -284,6 +311,68 @@ export async function pullVaultIfChanged(
     });
   } catch (e) {
     return err(`Sync pull failed: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Recover a vault on a new device from a passphrase alone.
+ *
+ * Derives the vault ID via PBKDF2 (the routing identifier — unchanged
+ * across KDF migrations), pulls the encrypted envelope, reads its
+ * stamped `kdf` field, derives the matching vault key, and decrypts.
+ *
+ * Returns full credentials whose `kdfSpec` matches what the cloud
+ * envelope was encrypted with — so subsequent pushes from this
+ * device stamp the same spec, preserving the cloud encoding. Use
+ * this from any flow that holds only the passphrase (recovery-step,
+ * switchToExistingCloud). The plain `pullVault(passphrase)` path
+ * cannot decrypt Argon2id envelopes — it assumes legacy KDF.
+ */
+export async function recoverVault(
+  passphrase: string,
+): Promise<Result<{ vault: VaultData; credentials: SyncCredentials }>> {
+  const vaultIdResult = await deriveVaultId(passphrase);
+  if (!vaultIdResult.ok) return vaultIdResult;
+  const vaultId = vaultIdResult.value;
+
+  try {
+    const response = await syncFetch(`/api/sync?vaultId=${vaultId}`);
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return err(
+          "No cloud vault was found for this passphrase. " +
+            "If this is your first device, push from there first. " +
+            "If you're restoring on a new device, double-check the passphrase — " +
+            "every word matters and order matters.",
+        );
+      }
+      const text = await response.text();
+      return err(`Sync pull failed (${response.status}): ${text}`);
+    }
+
+    const data = await response.json();
+    if (!data.vault) return err("Server returned no vault data");
+
+    const envelope = data.vault as EncryptedVault;
+    const kdfSpec = readKdfSpec(envelope);
+
+    const vaultKeyResult = await deriveVaultKey(passphrase, {
+      extractable: true,
+      kdfSpec,
+    });
+    if (!vaultKeyResult.ok) return vaultKeyResult;
+    const vaultKey = vaultKeyResult.value;
+
+    const decryptResult = await decryptVault(vaultKey, envelope);
+    if (!decryptResult.ok) return decryptResult;
+
+    return ok({
+      vault: decryptResult.value,
+      credentials: { vaultId, vaultKey, kdfSpec },
+    });
+  } catch (e) {
+    return err(`Vault recovery failed: ${(e as Error).message}`);
   }
 }
 

--- a/src/core/sync/sync-service.ts
+++ b/src/core/sync/sync-service.ts
@@ -9,6 +9,7 @@ import {
   decryptVault,
   readKdfSpec,
   LEGACY_KDF_SPEC,
+  DEFAULT_NEW_VAULT_KDF,
 } from "./vault-crypto.ts";
 import type { VaultData, EncryptedVault, KdfSpec } from "./types.ts";
 import { syncFetch } from "./sync-fetch.ts";
@@ -374,6 +375,90 @@ export async function recoverVault(
   } catch (e) {
     return err(`Vault recovery failed: ${(e as Error).message}`);
   }
+}
+
+/**
+ * Whether two KDF specs are equivalent (same kind and same params).
+ * Used by `upgradeVaultKdf` to short-circuit no-op upgrades.
+ */
+function kdfSpecsMatch(a: KdfSpec, b: KdfSpec): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "pbkdf2-600k") return true;
+  if (b.kind !== "argon2id") return false;
+  return (
+    a.memoryKib === b.memoryKib &&
+    a.iterations === b.iterations &&
+    a.parallelism === b.parallelism
+  );
+}
+
+/**
+ * Re-encrypt a sync vault with a stronger KDF and push it back to the
+ * same vault ID. Used by the recovery flow to silently upgrade legacy
+ * PBKDF2 vaults to Argon2id the first time the user types their
+ * passphrase on a new device — the "auto-upgrade on next passphrase
+ * entry" migration path.
+ *
+ * The vault ID derivation is intentionally KDF-invariant (always
+ * PBKDF2), so the upgrade is a single PUT to the same vault ID, no
+ * migration of identifiers. Returns the new credentials whose
+ * `vaultKey` corresponds to the new spec — callers MUST persist
+ * these via `updateStoredVaultKey` before they can be used again
+ * on this device.
+ *
+ * Caller-friendly behavior: if `current.kdfSpec` already matches
+ * `targetSpec`, the function returns `current` unchanged without
+ * any network call. If the push fails, the function returns an
+ * error and the caller can fall back to the legacy credentials —
+ * the cloud envelope is unchanged in that case, so a retry on the
+ * next session can complete the upgrade.
+ */
+export async function upgradeVaultKdf(
+  passphrase: string,
+  current: SyncCredentials,
+  vault: VaultData,
+  targetSpec: KdfSpec = DEFAULT_NEW_VAULT_KDF,
+): Promise<Result<SyncCredentials>> {
+  if (kdfSpecsMatch(current.kdfSpec, targetSpec)) {
+    return ok(current);
+  }
+
+  const newKeyResult = await deriveVaultKey(passphrase, {
+    extractable: true,
+    kdfSpec: targetSpec,
+  });
+  if (!newKeyResult.ok) return newKeyResult;
+
+  const encryptedResult = await encryptVault(
+    newKeyResult.value,
+    vault,
+    targetSpec,
+  );
+  if (!encryptedResult.ok) return encryptedResult;
+
+  const body = padPayload(
+    JSON.stringify({
+      vaultId: current.vaultId,
+      vault: encryptedResult.value,
+    }),
+  );
+
+  const response = await syncFetch("/api/sync", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    return err(`KDF upgrade push failed (${response.status}): ${text}`);
+  }
+
+  return ok({
+    vaultId: current.vaultId,
+    vaultKey: newKeyResult.value,
+    kdfSpec: targetSpec,
+  });
 }
 
 /**

--- a/src/core/sync/types.ts
+++ b/src/core/sync/types.ts
@@ -41,11 +41,41 @@ export interface VaultData {
   preferencesUpdatedAt?: number;
 }
 
+/**
+ * Identifies which key-derivation function was used to derive the AES key
+ * that encrypted a vault's ciphertext. Stamped on the envelope so a vault
+ * written with one KDF can be opened on a device whose default has since
+ * moved on — the recovery flow reads this field and picks the matching
+ * derivation function.
+ *
+ * `pbkdf2-600k` is the legacy default for envelopes written before this
+ * field existed; `readKdfSpec(envelope)` returns it when the field is
+ * absent. Argon2id carries its full cost triple so we can change the
+ * production default without orphaning older vaults.
+ */
+export type KdfSpec =
+  | { kind: "pbkdf2-600k" }
+  | {
+      kind: "argon2id";
+      /** Memory cost in KiB (65536 = 64 MiB). */
+      memoryKib: number;
+      /** Number of passes over the memory. */
+      iterations: number;
+      /** Number of parallel lanes. */
+      parallelism: number;
+    };
+
 /** Encrypted vault as stored on the server. */
 export interface EncryptedVault {
   version: number;
   iv: number[];
   ciphertext: string;
+  /**
+   * Which KDF derived the encryption key. Absent on envelopes written
+   * before this field existed; consumers must default to PBKDF2 via
+   * `readKdfSpec()` rather than reading the field directly.
+   */
+  kdf?: KdfSpec;
 }
 
 /** Server response shape for sync API. */

--- a/src/core/sync/vault-crypto.ts
+++ b/src/core/sync/vault-crypto.ts
@@ -3,7 +3,25 @@ import type { Result } from "../../../packages/core/src/utils/result";
 import { SYNC } from "../../../packages/core/src/utils/constants";
 import { deriveBytes, deriveKey, decrypt } from "../storage/crypto.ts";
 import { uint8ArrayToBase64, base64ToUint8Array } from "../../../packages/core/src/utils/base64";
-import type { VaultData, EncryptedVault } from "./types.ts";
+import type { VaultData, EncryptedVault, KdfSpec } from "./types.ts";
+
+/**
+ * KDF spec assumed for envelopes written before the `kdf` field existed.
+ * Every envelope without an explicit `kdf` was produced by `deriveKey`
+ * (PBKDF2-SHA256 with 600,000 iterations), so the recovery flow uses
+ * this when nothing else is available.
+ */
+export const LEGACY_KDF_SPEC: KdfSpec = { kind: "pbkdf2-600k" };
+
+/**
+ * Read the KDF spec from an envelope, falling back to the PBKDF2
+ * legacy default when the field is absent. Always go through this
+ * helper rather than reading `envelope.kdf` directly — the back-compat
+ * default lives here so existing vaults stay readable.
+ */
+export function readKdfSpec(envelope: EncryptedVault): KdfSpec {
+  return envelope.kdf ?? LEGACY_KDF_SPEC;
+}
 
 /** AES-GCM IV length in bytes. */
 const IV_LENGTH = 12;
@@ -83,10 +101,16 @@ export async function deriveVaultKey(
  * + summaries, repeated structural keys — gzip typically shrinks the
  * payload 60–80%. Smaller ciphertext means smaller pushes, smaller
  * pulls, and smaller `padPayload` buckets in sync-service.
+ *
+ * When `kdfSpec` is provided, it is stamped on the envelope so the
+ * recovery flow can pick the matching key-derivation function on a
+ * new device. Omit it only for tests of legacy back-compat — production
+ * callers (`pushVault` and the auto-upgrade path) always pass a spec.
  */
 export async function encryptVault(
   key: CryptoKey,
   vault: VaultData,
+  kdfSpec?: KdfSpec,
 ): Promise<Result<EncryptedVault>> {
   try {
     const json = JSON.stringify(vault);
@@ -100,11 +124,13 @@ export async function encryptVault(
         compressed as BufferSource,
       ),
     );
-    return ok({
+    const envelope: EncryptedVault = {
       version: SYNC.FORMAT_VERSION,
       iv: Array.from(iv),
       ciphertext: uint8ArrayToBase64(ct),
-    });
+    };
+    if (kdfSpec) envelope.kdf = kdfSpec;
+    return ok(envelope);
   } catch (e) {
     return err(`Vault encryption failed: ${(e as Error).message}`);
   }

--- a/src/core/sync/vault-crypto.ts
+++ b/src/core/sync/vault-crypto.ts
@@ -5,22 +5,39 @@ import { deriveBytes, deriveKey, decrypt } from "../storage/crypto.ts";
 import { uint8ArrayToBase64, base64ToUint8Array } from "../../../packages/core/src/utils/base64";
 import {
   ARGON2ID_PRODUCTION_PARAMS,
+  ARGON2ID_TEST_PARAMS,
   deriveArgon2idKey,
 } from "../crypto/argon2.ts";
 import type { VaultData, EncryptedVault, KdfSpec } from "./types.ts";
 
 /**
- * KDF spec used to encrypt every newly-created sync vault. Argon2id at
- * the OWASP-recommended cost destroys the GPU/ASIC advantage that
- * makes a 4-word diceware passphrase brute-forceable offline. The full
- * cost triple is stamped on the envelope so we can raise this floor
- * without orphaning vaults written with older settings.
+ * Argon2id parameters used when constructing `DEFAULT_NEW_VAULT_KDF`.
+ * Production always uses the OWASP-recommended cost (64 MiB, t=3, p=1).
+ * The Vitest suite would otherwise pay ~700ms per new-vault derivation
+ * across hundreds of tests — encryption correctness is independent of
+ * cost, so the test path uses cheap params. Mirrors the PBKDF2 test
+ * override in packages/core/src/utils/constants.ts.
+ *
+ * `process` is undefined in the browser bundle, so production and the
+ * Hono server always use the full OWASP floor.
+ */
+const DEFAULT_NEW_VAULT_ARGON2ID_PARAMS =
+  typeof process !== "undefined" && process.env.VITEST
+    ? ARGON2ID_TEST_PARAMS
+    : ARGON2ID_PRODUCTION_PARAMS;
+
+/**
+ * KDF spec used to encrypt every newly-created sync vault. Argon2id is
+ * memory-hard and destroys the GPU/ASIC advantage that makes a 4-word
+ * diceware passphrase brute-forceable offline. The full cost triple is
+ * stamped on the envelope so we can raise this floor without orphaning
+ * vaults written with older settings.
  */
 export const DEFAULT_NEW_VAULT_KDF: KdfSpec = {
   kind: "argon2id",
-  memoryKib: ARGON2ID_PRODUCTION_PARAMS.memoryKib,
-  iterations: ARGON2ID_PRODUCTION_PARAMS.iterations,
-  parallelism: ARGON2ID_PRODUCTION_PARAMS.parallelism,
+  memoryKib: DEFAULT_NEW_VAULT_ARGON2ID_PARAMS.memoryKib,
+  iterations: DEFAULT_NEW_VAULT_ARGON2ID_PARAMS.iterations,
+  parallelism: DEFAULT_NEW_VAULT_ARGON2ID_PARAMS.parallelism,
 };
 
 /**

--- a/src/core/sync/vault-crypto.ts
+++ b/src/core/sync/vault-crypto.ts
@@ -3,7 +3,25 @@ import type { Result } from "../../../packages/core/src/utils/result";
 import { SYNC } from "../../../packages/core/src/utils/constants";
 import { deriveBytes, deriveKey, decrypt } from "../storage/crypto.ts";
 import { uint8ArrayToBase64, base64ToUint8Array } from "../../../packages/core/src/utils/base64";
+import {
+  ARGON2ID_PRODUCTION_PARAMS,
+  deriveArgon2idKey,
+} from "../crypto/argon2.ts";
 import type { VaultData, EncryptedVault, KdfSpec } from "./types.ts";
+
+/**
+ * KDF spec used to encrypt every newly-created sync vault. Argon2id at
+ * the OWASP-recommended cost destroys the GPU/ASIC advantage that
+ * makes a 4-word diceware passphrase brute-forceable offline. The full
+ * cost triple is stamped on the envelope so we can raise this floor
+ * without orphaning vaults written with older settings.
+ */
+export const DEFAULT_NEW_VAULT_KDF: KdfSpec = {
+  kind: "argon2id",
+  memoryKib: ARGON2ID_PRODUCTION_PARAMS.memoryKib,
+  iterations: ARGON2ID_PRODUCTION_PARAMS.iterations,
+  parallelism: ARGON2ID_PRODUCTION_PARAMS.parallelism,
+};
 
 /**
  * KDF spec assumed for envelopes written before the `kdf` field existed.
@@ -79,16 +97,39 @@ export async function deriveEncryptionSalt(
 }
 
 /**
- * Derive the AES-GCM-256 encryption key from a passphrase.
- * Two-step: derive deterministic salt, then derive key from passphrase + salt.
+ * Derive the AES-GCM-256 vault encryption key from a passphrase.
+ *
+ * The KDF is selected by `kdfSpec`. When unset, defaults to the
+ * legacy PBKDF2 spec so existing callers keep producing the same key
+ * bytes for the same passphrase (recovery on a primary device with a
+ * stored JWK relies on this — a silent switch would orphan the local
+ * encrypted DB). New-signup callers and recovery-after-upgrade
+ * callers should pass `DEFAULT_NEW_VAULT_KDF` or the spec read off
+ * the cloud envelope via `readKdfSpec`.
  */
 export async function deriveVaultKey(
   passphrase: string,
-  options?: { extractable?: boolean },
+  options?: { extractable?: boolean; kdfSpec?: KdfSpec },
 ): Promise<Result<CryptoKey>> {
   const saltResult = await deriveEncryptionSalt(passphrase);
   if (!saltResult.ok) return saltResult;
-  return deriveKey(passphrase, saltResult.value, options);
+
+  const spec = options?.kdfSpec ?? LEGACY_KDF_SPEC;
+  if (spec.kind === "argon2id") {
+    return deriveArgon2idKey(
+      passphrase,
+      saltResult.value,
+      {
+        memoryKib: spec.memoryKib,
+        iterations: spec.iterations,
+        parallelism: spec.parallelism,
+      },
+      { extractable: options?.extractable },
+    );
+  }
+  return deriveKey(passphrase, saltResult.value, {
+    extractable: options?.extractable,
+  });
 }
 
 /**

--- a/src/stores/sync-store.ts
+++ b/src/stores/sync-store.ts
@@ -3,13 +3,13 @@ import {
   pushVault,
   pullVault,
   pullVaultIfChanged,
+  recoverVault,
   importVault,
   deleteVault,
   exportVault,
   mergeVaults,
 } from "../core/sync/sync-service";
 import type { SyncCredentials } from "../core/sync/sync-service";
-import { deriveVaultId, deriveVaultKey } from "../core/sync/vault-crypto.ts";
 import {
   addVaultKeys,
   removeVaultKeys,
@@ -139,18 +139,6 @@ function clearPendingTimers(): void {
     clearTimeout(jitterTimer);
     jitterTimer = null;
   }
-}
-
-async function deriveSyncCredentials(
-  passphrase: string,
-): Promise<Result<SyncCredentials>> {
-  const [vaultIdResult, vaultKeyResult] = await Promise.all([
-    deriveVaultId(passphrase),
-    deriveVaultKey(passphrase),
-  ]);
-  if (!vaultIdResult.ok) return vaultIdResult;
-  if (!vaultKeyResult.ok) return vaultKeyResult;
-  return ok({ vaultId: vaultIdResult.value, vaultKey: vaultKeyResult.value });
 }
 
 export const useSyncStore = create<SyncStore>((set, get) => ({
@@ -388,25 +376,28 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
   switchToExistingCloud: async (passphrase, mode) => {
     set({ status: "syncing", error: null });
 
-    const credsResult = await deriveSyncCredentials(passphrase);
-    if (!credsResult.ok) {
-      set({ status: "error", error: credsResult.error });
-      return err(credsResult.error);
-    }
-    const credentials = credsResult.value;
-
     // Mode-specific source data: either the cloud vault directly
     // (replace) or local merged with cloud (merge). The destructive
     // local rewrite happens INSIDE applyCloudVault — only after pull
     // succeeds. If pull fails, the local DB is untouched.
+    //
+    // Either mode uses `recoverVault` (not `pullVault`) so the cloud
+    // envelope's stamped KDF spec drives the matching key derivation;
+    // `deriveSyncCredentials` (legacy PBKDF2) here would have failed
+    // to decrypt any Argon2id-encrypted vault.
     if (mode === "replace") {
-      const pullResult = await pullVault(credentials);
-      if (!pullResult.ok) {
-        set({ status: "error", error: pullResult.error });
-        return pullResult;
+      const recoverResult = await recoverVault(passphrase);
+      if (!recoverResult.ok) {
+        set({ status: "error", error: recoverResult.error });
+        return err(recoverResult.error);
       }
+      const { vault: cloudVault, credentials } = recoverResult.value;
 
-      const applyResult = await applyCloudVault(passphrase, pullResult.value);
+      const applyResult = await applyCloudVault(
+        passphrase,
+        cloudVault,
+        credentials.kdfSpec,
+      );
       if (!applyResult.ok) {
         set({ status: "error", error: applyResult.error });
         return applyResult;
@@ -421,28 +412,35 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
       return ok(true);
     }
 
-    // Merge mode: snapshot local, pull cloud, merge in memory, then
-    // apply the merged result. Push the (now-cloud-passphrase-encrypted)
-    // result so the cloud reflects the merge.
+    // Merge mode: snapshot local FIRST so a local-export failure
+    // short-circuits before we burn a network round-trip on the cloud
+    // pull. Then recoverVault discovers the cloud KDF + decrypts; the
+    // merged vault is pushed back with the same KDF the cloud
+    // envelope was already stamped with.
     const exportResult = await exportVault();
     if (!exportResult.ok) {
       set({ status: "error", error: exportResult.error });
       return exportResult;
     }
 
-    const pullResult = await pullVault(credentials);
-    if (!pullResult.ok) {
-      set({ status: "error", error: pullResult.error });
-      return pullResult;
+    const recoverResult = await recoverVault(passphrase);
+    if (!recoverResult.ok) {
+      set({ status: "error", error: recoverResult.error });
+      return err(recoverResult.error);
     }
+    const { vault: cloudVault, credentials } = recoverResult.value;
 
-    const mergeResult = mergeVaults(exportResult.value, pullResult.value);
+    const mergeResult = mergeVaults(exportResult.value, cloudVault);
     if (!mergeResult.ok) {
       set({ status: "error", error: mergeResult.error });
       return mergeResult;
     }
 
-    const applyResult = await applyCloudVault(passphrase, mergeResult.value);
+    const applyResult = await applyCloudVault(
+      passphrase,
+      mergeResult.value,
+      credentials.kdfSpec,
+    );
     if (!applyResult.ok) {
       set({ status: "error", error: applyResult.error });
       return applyResult;
@@ -521,6 +519,7 @@ async function gatePreferencesByTimestamp(
 async function applyCloudVault(
   passphrase: string,
   vault: import("../core/sync/types.ts").VaultData,
+  vaultKdfSpec: import("../core/sync/types.ts").KdfSpec,
 ): Promise<Result<boolean>> {
   close();
   const deleteResult = await deleteDatabase();
@@ -532,8 +531,14 @@ async function applyCloudVault(
   const importResult = await importVault(vault);
   if (!importResult.ok) return importResult;
 
+  // Persist the vault key with the SAME KDF that encrypted the cloud
+  // envelope. Defaulting to Argon2id here would silently re-key a
+  // legacy PBKDF2 vault's local store, and the next push would
+  // re-encrypt the cloud envelope with a key the originating device
+  // cannot reproduce — recovery on the original device would fail.
   const persistResult = await persistDerivedKeysFromOpenDb(passphrase, {
     sync: true,
+    vaultKdfSpec,
   });
   if (!persistResult.ok) return persistResult;
 

--- a/src/stores/sync-store.ts
+++ b/src/stores/sync-store.ts
@@ -4,18 +4,21 @@ import {
   pullVault,
   pullVaultIfChanged,
   recoverVault,
+  upgradeVaultKdf,
   importVault,
   deleteVault,
   exportVault,
   mergeVaults,
 } from "../core/sync/sync-service";
 import type { SyncCredentials } from "../core/sync/sync-service";
+import type { VaultData } from "../core/sync/types.ts";
 import {
   addVaultKeys,
   removeVaultKeys,
   destroyLocal,
   persistDerivedKeysFromOpenDb,
   assertKeyDataCoupling,
+  updateStoredVaultKey,
 } from "../core/storage/key-manager.ts";
 import {
   close,
@@ -23,7 +26,6 @@ import {
   open,
   getPreferencesUpdatedAt,
 } from "../core/storage/db.ts";
-import type { VaultData } from "../core/sync/types.ts";
 import { clearLicenseToken } from "../core/license/license-token-store.ts";
 import { LOCAL_STORAGE } from "@feedzero/core/utils/constants";
 import type { Result } from "@feedzero/core/utils/result";
@@ -403,8 +405,14 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
         return applyResult;
       }
 
-      set({
+      const finalCreds = await autoUpgradeOnPassphraseEntry(
+        passphrase,
         credentials,
+        cloudVault,
+      );
+
+      set({
+        credentials: finalCreds,
         status: "synced",
         lastSyncedAt: Date.now(),
         error: null,
@@ -452,8 +460,14 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
       return err(pushResult.error);
     }
 
-    set({
+    const finalCreds = await autoUpgradeOnPassphraseEntry(
+      passphrase,
       credentials,
+      mergeResult.value,
+    );
+
+    set({
+      credentials: finalCreds,
       status: "synced",
       lastSyncedAt: pushResult.value.updatedAt,
       lastVaultEtag: pushResult.value.etag,
@@ -462,6 +476,38 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
     return ok(true);
   },
 }));
+
+/**
+ * Auto-upgrade hook for any passphrase-entry flow: when the cloud
+ * envelope is still on the legacy PBKDF2 KDF, derive a fresh Argon2id
+ * key, re-encrypt + push, and persist the new key locally so the
+ * device's stored JWK stays aligned with the cloud's encoding.
+ *
+ * Best-effort by design — failure here MUST NOT break recovery. The
+ * caller continues with the original `current` credentials and the
+ * upgrade can retry on the next passphrase entry.
+ *
+ * See CLAUDE.md "Auto-upgrade on next passphrase entry" — this is
+ * the migration plan for existing PBKDF2 sync users to land on
+ * Argon2id without a UI prompt.
+ */
+async function autoUpgradeOnPassphraseEntry(
+  passphrase: string,
+  current: SyncCredentials,
+  vault: VaultData,
+): Promise<SyncCredentials> {
+  const upgraded = await upgradeVaultKdf(passphrase, current, vault);
+  if (!upgraded.ok || upgraded.value === current) return current;
+  const persistResult = await updateStoredVaultKey(upgraded.value);
+  // If persistence fails, the cloud has been upgraded but local
+  // can't store the new JWK — degrade gracefully: keep using the
+  // old in-memory creds. The local JWK still decrypts what's in
+  // IndexedDB; only future cloud pulls would mismatch, and those
+  // will trigger a recovery flow that will derive the right key
+  // from the envelope's spec.
+  if (!persistResult.ok) return current;
+  return upgraded.value;
+}
 
 /**
  * Apply timestamp last-write-wins to the preferences carried by a pulled

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -168,6 +168,7 @@ describe("App sync-aware init", () => {
     const mockCredentials = {
       vaultId: "stored-vault-id",
       vaultKey: "mock-key" as unknown as CryptoKey,
+      kdfSpec: { kind: "pbkdf2-600k" } as const,
     };
     vi.mocked(restore).mockResolvedValue({
       status: "ready",

--- a/tests/components/onboarding/onboarding-modal.test.tsx
+++ b/tests/components/onboarding/onboarding-modal.test.tsx
@@ -15,7 +15,11 @@ vi.mock("@/core/storage/key-manager", () => ({
   destroy: vi.fn().mockResolvedValue(undefined),
   addVaultKeys: vi.fn().mockResolvedValue({
     ok: true,
-    value: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" },
+    value: {
+      vaultId: "mock-vault-id",
+      vaultKey: "mock-vault-key",
+      kdfSpec: { kind: "pbkdf2-600k" },
+    },
   }),
   removeVaultKeys: vi.fn(),
   destroyLocal: vi.fn().mockResolvedValue(undefined),

--- a/tests/components/onboarding/recovery-step.test.tsx
+++ b/tests/components/onboarding/recovery-step.test.tsx
@@ -14,13 +14,25 @@ vi.mock("@/core/storage/key-manager", () => ({
 
 vi.mock("@/core/sync/sync-service", () => ({
   pushVault: vi.fn().mockResolvedValue({ ok: true, value: Date.now() }),
-  pullVault: vi.fn().mockResolvedValue({ ok: false, error: "Not found" }),
+  recoverVault: vi
+    .fn()
+    .mockResolvedValue({ ok: false, error: "Not found" }),
   importVault: vi.fn().mockResolvedValue({ ok: true, value: true }),
   checkVaultExists: vi.fn().mockResolvedValue({ ok: true, value: true }),
 }));
 
 import { initFresh } from "@/core/storage/key-manager";
-import { pullVault, importVault, checkVaultExists } from "@/core/sync/sync-service";
+import {
+  recoverVault,
+  importVault,
+  checkVaultExists,
+} from "@/core/sync/sync-service";
+
+const FAKE_RECOVERED_CREDENTIALS = {
+  vaultId: "mock-vault-id",
+  vaultKey: "mock-vault-key" as unknown as CryptoKey,
+  kdfSpec: { kind: "pbkdf2-600k" } as const,
+};
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -108,9 +120,9 @@ describe("RecoveryStep", () => {
 
   it("shows error when db open fails", async () => {
     const user = userEvent.setup();
-    vi.mocked(pullVault).mockResolvedValue({
+    vi.mocked(recoverVault).mockResolvedValue({
       ok: true,
-      value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+      value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
     });
     vi.mocked(initFresh).mockResolvedValue({
       ok: false,
@@ -132,14 +144,14 @@ describe("RecoveryStep", () => {
 
   it("completes onboarding when passphrase is valid and vault exists", async () => {
     const user = userEvent.setup();
-    vi.mocked(pullVault).mockResolvedValue({
+    vi.mocked(recoverVault).mockResolvedValue({
       ok: true,
-      value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+      value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
     });
     vi.mocked(initFresh).mockResolvedValue({
       ok: true,
       value: {
-        credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey },
+        credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
       },
     });
     vi.mocked(importVault).mockResolvedValue({ ok: true, value: true });
@@ -159,14 +171,14 @@ describe("RecoveryStep", () => {
 
   it("stores derived keys on recovery", async () => {
     const user = userEvent.setup();
-    vi.mocked(pullVault).mockResolvedValue({
+    vi.mocked(recoverVault).mockResolvedValue({
       ok: true,
-      value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+      value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
     });
     vi.mocked(initFresh).mockResolvedValue({
       ok: true,
       value: {
-        credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey },
+        credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
       },
     });
     vi.mocked(importVault).mockResolvedValue({ ok: true, value: true });
@@ -185,7 +197,7 @@ describe("RecoveryStep", () => {
 
     expect(initFresh).toHaveBeenCalledWith(
       "carbon mango velvet prism",
-      { sync: true, skipServerCleanup: true },
+      { sync: true, skipServerCleanup: true, vaultKdfSpec: FAKE_RECOVERED_CREDENTIALS.kdfSpec },
     );
   });
 
@@ -220,10 +232,10 @@ describe("RecoveryStep", () => {
       vi.mocked(initFresh).mockResolvedValue({
       ok: true,
       value: {
-        credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey },
+        credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
       },
     });
-      vi.mocked(pullVault).mockResolvedValue({ ok: true, value: vaultData });
+      vi.mocked(recoverVault).mockResolvedValue({ ok: true, value: { vault: vaultData, credentials: FAKE_RECOVERED_CREDENTIALS } });
       vi.mocked(importVault).mockResolvedValue({ ok: true, value: true });
 
       renderInDialog(<RecoveryStep />);
@@ -239,7 +251,7 @@ describe("RecoveryStep", () => {
       });
 
       // pullVault is called with derived credentials (not raw passphrase)
-      expect(pullVault).toHaveBeenCalled();
+      expect(recoverVault).toHaveBeenCalled();
       expect(importVault).toHaveBeenCalledWith(vaultData);
     });
 
@@ -248,12 +260,12 @@ describe("RecoveryStep", () => {
       vi.mocked(initFresh).mockResolvedValue({
       ok: true,
       value: {
-        credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey },
+        credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
       },
     });
-      vi.mocked(pullVault).mockResolvedValue({
+      vi.mocked(recoverVault).mockResolvedValue({
         ok: true,
-        value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+        value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
       });
       vi.mocked(importVault).mockResolvedValue({ ok: true, value: true });
 
@@ -274,11 +286,11 @@ describe("RecoveryStep", () => {
     it("pulls vault BEFORE calling initFresh (no destructive ops before read)", async () => {
       const user = userEvent.setup();
       const callOrder: string[] = [];
-      vi.mocked(pullVault).mockImplementation(async () => {
-        callOrder.push("pullVault");
+      vi.mocked(recoverVault).mockImplementation(async () => {
+        callOrder.push("recoverVault");
         return {
           ok: true,
-          value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+          value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
         };
       });
       vi.mocked(initFresh).mockImplementation(async () => {
@@ -286,7 +298,7 @@ describe("RecoveryStep", () => {
         return {
           ok: true,
           value: {
-            credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey },
+            credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
           },
         };
       });
@@ -304,19 +316,19 @@ describe("RecoveryStep", () => {
         expect(useAppStore.getState().hasCompletedOnboarding).toBe(true);
       });
 
-      expect(callOrder).toEqual(["pullVault", "initFresh"]);
+      expect(callOrder).toEqual(["recoverVault", "initFresh"]);
     });
 
     it("calls initFresh with skipServerCleanup during recovery", async () => {
       const user = userEvent.setup();
-      vi.mocked(pullVault).mockResolvedValue({
+      vi.mocked(recoverVault).mockResolvedValue({
         ok: true,
-        value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+        value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
       });
       vi.mocked(initFresh).mockResolvedValue({
         ok: true,
         value: {
-          credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey },
+          credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
         },
       });
       vi.mocked(importVault).mockResolvedValue({ ok: true, value: true });
@@ -332,7 +344,7 @@ describe("RecoveryStep", () => {
       await waitFor(() => {
         expect(initFresh).toHaveBeenCalledWith(
           "carbon mango velvet prism",
-          { sync: true, skipServerCleanup: true },
+          { sync: true, skipServerCleanup: true, vaultKdfSpec: FAKE_RECOVERED_CREDENTIALS.kdfSpec },
         );
       });
     });
@@ -342,12 +354,12 @@ describe("RecoveryStep", () => {
       vi.mocked(initFresh).mockResolvedValue({
         ok: true,
         value: {
-          credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey },
+          credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
         },
       });
-      vi.mocked(pullVault).mockResolvedValue({
+      vi.mocked(recoverVault).mockResolvedValue({
         ok: true,
-        value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+        value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
       });
       vi.mocked(importVault).mockResolvedValue({ ok: true, value: true });
 
@@ -362,7 +374,7 @@ describe("RecoveryStep", () => {
       await waitFor(() => {
         expect(initFresh).toHaveBeenCalledWith(
           "carbon mango velvet prism",
-          { sync: true, skipServerCleanup: true },
+          { sync: true, skipServerCleanup: true, vaultKdfSpec: FAKE_RECOVERED_CREDENTIALS.kdfSpec },
         );
       });
     });
@@ -375,14 +387,14 @@ describe("RecoveryStep", () => {
 
     it("submits on Enter key in input field", async () => {
       const user = userEvent.setup();
-      vi.mocked(pullVault).mockResolvedValue({
+      vi.mocked(recoverVault).mockResolvedValue({
         ok: true,
-        value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+        value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
       });
       vi.mocked(initFresh).mockResolvedValue({
         ok: true,
         value: {
-          credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey },
+          credentials: { vaultId: "mock-vault-id", vaultKey: "mock-vault-key" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
         },
       });
       vi.mocked(importVault).mockResolvedValue({ ok: true, value: true });
@@ -401,7 +413,7 @@ describe("RecoveryStep", () => {
 
     it("shows error and does not complete onboarding when pull fails", async () => {
       const user = userEvent.setup();
-      vi.mocked(pullVault).mockResolvedValue({
+      vi.mocked(recoverVault).mockResolvedValue({
         ok: false,
         error: "Sync pull failed (404): Not found",
       });
@@ -435,11 +447,11 @@ describe("RecoveryStep", () => {
         callOrder.push("checkVaultExists");
         return { ok: true, value: true };
       });
-      vi.mocked(pullVault).mockImplementation(async () => {
-        callOrder.push("pullVault");
+      vi.mocked(recoverVault).mockImplementation(async () => {
+        callOrder.push("recoverVault");
         return {
           ok: true,
-          value: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] },
+          value: { vault: { version: 1, exportedAt: Date.now(), feeds: [], articles: [] }, credentials: FAKE_RECOVERED_CREDENTIALS },
         };
       });
       vi.mocked(initFresh).mockResolvedValue({
@@ -448,6 +460,7 @@ describe("RecoveryStep", () => {
           credentials: {
             vaultId: "v",
             vaultKey: "k" as unknown as CryptoKey,
+            kdfSpec: { kind: "pbkdf2-600k" } as const,
           },
         },
       });
@@ -464,7 +477,7 @@ describe("RecoveryStep", () => {
       });
       // HEAD before GET — cheaper failure when the passphrase is wrong,
       // and lets the UI distinguish "checking" from "restoring."
-      expect(callOrder).toEqual(["checkVaultExists", "pullVault"]);
+      expect(callOrder).toEqual(["checkVaultExists", "recoverVault"]);
     });
 
     it("short-circuits when checkVaultExists returns false — no pullVault, no initFresh", async () => {
@@ -488,7 +501,7 @@ describe("RecoveryStep", () => {
       });
 
       // The whole point: bail before the destructive flow.
-      expect(pullVault).not.toHaveBeenCalled();
+      expect(recoverVault).not.toHaveBeenCalled();
       expect(initFresh).not.toHaveBeenCalled();
       expect(useAppStore.getState().hasCompletedOnboarding).toBe(false);
     });
@@ -513,7 +526,7 @@ describe("RecoveryStep", () => {
       await waitFor(() => {
         expect(screen.getByText(/backend overloaded/i)).toBeInTheDocument();
       });
-      expect(pullVault).not.toHaveBeenCalled();
+      expect(recoverVault).not.toHaveBeenCalled();
       expect(initFresh).not.toHaveBeenCalled();
     });
   });

--- a/tests/components/onboarding/recovery-step.test.tsx
+++ b/tests/components/onboarding/recovery-step.test.tsx
@@ -10,6 +10,9 @@ import { useSyncStore } from "@/stores/sync-store";
 vi.mock("@/core/storage/key-manager", () => ({
   initFresh: vi.fn(),
   persistDerivedKeysFromOpenDb: vi.fn().mockResolvedValue({ ok: true, value: {} }),
+  updateStoredVaultKey: vi
+    .fn()
+    .mockResolvedValue({ ok: true, value: undefined }),
 }));
 
 vi.mock("@/core/sync/sync-service", () => ({
@@ -17,6 +20,13 @@ vi.mock("@/core/sync/sync-service", () => ({
   recoverVault: vi
     .fn()
     .mockResolvedValue({ ok: false, error: "Not found" }),
+  // Default: no-op (returns the same creds the caller passed in). The
+  // recovery flow treats `upgradeVaultKdf` as best-effort, so this
+  // covers all tests that don't specifically exercise the upgrade.
+  upgradeVaultKdf: vi.fn().mockImplementation(
+    async (_passphrase: string, current: unknown) =>
+      ({ ok: true, value: current }),
+  ),
   importVault: vi.fn().mockResolvedValue({ ok: true, value: true }),
   checkVaultExists: vi.fn().mockResolvedValue({ ok: true, value: true }),
 }));

--- a/tests/components/settings/data-sync-disable-fork.test.tsx
+++ b/tests/components/settings/data-sync-disable-fork.test.tsx
@@ -41,6 +41,7 @@ import { deleteVault as deleteVaultMock } from "@/core/sync/sync-service";
 const mockCredentials = {
   vaultId: "test-vault-id",
   vaultKey: "test-vault-key" as unknown as CryptoKey,
+  kdfSpec: { kind: "pbkdf2-600k" } as const,
 };
 
 function renderSection() {

--- a/tests/core/crypto/argon2.test.ts
+++ b/tests/core/crypto/argon2.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveArgon2idKey,
+  ARGON2ID_TEST_PARAMS,
+} from "@/core/crypto/argon2";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+async function encryptString(key: CryptoKey, plaintext: string) {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: iv as BufferSource },
+    key,
+    encoder.encode(plaintext) as BufferSource,
+  );
+  return { iv, ct: new Uint8Array(ct) };
+}
+
+async function decryptString(
+  key: CryptoKey,
+  iv: Uint8Array,
+  ct: Uint8Array,
+): Promise<string> {
+  const pt = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: iv as BufferSource },
+    key,
+    ct as BufferSource,
+  );
+  return decoder.decode(pt);
+}
+
+describe("deriveArgon2idKey", () => {
+  const salt = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+
+  it("derives an AES-GCM CryptoKey from a passphrase", async () => {
+    const result = await deriveArgon2idKey(
+      "correct horse battery staple",
+      salt,
+      ARGON2ID_TEST_PARAMS,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.algorithm).toMatchObject({ name: "AES-GCM" });
+  });
+
+  it("same passphrase + salt + params produces an equivalent key", async () => {
+    const a = await deriveArgon2idKey("rosebud", salt, ARGON2ID_TEST_PARAMS);
+    const b = await deriveArgon2idKey("rosebud", salt, ARGON2ID_TEST_PARAMS);
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+
+    const { iv, ct } = await encryptString(a.value, "the package is in the lobby");
+    const plaintext = await decryptString(b.value, iv, ct);
+    expect(plaintext).toBe("the package is in the lobby");
+  });
+
+  it("different passphrases produce non-interchangeable keys", async () => {
+    const a = await deriveArgon2idKey("alpha", salt, ARGON2ID_TEST_PARAMS);
+    const b = await deriveArgon2idKey("bravo", salt, ARGON2ID_TEST_PARAMS);
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+
+    const { iv, ct } = await encryptString(a.value, "secret");
+    await expect(decryptString(b.value, iv, ct)).rejects.toThrow();
+  });
+
+  it("different salts produce non-interchangeable keys", async () => {
+    const saltA = new Uint8Array(16).fill(1);
+    const saltB = new Uint8Array(16).fill(2);
+    const a = await deriveArgon2idKey("rosebud", saltA, ARGON2ID_TEST_PARAMS);
+    const b = await deriveArgon2idKey("rosebud", saltB, ARGON2ID_TEST_PARAMS);
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+
+    const { iv, ct } = await encryptString(a.value, "secret");
+    await expect(decryptString(b.value, iv, ct)).rejects.toThrow();
+  });
+
+  it("respects the extractable flag (default: non-extractable)", async () => {
+    const nonExtractable = await deriveArgon2idKey(
+      "rosebud",
+      salt,
+      ARGON2ID_TEST_PARAMS,
+    );
+    expect(nonExtractable.ok).toBe(true);
+    if (!nonExtractable.ok) return;
+    await expect(
+      crypto.subtle.exportKey("raw", nonExtractable.value),
+    ).rejects.toThrow();
+
+    const extractable = await deriveArgon2idKey(
+      "rosebud",
+      salt,
+      ARGON2ID_TEST_PARAMS,
+      { extractable: true },
+    );
+    expect(extractable.ok).toBe(true);
+    if (!extractable.ok) return;
+    const raw = await crypto.subtle.exportKey("raw", extractable.value);
+    expect(raw.byteLength).toBe(32);
+  });
+});

--- a/tests/core/sync/cross-device-roundtrip.test.ts
+++ b/tests/core/sync/cross-device-roundtrip.test.ts
@@ -215,7 +215,7 @@ describe("cross-device sync round-trip via openWithKeys", () => {
       name: CRYPTO.ALGORITHM,
       length: CRYPTO.KEY_LENGTH,
     });
-    const credentials = { vaultId: stored.vaultId!, vaultKey };
+    const credentials = { vaultId: stored.vaultId!, vaultKey, kdfSpec: stored.vaultKdfSpec ?? { kind: "pbkdf2-600k" as const } };
 
     // Device A: open via JWKs, add feeds, push via sync-service
     unwrap(await openWithKeys(stored.dbKeyJwk, stored.hmacKeyJwk));
@@ -270,7 +270,7 @@ describe("cross-device sync round-trip via openWithKeys", () => {
       name: CRYPTO.ALGORITHM,
       length: CRYPTO.KEY_LENGTH,
     });
-    const credentials = { vaultId: stored.vaultId!, vaultKey };
+    const credentials = { vaultId: stored.vaultId!, vaultKey, kdfSpec: stored.vaultKdfSpec ?? { kind: "pbkdf2-600k" as const } };
 
     // Device A: push a 100-feed vault.
     unwrap(await openWithKeys(stored.dbKeyJwk, stored.hmacKeyJwk));

--- a/tests/core/sync/recover-vault.test.ts
+++ b/tests/core/sync/recover-vault.test.ts
@@ -139,6 +139,138 @@ describe("recoverVault", () => {
 });
 
 /**
+ * Auto-upgrade: a recovery-flow caller can upgrade a legacy PBKDF2
+ * vault to Argon2id by deriving a new key, re-encrypting the vault
+ * with that key, and pushing back to the same vault ID. The cloud
+ * envelope is rewritten in place — vault ID derivation is PBKDF2-
+ * only by design, so no migration of identifiers is needed.
+ */
+describe("upgradeVaultKdf", () => {
+  const PASSPHRASE = "carbon mango velvet prism";
+  const TARGET_SPEC = {
+    kind: "argon2id" as const,
+    memoryKib: 256,
+    iterations: 1,
+    parallelism: 1,
+  };
+
+  beforeEach(async () => {
+    const result = await open(PASSPHRASE);
+    if (!result.ok) throw new Error(result.error);
+  });
+
+  afterEach(() => {
+    close();
+    indexedDB.deleteDatabase("feedzero");
+    vi.restoreAllMocks();
+  });
+
+  it("re-encrypts a legacy vault with Argon2id and PUTs to the same vault ID", async () => {
+    const { upgradeVaultKdf } = await import("@/core/sync/sync-service");
+
+    const legacyKey = unwrap(
+      await deriveVaultKey(PASSPHRASE, {
+        extractable: true,
+        kdfSpec: LEGACY_KDF_SPEC,
+      }),
+    );
+    const vaultId = unwrap(await deriveVaultId(PASSPHRASE));
+    const legacyCreds = { vaultId, vaultKey: legacyKey, kdfSpec: LEGACY_KDF_SPEC };
+
+    const vault = unwrap(await exportVault());
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true, updatedAt: Date.now() }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await upgradeVaultKdf(
+      PASSPHRASE,
+      legacyCreds,
+      vault,
+      TARGET_SPEC,
+    );
+    expect(isOk(result)).toBe(true);
+    if (!result.ok) return;
+
+    // Returned creds carry the new spec, same vault ID, new vault key
+    expect(result.value.kdfSpec).toEqual(TARGET_SPEC);
+    expect(result.value.vaultId).toBe(vaultId);
+    expect(result.value.vaultKey).not.toBe(legacyKey);
+
+    // The push targets the same vault ID and stamps Argon2id on the envelope
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.vaultId).toBe(vaultId);
+    expect(body.vault.kdf).toEqual(TARGET_SPEC);
+  });
+
+  it("is a no-op when the credentials already use the target spec", async () => {
+    const { upgradeVaultKdf } = await import("@/core/sync/sync-service");
+
+    const argonKey = unwrap(
+      await deriveVaultKey(PASSPHRASE, {
+        extractable: true,
+        kdfSpec: TARGET_SPEC,
+      }),
+    );
+    const vaultId = unwrap(await deriveVaultId(PASSPHRASE));
+    const argonCreds = { vaultId, vaultKey: argonKey, kdfSpec: TARGET_SPEC };
+
+    const vault = unwrap(await exportVault());
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await upgradeVaultKdf(
+      PASSPHRASE,
+      argonCreds,
+      vault,
+      TARGET_SPEC,
+    );
+    expect(isOk(result)).toBe(true);
+    if (!result.ok) return;
+
+    // Same creds returned, no network call
+    expect(result.value).toBe(argonCreds);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns err on push failure (caller falls back to legacy creds)", async () => {
+    const { upgradeVaultKdf } = await import("@/core/sync/sync-service");
+
+    const legacyKey = unwrap(
+      await deriveVaultKey(PASSPHRASE, {
+        extractable: true,
+        kdfSpec: LEGACY_KDF_SPEC,
+      }),
+    );
+    const vaultId = unwrap(await deriveVaultId(PASSPHRASE));
+    const legacyCreds = { vaultId, vaultKey: legacyKey, kdfSpec: LEGACY_KDF_SPEC };
+
+    const vault = unwrap(await exportVault());
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Internal error"),
+      }),
+    );
+
+    const result = await upgradeVaultKdf(
+      PASSPHRASE,
+      legacyCreds,
+      vault,
+      TARGET_SPEC,
+    );
+    expect(isErr(result)).toBe(true);
+  });
+});
+
+/**
  * pushVault now stamps the credentials' `kdfSpec` onto the cloud
  * envelope. The signup-time wiring in `addVaultKeys` / `initFresh`
  * passes Argon2id by default, so a recovering device sees the

--- a/tests/core/sync/recover-vault.test.ts
+++ b/tests/core/sync/recover-vault.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { open, close, addFeed } from "@/core/storage/db";
+import { createFeed } from "@/core/storage/schema";
+import { unwrap, isOk, isErr } from "@feedzero/core/utils/result";
+import {
+  exportVault,
+  pushVault,
+  recoverVault,
+} from "@/core/sync/sync-service";
+import {
+  encryptVault,
+  deriveVaultId,
+  deriveVaultKey,
+  DEFAULT_NEW_VAULT_KDF,
+  LEGACY_KDF_SPEC,
+} from "@/core/sync/vault-crypto";
+
+/**
+ * Recovery-flow tests: a new device with only the passphrase reads
+ * the cloud envelope's stamped KDF, derives the matching key, and
+ * returns credentials whose `kdfSpec` matches the envelope. The
+ * key-data coupling invariant from CLAUDE.md depends on this — if
+ * recoverVault returned the wrong spec, the next push would re-
+ * encrypt the cloud vault with a key the original device cannot
+ * reproduce.
+ */
+describe("recoverVault", () => {
+  const PASSPHRASE = "carbon mango velvet prism";
+
+  beforeEach(async () => {
+    const result = await open(PASSPHRASE);
+    if (!result.ok) throw new Error(result.error);
+  });
+
+  afterEach(() => {
+    close();
+    indexedDB.deleteDatabase("feedzero");
+    vi.restoreAllMocks();
+  });
+
+  async function stageVaultOnFakeServer(envelopeKdfSpec?: typeof DEFAULT_NEW_VAULT_KDF) {
+    const feed = unwrap(
+      createFeed({ url: "https://example.com/rss", title: "Recovered" }),
+    );
+    await addFeed(feed);
+
+    const vault = unwrap(await exportVault());
+    const kdfSpec = envelopeKdfSpec;
+    const key = unwrap(
+      await deriveVaultKey(PASSPHRASE, {
+        extractable: true,
+        kdfSpec: kdfSpec ?? LEGACY_KDF_SPEC,
+      }),
+    );
+    const encrypted = unwrap(await encryptVault(key, vault, kdfSpec));
+    return encrypted;
+  }
+
+  it("decrypts a legacy (no-kdf) envelope and returns LEGACY credentials", async () => {
+    const encrypted = await stageVaultOnFakeServer();
+    expect("kdf" in encrypted).toBe(false);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, vault: encrypted }),
+      }),
+    );
+
+    const result = await recoverVault(PASSPHRASE);
+    expect(isOk(result)).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.credentials.kdfSpec).toEqual(LEGACY_KDF_SPEC);
+    expect(result.value.vault.feeds[0].title).toBe("Recovered");
+  });
+
+  it("decrypts an Argon2id envelope and returns Argon2id credentials", async () => {
+    const spec = {
+      kind: "argon2id" as const,
+      memoryKib: 256,
+      iterations: 1,
+      parallelism: 1,
+    };
+    const encrypted = await stageVaultOnFakeServer(spec);
+    expect(encrypted.kdf).toEqual(spec);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, vault: encrypted }),
+      }),
+    );
+
+    const result = await recoverVault(PASSPHRASE);
+    expect(isOk(result)).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.credentials.kdfSpec).toEqual(spec);
+    expect(result.value.vault.feeds[0].title).toBe("Recovered");
+  });
+
+  it("returns an err with a guiding message on 404 (no vault for this passphrase)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("Not found"),
+      }),
+    );
+
+    const result = await recoverVault(PASSPHRASE);
+    expect(isErr(result)).toBe(true);
+    if (result.ok) return;
+    expect(result.error).toMatch(/no cloud vault was found/i);
+    expect(result.error).toMatch(/every word matters/i);
+  });
+
+  it("recovered credentials' vaultId equals the passphrase-derived vault ID", async () => {
+    const encrypted = await stageVaultOnFakeServer();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, vault: encrypted }),
+      }),
+    );
+
+    const result = await recoverVault(PASSPHRASE);
+    expect(isOk(result)).toBe(true);
+    if (!result.ok) return;
+    const expectedId = unwrap(await deriveVaultId(PASSPHRASE));
+    expect(result.value.credentials.vaultId).toBe(expectedId);
+  });
+});
+
+/**
+ * pushVault now stamps the credentials' `kdfSpec` onto the cloud
+ * envelope. The signup-time wiring in `addVaultKeys` / `initFresh`
+ * passes Argon2id by default, so a recovering device sees the
+ * memory-hard spec and re-derives the same key.
+ */
+describe("pushVault stamps the KDF spec on the envelope", () => {
+  beforeEach(async () => {
+    const result = await open("test-passphrase");
+    if (!result.ok) throw new Error(result.error);
+  });
+
+  afterEach(() => {
+    close();
+    indexedDB.deleteDatabase("feedzero");
+    vi.restoreAllMocks();
+  });
+
+  it("stamps the credentials' kdfSpec on the pushed envelope", async () => {
+    const argonSpec = {
+      kind: "argon2id" as const,
+      memoryKib: 256,
+      iterations: 1,
+      parallelism: 1,
+    };
+    const vaultKey = unwrap(
+      await deriveVaultKey("test-passphrase", {
+        extractable: true,
+        kdfSpec: argonSpec,
+      }),
+    );
+    const vaultId = unwrap(await deriveVaultId("test-passphrase"));
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true, updatedAt: Date.now() }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await pushVault({
+      vaultId,
+      vaultKey,
+      kdfSpec: argonSpec,
+    });
+    expect(isOk(result)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.vault.kdf).toEqual(argonSpec);
+  });
+
+  it("stamps LEGACY when the credentials say legacy (back-compat for PBKDF2 users)", async () => {
+    const vaultKey = unwrap(
+      await deriveVaultKey("test-passphrase", {
+        extractable: true,
+        kdfSpec: LEGACY_KDF_SPEC,
+      }),
+    );
+    const vaultId = unwrap(await deriveVaultId("test-passphrase"));
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true, updatedAt: Date.now() }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await pushVault({
+      vaultId,
+      vaultKey,
+      kdfSpec: LEGACY_KDF_SPEC,
+    });
+    expect(isOk(result)).toBe(true);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.vault.kdf).toEqual(LEGACY_KDF_SPEC);
+  });
+});

--- a/tests/core/sync/vault-crypto.test.ts
+++ b/tests/core/sync/vault-crypto.test.ts
@@ -103,6 +103,59 @@ describe("vault-crypto", () => {
       expect(isOk(decrypted)).toBe(true);
       expect(unwrap(decrypted).feeds[0].title).toBe("Example Feed");
     });
+
+    it("defaults to the legacy PBKDF2 KDF when no spec is given", async () => {
+      // Locks in that pre-existing callers (no spec arg) keep PBKDF2 —
+      // any silent switch to Argon2id here would mean a primary-device
+      // user's stored JWK no longer matches what `deriveVaultKey`
+      // produces on a passphrase re-entry, breaking recovery.
+      const legacy = unwrap(await deriveVaultKey("carbon mango velvet prism"));
+      const explicit = unwrap(
+        await deriveVaultKey("carbon mango velvet prism", {
+          kdfSpec: LEGACY_KDF_SPEC,
+        }),
+      );
+      const encrypted = unwrap(await encryptVault(legacy, makeVault()));
+      const decrypted = await decryptVault(explicit, encrypted);
+      expect(isOk(decrypted)).toBe(true);
+    });
+
+    it("derives via Argon2id when given an argon2id spec", async () => {
+      const spec: KdfSpec = {
+        kind: "argon2id",
+        memoryKib: 256,
+        iterations: 1,
+        parallelism: 1,
+      };
+      const key = unwrap(
+        await deriveVaultKey("carbon mango velvet prism", { kdfSpec: spec }),
+      );
+      const sameKey = unwrap(
+        await deriveVaultKey("carbon mango velvet prism", { kdfSpec: spec }),
+      );
+      const vault = makeVault();
+      const encrypted = unwrap(await encryptVault(key, vault, spec));
+      const decrypted = unwrap(await decryptVault(sameKey, encrypted));
+      expect(decrypted.feeds[0].title).toBe("Example Feed");
+      expect(encrypted.kdf).toEqual(spec);
+    });
+
+    it("Argon2id and PBKDF2 keys are NOT interchangeable for the same passphrase", async () => {
+      const argon = unwrap(
+        await deriveVaultKey("carbon mango velvet prism", {
+          kdfSpec: {
+            kind: "argon2id",
+            memoryKib: 256,
+            iterations: 1,
+            parallelism: 1,
+          },
+        }),
+      );
+      const pbkdf2 = unwrap(await deriveVaultKey("carbon mango velvet prism"));
+      const encrypted = unwrap(await encryptVault(argon, makeVault()));
+      const decrypted = await decryptVault(pbkdf2, encrypted);
+      expect(isErr(decrypted)).toBe(true);
+    });
   });
 
   describe("encryptVault / decryptVault", () => {

--- a/tests/core/sync/vault-crypto.test.ts
+++ b/tests/core/sync/vault-crypto.test.ts
@@ -5,10 +5,12 @@ import {
   deriveVaultKey,
   encryptVault,
   decryptVault,
+  readKdfSpec,
+  LEGACY_KDF_SPEC,
 } from "@/core/sync/vault-crypto";
 import { isOk, isErr, unwrap } from "@feedzero/core/utils/result";
 import { SYNC } from "@feedzero/core/utils/constants";
-import type { VaultData } from "@/core/sync/types";
+import type { VaultData, KdfSpec } from "@/core/sync/types";
 
 function makeVault(overrides: Partial<VaultData> = {}): VaultData {
   return {
@@ -196,6 +198,80 @@ describe("vault-crypto", () => {
       const decrypted = unwrap(await decryptVault(key, v3Encrypted));
       expect(decrypted.feeds).toEqual(vault.feeds);
       expect(decrypted.articles).toEqual(vault.articles);
+    });
+  });
+
+  describe("KDF spec on the envelope", () => {
+    it("encryptVault omits the kdf field when no spec is provided (back-compat)", async () => {
+      const key = unwrap(await deriveVaultKey("carbon mango velvet prism"));
+      const encrypted = unwrap(await encryptVault(key, makeVault()));
+      expect("kdf" in encrypted).toBe(false);
+    });
+
+    it("encryptVault stamps the kdf field when a spec is provided", async () => {
+      const key = unwrap(await deriveVaultKey("carbon mango velvet prism"));
+      const spec: KdfSpec = {
+        kind: "argon2id",
+        memoryKib: 65536,
+        iterations: 3,
+        parallelism: 1,
+      };
+      const encrypted = unwrap(
+        await encryptVault(key, makeVault(), spec),
+      );
+      expect(encrypted.kdf).toEqual(spec);
+    });
+
+    it("decryptVault still works on envelopes missing the kdf field", async () => {
+      // Decryption never reads the kdf field — the field is metadata for
+      // the recovery flow only. This locks in that legacy envelopes
+      // continue to decrypt without any code path change.
+      const key = unwrap(await deriveVaultKey("carbon mango velvet prism"));
+      const vault = makeVault();
+      const encrypted = unwrap(await encryptVault(key, vault));
+      const decrypted = unwrap(await decryptVault(key, encrypted));
+      expect(decrypted.feeds).toEqual(vault.feeds);
+    });
+
+    it("decryptVault works on envelopes that DO carry a kdf field", async () => {
+      const key = unwrap(await deriveVaultKey("carbon mango velvet prism"));
+      const vault = makeVault();
+      const encrypted = unwrap(
+        await encryptVault(key, vault, {
+          kind: "argon2id",
+          memoryKib: 256,
+          iterations: 1,
+          parallelism: 1,
+        }),
+      );
+      const decrypted = unwrap(await decryptVault(key, encrypted));
+      expect(decrypted.feeds).toEqual(vault.feeds);
+    });
+
+    it("readKdfSpec returns the legacy PBKDF2 default for envelopes without a kdf field", () => {
+      const envelope = {
+        version: SYNC.FORMAT_VERSION,
+        iv: [],
+        ciphertext: "",
+      };
+      expect(readKdfSpec(envelope)).toEqual(LEGACY_KDF_SPEC);
+      expect(LEGACY_KDF_SPEC).toEqual({ kind: "pbkdf2-600k" });
+    });
+
+    it("readKdfSpec returns the stamped spec when present", () => {
+      const spec: KdfSpec = {
+        kind: "argon2id",
+        memoryKib: 65536,
+        iterations: 3,
+        parallelism: 1,
+      };
+      const envelope = {
+        version: SYNC.FORMAT_VERSION,
+        iv: [],
+        ciphertext: "",
+        kdf: spec,
+      };
+      expect(readKdfSpec(envelope)).toEqual(spec);
     });
   });
 

--- a/tests/integration/sync-pending-push.test.ts
+++ b/tests/integration/sync-pending-push.test.ts
@@ -75,7 +75,11 @@ describe("sync: unpushed local rename survives a pull", () => {
     await open("test-passphrase");
     useFeedStore.setState({ feeds: [], feedsLoaded: false });
     useSyncStore.setState({
-      credentials: { vaultId: "vault", vaultKey: {} as CryptoKey },
+      credentials: {
+        vaultId: "vault",
+        vaultKey: {} as CryptoKey,
+        kdfSpec: { kind: "pbkdf2-600k" } as const,
+      },
       status: "synced",
     });
 

--- a/tests/integration/sync-store-db.test.ts
+++ b/tests/integration/sync-store-db.test.ts
@@ -126,6 +126,13 @@ vi.mock("../../src/core/sync/sync-service.ts", async () => {
     pullVault: (...args: unknown[]) => pullVaultMock(...args),
     pullVaultIfChanged: pullCompat,
     recoverVault: recoverCompat,
+    // No-op upgrade: integration tests pre-date the Argon2id rollout
+    // and their fixtures use legacy creds throughout. The real
+    // upgrade path is exercised by tests/core/sync/recover-vault.test.ts.
+    upgradeVaultKdf: async (
+      _passphrase: string,
+      current: unknown,
+    ) => ({ ok: true as const, value: current }),
     deleteVault: (...args: unknown[]) => deleteVaultMock(...args),
   };
 });

--- a/tests/integration/sync-store-db.test.ts
+++ b/tests/integration/sync-store-db.test.ts
@@ -90,11 +90,42 @@ vi.mock("../../src/core/sync/sync-service.ts", async () => {
       value: { notModified: false, vault: r.value, etag: null },
     };
   };
+  // recoverVault wraps the same vault fixture and pairs it with the
+  // legacy PBKDF2 credentials shape — these tests pre-date the
+  // Argon2id migration and use the legacy KDF as the safe default.
+  // The integration is what's interesting; the spec round-trip is
+  // covered by tests/core/sync/recover-vault.test.ts.
+  const vaultCrypto = await vi.importActual<
+    typeof import("../../src/core/sync/vault-crypto.ts")
+  >("../../src/core/sync/vault-crypto.ts");
+  const recoverCompat = async (passphrase: string) => {
+    const r = await pullVaultMock(passphrase);
+    if (!r.ok) return r;
+    const vid = await vaultCrypto.deriveVaultId(passphrase);
+    const vk = await vaultCrypto.deriveVaultKey(passphrase, {
+      extractable: true,
+      kdfSpec: vaultCrypto.LEGACY_KDF_SPEC,
+    });
+    if (!vid.ok) return vid;
+    if (!vk.ok) return vk;
+    return {
+      ok: true as const,
+      value: {
+        vault: r.value,
+        credentials: {
+          vaultId: vid.value,
+          vaultKey: vk.value,
+          kdfSpec: vaultCrypto.LEGACY_KDF_SPEC,
+        },
+      },
+    };
+  };
   return {
     ...actual,
     pushVault: (...args: unknown[]) => pushVaultMock(...args),
     pullVault: (...args: unknown[]) => pullVaultMock(...args),
     pullVaultIfChanged: pullCompat,
+    recoverVault: recoverCompat,
     deleteVault: (...args: unknown[]) => deleteVaultMock(...args),
   };
 });

--- a/tests/stores/app-store.test.ts
+++ b/tests/stores/app-store.test.ts
@@ -119,7 +119,7 @@ describe("app-store", () => {
   it("initialize passes sync option to initFresh", async () => {
     vi.mocked(initFresh).mockResolvedValue({
       ok: true,
-      value: { credentials: { vaultId: "v", vaultKey: "k" as unknown as CryptoKey } },
+      value: { credentials: { vaultId: "v", vaultKey: "k" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } } },
     });
 
     await useAppStore.getState().initialize("test-key", { sync: true });
@@ -253,6 +253,7 @@ describe("app-store", () => {
       const mockCredentials = {
         vaultId: "vault-id",
         vaultKey: "mock-key" as unknown as CryptoKey,
+      kdfSpec: { kind: "pbkdf2-600k" } as const,
       };
       vi.mocked(restore).mockResolvedValue({
         status: "ready",
@@ -283,6 +284,7 @@ describe("app-store", () => {
         credentials: {
           vaultId: "vault-id",
           vaultKey: "mock-key" as unknown as CryptoKey,
+        kdfSpec: { kind: "pbkdf2-600k" } as const,
         },
       });
       vi.mocked(pullVaultIfChanged).mockResolvedValue({
@@ -307,6 +309,7 @@ describe("app-store", () => {
         credentials: {
           vaultId: "vault-id",
           vaultKey: "mock-key" as unknown as CryptoKey,
+        kdfSpec: { kind: "pbkdf2-600k" } as const,
         },
       });
       // pullVaultIfChanged returns a promise that never resolves.

--- a/tests/stores/feed-store.test.ts
+++ b/tests/stores/feed-store.test.ts
@@ -786,7 +786,7 @@ describe("feed-store", () => {
       });
       vi.mocked(getFeeds).mockResolvedValue({ ok: true, value: [] });
       useSyncStore.setState({
-        credentials: { vaultId: "v", vaultKey: "k" as unknown as CryptoKey },
+        credentials: { vaultId: "v", vaultKey: "k" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
       });
 
       await useFeedStore.getState().refreshAll();
@@ -834,7 +834,7 @@ describe("feed-store", () => {
         return { ok: true, value: { results: [] } };
       });
       useSyncStore.setState({
-        credentials: { vaultId: "v", vaultKey: "k" as unknown as CryptoKey },
+        credentials: { vaultId: "v", vaultKey: "k" as unknown as CryptoKey, kdfSpec: { kind: "pbkdf2-600k" } },
       });
 
       await useFeedStore.getState().refreshAll();

--- a/tests/stores/sync-store-switch.test.ts
+++ b/tests/stores/sync-store-switch.test.ts
@@ -6,6 +6,10 @@ vi.mock("../../src/core/sync/sync-service", () => ({
   pullVault: vi.fn(),
   pullVaultIfChanged: vi.fn(),
   recoverVault: vi.fn(),
+  upgradeVaultKdf: vi.fn().mockImplementation(
+    async (_passphrase: string, current: unknown) =>
+      ({ ok: true, value: current }),
+  ),
   importVault: vi.fn(),
   deleteVault: vi.fn(),
   exportVault: vi.fn(),
@@ -30,6 +34,9 @@ vi.mock("../../src/core/storage/key-manager", () => ({
     .fn()
     .mockResolvedValue({ ok: true, value: {} }),
   assertKeyDataCoupling: vi
+    .fn()
+    .mockResolvedValue({ ok: true, value: undefined }),
+  updateStoredVaultKey: vi
     .fn()
     .mockResolvedValue({ ok: true, value: undefined }),
 }));

--- a/tests/stores/sync-store-switch.test.ts
+++ b/tests/stores/sync-store-switch.test.ts
@@ -4,6 +4,8 @@ import { useSyncStore } from "../../src/stores/sync-store";
 vi.mock("../../src/core/sync/sync-service", () => ({
   pushVault: vi.fn(),
   pullVault: vi.fn(),
+  pullVaultIfChanged: vi.fn(),
+  recoverVault: vi.fn(),
   importVault: vi.fn(),
   deleteVault: vi.fn(),
   exportVault: vi.fn(),
@@ -58,17 +60,37 @@ vi.mock("../../src/stores/preferences-store", () => ({
 
 import {
   pushVault,
-  pullVault,
+  recoverVault,
   importVault,
   exportVault,
   mergeVaults,
 } from "../../src/core/sync/sync-service";
 
 const mockPushVault = vi.mocked(pushVault);
-const mockPullVault = vi.mocked(pullVault);
+const mockRecoverVault = vi.mocked(recoverVault);
 const mockImportVault = vi.mocked(importVault);
 const mockExportVault = vi.mocked(exportVault);
 const mockMergeVaults = vi.mocked(mergeVaults);
+
+const RECOVERED_CREDENTIALS = {
+  vaultId: "mock-vault-id",
+  vaultKey: "mock-vault-key" as unknown as CryptoKey,
+  kdfSpec: { kind: "pbkdf2-600k" } as const,
+};
+
+/**
+ * Helper for the new recoverVault shape. The production code calls
+ * `recoverVault(passphrase)` and receives `{vault, credentials}` —
+ * tests that previously mocked `pullVault` returning the vault
+ * directly use this to express the same intent without dragging in
+ * the credentials' construction at every site.
+ */
+function mockRecoveredOk(vault: ReturnType<typeof makeVaultData>) {
+  return {
+    ok: true as const,
+    value: { vault, credentials: RECOVERED_CREDENTIALS },
+  };
+}
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -125,7 +147,7 @@ describe("sync-store switchToExistingCloud", () => {
   describe("replace mode", () => {
     it("pulls cloud vault and imports it (replacing local data)", async () => {
       const cloudVault = makeVaultData(3);
-      mockPullVault.mockResolvedValue({ ok: true, value: cloudVault });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(cloudVault));
       mockImportVault.mockResolvedValue({ ok: true, value: true });
 
       await useSyncStore
@@ -137,7 +159,7 @@ describe("sync-store switchToExistingCloud", () => {
 
     it("transitions to synced state on success", async () => {
       const cloudVault = makeVaultData(2);
-      mockPullVault.mockResolvedValue({ ok: true, value: cloudVault });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(cloudVault));
       mockImportVault.mockResolvedValue({ ok: true, value: true });
 
       await useSyncStore
@@ -157,7 +179,7 @@ describe("sync-store switchToExistingCloud", () => {
       // anything. Previously, importVault ran first (under stale local
       // keys), then a rekey wrote NEW keys to localStorage — leaving
       // key/data drift that nuked the server vault on next reload.
-      mockPullVault.mockResolvedValue({ ok: true, value: makeVaultData() });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(makeVaultData()));
       mockImportVault.mockResolvedValue({ ok: true, value: true });
 
       const db = await import("../../src/core/storage/db");
@@ -183,15 +205,15 @@ describe("sync-store switchToExistingCloud", () => {
       expect(vi.mocked(db.open)).toHaveBeenCalledWith("cloud-passphrase");
       expect(keyManager.persistDerivedKeysFromOpenDb).toHaveBeenCalledWith(
         "cloud-passphrase",
-        { sync: true },
+        { sync: true, vaultKdfSpec: RECOVERED_CREDENTIALS.kdfSpec },
       );
     });
 
     it("sets status to syncing during operation", async () => {
       let capturedStatus: string | null = null;
-      mockPullVault.mockImplementation(async () => {
+      mockRecoverVault.mockImplementation(async () => {
         capturedStatus = useSyncStore.getState().status;
-        return { ok: true, value: makeVaultData() };
+        return mockRecoveredOk(makeVaultData());
       });
       mockImportVault.mockResolvedValue({ ok: true, value: true });
 
@@ -203,7 +225,7 @@ describe("sync-store switchToExistingCloud", () => {
     });
 
     it("returns error when pull fails", async () => {
-      mockPullVault.mockResolvedValue({ ok: false, error: "Vault not found" });
+      mockRecoverVault.mockResolvedValue({ ok: false, error: "Vault not found" });
 
       const result = await useSyncStore
         .getState()
@@ -218,7 +240,7 @@ describe("sync-store switchToExistingCloud", () => {
     });
 
     it("returns error when import fails", async () => {
-      mockPullVault.mockResolvedValue({ ok: true, value: makeVaultData() });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(makeVaultData()));
       mockImportVault.mockResolvedValue({ ok: false, error: "Import failed" });
 
       const result = await useSyncStore
@@ -230,7 +252,7 @@ describe("sync-store switchToExistingCloud", () => {
     });
 
     it("does not push after replace (cloud already has data)", async () => {
-      mockPullVault.mockResolvedValue({ ok: true, value: makeVaultData() });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(makeVaultData()));
       mockImportVault.mockResolvedValue({ ok: true, value: true });
 
       await useSyncStore
@@ -248,7 +270,7 @@ describe("sync-store switchToExistingCloud", () => {
       const mergedVault = makeVaultData(5);
 
       mockExportVault.mockResolvedValue({ ok: true, value: localVault });
-      mockPullVault.mockResolvedValue({ ok: true, value: cloudVault });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(cloudVault));
       mockMergeVaults.mockReturnValue({ ok: true, value: mergedVault });
       mockImportVault.mockResolvedValue({ ok: true, value: true });
       mockPushVault.mockResolvedValue({ ok: true, value: { updatedAt: Date.now(), etag: null } });
@@ -267,7 +289,7 @@ describe("sync-store switchToExistingCloud", () => {
       const mergedVault = makeVaultData(5);
 
       mockExportVault.mockResolvedValue({ ok: true, value: localVault });
-      mockPullVault.mockResolvedValue({ ok: true, value: cloudVault });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(cloudVault));
       mockMergeVaults.mockReturnValue({ ok: true, value: mergedVault });
       mockImportVault.mockResolvedValue({ ok: true, value: true });
       mockPushVault.mockResolvedValue({ ok: true, value: { updatedAt: Date.now(), etag: null } });
@@ -282,7 +304,7 @@ describe("sync-store switchToExistingCloud", () => {
 
     it("transitions to synced state on success", async () => {
       mockExportVault.mockResolvedValue({ ok: true, value: makeVaultData(1) });
-      mockPullVault.mockResolvedValue({ ok: true, value: makeVaultData(2) });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(makeVaultData(2)));
       mockMergeVaults.mockReturnValue({ ok: true, value: makeVaultData(3) });
       mockImportVault.mockResolvedValue({ ok: true, value: true });
       mockPushVault.mockResolvedValue({ ok: true, value: { updatedAt: Date.now(), etag: null } });
@@ -305,12 +327,12 @@ describe("sync-store switchToExistingCloud", () => {
 
       expect(result.ok).toBe(false);
       expect(useSyncStore.getState().status).toBe("error");
-      expect(mockPullVault).not.toHaveBeenCalled();
+      expect(mockRecoverVault).not.toHaveBeenCalled();
     });
 
     it("returns error when pull fails", async () => {
       mockExportVault.mockResolvedValue({ ok: true, value: makeVaultData(1) });
-      mockPullVault.mockResolvedValue({ ok: false, error: "Pull failed" });
+      mockRecoverVault.mockResolvedValue({ ok: false, error: "Pull failed" });
 
       const result = await useSyncStore
         .getState()
@@ -323,7 +345,7 @@ describe("sync-store switchToExistingCloud", () => {
 
     it("returns error when merge fails", async () => {
       mockExportVault.mockResolvedValue({ ok: true, value: makeVaultData(1) });
-      mockPullVault.mockResolvedValue({ ok: true, value: makeVaultData(2) });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(makeVaultData(2)));
       mockMergeVaults.mockReturnValue({ ok: false, error: "Merge failed" });
 
       const result = await useSyncStore
@@ -338,7 +360,7 @@ describe("sync-store switchToExistingCloud", () => {
     it("returns error when push fails (but keeps local merged data)", async () => {
       const mergedVault = makeVaultData(3);
       mockExportVault.mockResolvedValue({ ok: true, value: makeVaultData(1) });
-      mockPullVault.mockResolvedValue({ ok: true, value: makeVaultData(2) });
+      mockRecoverVault.mockResolvedValue(mockRecoveredOk(makeVaultData(2)));
       mockMergeVaults.mockReturnValue({ ok: true, value: mergedVault });
       mockImportVault.mockResolvedValue({ ok: true, value: true });
       mockPushVault.mockResolvedValue({ ok: false, error: "Push failed" });

--- a/tests/stores/sync-store.test.ts
+++ b/tests/stores/sync-store.test.ts
@@ -51,6 +51,7 @@ const mockDeleteVault = vi.mocked(deleteVault);
 const mockCredentials = {
   vaultId: "test-vault-id",
   vaultKey: "test-vault-key" as unknown as CryptoKey,
+  kdfSpec: { kind: "pbkdf2-600k" } as const,
 };
 
 const localStorageMock = (() => {


### PR DESCRIPTION
## Summary

Replaces PBKDF2 with **Argon2id** for the sync-vault encryption key. The 4-word diceware passphrase (~51.7 bits of entropy) is no longer brute-forceable offline by GPU/ASIC farms — Argon2id is memory-hard, so each guess costs 64 MiB of RAM as well as compute, collapsing throughput from thousands of guesses/second per GPU to single digits.

The migration is **non-disruptive**:

- New sync signups → Argon2id from day one.
- Recovery on any new device → reads the envelope's stamped KDF and derives the matching key. Legacy PBKDF2 vaults still decrypt.
- Existing PBKDF2 users → auto-upgrade the cloud envelope to Argon2id the first time they type their passphrase (recovery flow, Settings → Restore from cloud, device-setup wizard). Same vault ID, single PUT, no migration of identifiers.
- Users on a single device who never re-type their passphrase stay on PBKDF2 forever — by design; their local IndexedDB encryption is unaffected (random AES key stored as JWK).

5 atomic commits, each independently reviewable:

1. `feat(crypto)` — Argon2id wrapper via `hash-wasm` (~40KB gzipped, lazy-loaded)
2. `feat(sync)` — stamp KDF spec on vault envelope (no behavior change)
3. `feat(sync)` — version `deriveVaultKey` by KdfSpec (no behavior change)
4. `feat(sync)` — encrypt new vaults with Argon2id; recovery reads stamp
5. `feat(sync)` — auto-upgrade legacy PBKDF2 vaults on passphrase entry

## Security analysis

**Threat model**: an attacker with the encrypted sync vault (server breach, traffic capture). Pre-change, ~8,000 PBKDF2-SHA256@600k guesses/sec on a single RTX 4090 → 2⁵¹·⁷ / 8,000 ≈ ~14,500 years for one GPU, but ~52 days on a 100k-GPU nation-state cluster — uncomfortably feasible against the threat actor named in the README ("journalists, activists, people living under surveillance").

Post-change, Argon2id at 64 MiB / t=3 / p=1 forces the attacker to spend memory per guess. Cracking rate drops by roughly three orders of magnitude on the same hardware, putting even a 100k-GPU farm into the "tens of years" range.

**What didn't change**:
- Vault ID derivation stays PBKDF2 forever — it's a routing identifier, not a secret. Versioning it would force every existing device to "forget" where its vault lives.
- Local IndexedDB encryption is untouched. Its random AES key is stored as JWK; the KDF only ever mattered when minting it.

**Key invariants preserved**:
- Key-data coupling: stored derived keys still decrypt local IndexedDB.
- No silent vault destruction (ADR 018).
- Recovery is read-then-mutate: pull happens before any local destructive op.

## Test plan

- [x] Unit: `tests/core/crypto/argon2.test.ts` — 5 tests, round-trip, determinism, passphrase/salt sensitivity
- [x] Unit: `tests/core/sync/vault-crypto.test.ts` — 8 new tests for KDF stamping, dispatch, legacy back-compat
- [x] Integration: `tests/core/sync/recover-vault.test.ts` (NEW) — 9 tests for recoverVault + upgradeVaultKdf round-trips
- [x] Component: `tests/components/onboarding/recovery-step.test.tsx` — updated to mock `recoverVault` + `upgradeVaultKdf`
- [x] Store: `tests/stores/sync-store-switch.test.ts` — updated for `recoverVault` + auto-upgrade in both replace/merge modes
- [x] Integration: `tests/integration/sync-store-db.test.ts` — bridges legacy `pullVaultMock` fixture through `recoverVault` compat wrapper
- [x] Full suite: **3453 passed | 33 skipped** (zero regressions)
- [x] TypeScript: `npx tsc --noEmit` clean

**Not yet covered (recommended follow-ups)**:
- [ ] E2E (Playwright): full recovery → upgrade dance against a real browser
- [ ] Smoke test (`tests/smoke/`): verify deployed system stamps Argon2id on new envelopes
- [ ] Mobile fallback: a `navigator.deviceMemory < 2` branch dropping to `ARGON2ID_MOBILE_PARAMS` (19 MiB, t=2) for cheap Android browsers — the 64 MiB allocation can be rough there

## UX impact

- Onboarding: a one-time ~700ms wait on the passphrase-confirm screen. The existing "initializing…" spinner already covers this; no UI changes needed.
- Day-to-day sync: zero impact. Derived keys live in localStorage as JWK; the KDF only matters when minting them.
- Recovery / settings-restore: ~700ms on the unlock screen (still feels like a normal network spinner). Auto-upgrade adds one extra PUT in the background — invisible to the user.

https://claude.ai/code/session_014p29w9iFhpNvYxbG975kV7

---
_Generated by [Claude Code](https://claude.ai/code/session_014p29w9iFhpNvYxbG975kV7)_