### PR TITLE
fix(briefings): register @tailwindcss/typography so prose classes render

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Single CSS entry: `src/index.css`. Tailwind CSS v4 via `@tailwindcss/vite` (zero
 
 - `@theme` — Design tokens (`--color-*`, `--font-*`).
 - `@layer base` — Resets, base button/input styles. (The desktop layout is a two-tier `ResizablePanelGroup` in `feeds-page.tsx`, not a CSS grid — see ADR 013.)
+- `@plugin "@tailwindcss/typography"` — Required for `prose` classes used by `BriefingAbstract` to render model-generated markdown (h2, ul, li, p). Without the directive the classes are silent no-ops and Tailwind's preflight strips browser-default styling — bullets run together, headings render as plain inline text. Locked by `tests/index-css-briefing-typography.test.ts`.
 - Use Tailwind utilities in JSX with `cn()` from `src/lib/utils.ts`.
 - **Spacing** — Use Tailwind v4's default numeric scale (`p-4`, `gap-2`). Do **not** define `--spacing-xs/sm/md/lg/xl` in `@theme` — these collide with `max-w-*` utilities (`max-w-lg` resolves to `--spacing-lg` instead of `--container-lg`). [Tailwind v4 gotcha](https://github.com/tailwindlabs/tailwindcss/discussions/17777).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,6 +181,7 @@ Tailwind CSS v4 via `@tailwindcss/vite` (build-time only, zero runtime cost). Si
 - **`@theme`** — Design tokens (colors, spacing, fonts, radius)
 - **`@layer base`** — Global resets, button/input base styles (the desktop layout itself is a two-tier `ResizablePanelGroup` in `feeds-page.tsx`, not a CSS grid — see ADR 013)
 - **Tailwind utilities** — Used in JSX `className` props via `cn()` helper (clsx + tailwind-merge)
+- **`@plugin "@tailwindcss/typography"`** — Required for the `prose` classes that style the briefing abstract (`BriefingAbstract`). Without it, Tailwind's preflight strips h2/ul/li styling and model-generated markdown renders as a wall of plain text. Locked by `tests/index-css-briefing-typography.test.ts`.
 
 See [ADR 004](decisions/004-tailwind-css.md) for Tailwind rationale.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -3902,6 +3903,33 @@
       ],
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tailwindcss/vite": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@plugin "@tailwindcss/typography";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme {

--- a/tests/index-css-briefing-typography.test.ts
+++ b/tests/index-css-briefing-typography.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression guard: the briefing abstract surface (BriefingAbstract) renders
+ * model-produced markdown inside a `prose prose-sm dark:prose-invert` wrapper.
+ * Those classes only do anything when `@tailwindcss/typography` is registered
+ * with the Tailwind v4 build via `@plugin` in src/index.css. Without it the
+ * classes are silent no-ops and Tailwind's preflight reset strips the default
+ * h2 / ul / li / p styling — headings render as plain inline text, bullets run
+ * together as paragraphs, citation chips trail the previous line. That is the
+ * exact symptom from the 2026-05-25 mobile-briefing screenshot.
+ *
+ * happy-dom doesn't compute Tailwind-generated CSS, and a Playwright E2E for
+ * briefings would need a Pro license + Anthropic key to materialize a real
+ * report. The next-best guard is asserting the CSS source registers the plugin.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const INDEX_CSS = readFileSync(
+  resolve(__dirname, "..", "src", "index.css"),
+  "utf-8",
+);
+
+describe("index.css — briefing typography plugin", () => {
+  it("registers @tailwindcss/typography so prose classes resolve to real styles", () => {
+    expect(INDEX_CSS).toMatch(
+      /@plugin\s+["']@tailwindcss\/typography["']/,
+    );
+  });
+});


### PR DESCRIPTION
What
  The briefing abstract surface (BriefingAbstract) was rendering as a
  wall of plain text on every viewport: section headings ("Key
  takeaways", "What's happening", "What to watch") appeared inline as
  body text, bullets ran together as paragraphs, and citation chips
  trailed the previous line. Reported via mobile screenshot 2026-05-25.

Why
  briefing-abstract.tsx wraps the markdown-to-HTML output in
  `className="prose prose-sm dark:prose-invert max-w-none ..."` —
  classes that only exist when @tailwindcss/typography is registered
  with the Tailwind v4 build. The plugin was never installed and the
  `@plugin` directive was missing from src/index.css, so the classes
  compiled to nothing and Tailwind's preflight reset stripped the
  default browser styling from h2 / ul / li / p. The markdown
  pipeline itself (marked → DOMPurify → DOM → React) was producing
  the correct semantic tags all along — it was a missing-styles bug,
  not a missing-markup bug.

Fix
  - Add @tailwindcss/typography as a devDependency.
  - Register it via `@plugin "@tailwindcss/typography";` in
    src/index.css, immediately after the tailwindcss import.
  - The prose classes already on BriefingAbstract now resolve to
    real styles; production build confirms `.prose` / `.prose-sm`
    selectors land in the bundle.

Prevention
  - tests/index-css-briefing-typography.test.ts asserts the
    `@plugin "@tailwindcss/typography"` directive is present in
    src/index.css. Follows the established content-grep pattern from
    tests/index-css-native-feel.test.ts — happy-dom can't compute
    Tailwind-generated CSS and a Playwright E2E for briefings would
    need a Pro license + Anthropic key to materialize a real report,
    so the next-best regression guard is at the CSS source.
  - CLAUDE.md and docs/architecture.md call out the plugin under
    Styling so the next agent doesn't strip it during a "tidy up
    index.css" pass.