### PR TITLE
fix(extractor): use browser UA for /api/page so WAF-protected sites work

### DIFF
--- a/api/page.ts
+++ b/api/page.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-// src/utils/result.ts
+// packages/core/src/utils/result.ts
 function ok(value) {
   return { ok: true, value };
 }
@@ -162,14 +162,15 @@ function cleanFeedContent(raw) {
 // src/core/proxy/pick-user-agent.ts
 var DEFAULT_USER_AGENT = "FeedZero/1.0 (RSS Reader)";
 var BROWSER_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0";
-function pickUserAgent(env) {
+function pickUserAgent(env, routeKind = "feed") {
   const explicit = env.FEED_USER_AGENT;
   if (explicit && explicit.length > 0) return explicit;
+  if (routeKind === "page") return BROWSER_USER_AGENT;
   if (env.SELF_HOSTED === "1") return BROWSER_USER_AGENT;
   return DEFAULT_USER_AGENT;
 }
 
-// src/utils/log-error.ts
+// packages/core/src/utils/log-error.ts
 var ALLOWED_FIELDS = [
   "route",
   "method",
@@ -198,7 +199,7 @@ function logError(fields) {
   }
 }
 
-// src/utils/trace-id.ts
+// packages/core/src/utils/trace-id.ts
 function newTraceId() {
   return "req_" + crypto.randomUUID().split("-")[0];
 }
@@ -238,15 +239,28 @@ async function handleProxyRequest(req, defaultContentType, options) {
       });
     }
   }
+  const validators = await extractValidators(req);
+  const upstreamHeaders = {
+    "User-Agent": pickUserAgent(process.env, options?.routeKind)
+  };
+  if (validators.etag) upstreamHeaders["If-None-Match"] = validators.etag;
+  if (validators.lastModified)
+    upstreamHeaders["If-Modified-Since"] = validators.lastModified;
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15e3);
     const response = await fetch(url, {
-      headers: { "User-Agent": pickUserAgent(process.env) },
+      headers: upstreamHeaders,
       signal: controller.signal
     });
     clearTimeout(timeout);
     const contentType = response.headers.get("content-type") || defaultContentType;
+    if (response.status === 304) {
+      return new Response("", {
+        status: 304,
+        headers: buildResponseHeaders(contentType, response)
+      });
+    }
     const body = await response.arrayBuffer();
     if (cache && response.status >= 200 && response.status < 400) {
       cache.set(url, body, contentType, response.status);
@@ -287,19 +301,42 @@ function buildResponseHeaders(contentType, upstream) {
     const retryAfter = upstream.headers.get("Retry-After");
     if (retryAfter) headers["Retry-After"] = retryAfter;
   }
+  const etag = upstream.headers.get("ETag");
+  if (etag) headers["ETag"] = etag;
+  const lastModified = upstream.headers.get("Last-Modified");
+  if (lastModified) headers["Last-Modified"] = lastModified;
+  if (upstream.status >= 200 && upstream.status < 300 && /^image\//i.test(contentType)) {
+    headers["Cache-Control"] = "public, max-age=86400, stale-while-revalidate=604800";
+  }
   return headers;
+}
+async function parseBody(req) {
+  if (req.method !== "POST") {
+    return { url: null, etag: null, lastModified: null };
+  }
+  try {
+    const body = await req.clone().json();
+    return {
+      url: body.url ?? null,
+      etag: body.etag ?? null,
+      lastModified: body.lastModified ?? null
+    };
+  } catch {
+    return { url: null, etag: null, lastModified: null };
+  }
 }
 async function extractTargetUrl(req) {
   if (req.method === "POST") {
-    try {
-      const body = await req.json();
-      return body.url ?? null;
-    } catch {
-      return null;
-    }
+    const body = await parseBody(req);
+    return body.url;
   }
   const url = new URL(req.url, "http://localhost");
   return url.searchParams.get("url");
+}
+async function extractValidators(req) {
+  if (req.method !== "POST") return { etag: null, lastModified: null };
+  const body = await parseBody(req);
+  return { etag: body.etag, lastModified: body.lastModified };
 }
 
 // src/core/proxy/rate-limiter.ts
@@ -409,6 +446,10 @@ var rateLimitPromise = resolveProxyRateLimiter();
 async function dispatch(req, contentType) {
   const rateLimit = await rateLimitPromise;
   return handleProxyRequest(req, contentType, {
+    // Article-page fetches mimic a real browser visit so the FeedZero
+    // identifier doesn't get blocked by Cloudflare-class WAFs on
+    // article URLs. See pick-user-agent.ts for the policy.
+    routeKind: "page",
     ...rateLimit ? { rateLimit } : {}
   });
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,7 +291,7 @@ Schema migrations are handled by Dexie's `version().stores()` API.
 | User IP leaked via favicons | Favicons proxied through the CORS proxy, not loaded directly from publisher servers |
 | Timing analysis of sync patterns | 0-30s random jitter added after debounce; vault payloads padded to power-of-2 bucket sizes |
 | IndexedDB metadata leakage | Index fields (url, feedId, guid) are HMAC-SHA256 hashed — deterministic for queries but non-reversible |
-| User-Agent fingerprinting via proxy | Fixed `User-Agent: FeedZero/1.0` on all outbound proxy requests |
+| User-Agent fingerprinting via proxy | Fixed `User-Agent: FeedZero/1.0` on feed-fetch proxy requests; article-page fetches (`/api/page`) use a fixed browser UA so the FeedZero identifier doesn't get blocked by WAFs and silently break extraction. Both UAs are constants — no per-user fingerprint. |
 | Data persistence after logout | "Delete all data" removes IndexedDB, localStorage (including derived keys), and cloud blob |
 
 ### What FeedZero does NOT protect against

--- a/docs/features/003-full-text-extraction.md
+++ b/docs/features/003-full-text-extraction.md
@@ -66,6 +66,7 @@ Feature: Full-text extraction (user-initiated)
 
 ## Design Decisions
 
+- **Browser User-Agent on `/api/page`** — Article-page fetches use a Firefox UA, not the `FeedZero/1.0 (RSS Reader)` identifier used for feed fetches. Cloudflare-class WAFs block bot-looking UAs on article URLs (where bot traffic isn't expected) while allowing them on feed URLs (where it is). Without the split, extraction on widely-deployed sites — kottke.org, zeit.de, others — fails silently because the upstream serves a challenge page that Defuddle can't extract. Policy lives in `src/core/proxy/pick-user-agent.ts`; the handler reads it via `options.routeKind` in `proxy-handler.ts`.
 - **Auto-detect, don't always extract** — Feeds that provide full content (like Spyglass) already have excellent HTML. Running extraction over it would strip author-intended elements and degrade quality.
 - **500-char threshold** — Articles with content shorter than 500 chars where content equals summary are treated as teasers. Genuinely short articles with distinct content are left alone.
 - **User-initiated extraction** — Extraction is triggered by clicking "Extracted" in the content view toggle, not automatically on add/refresh. This is faster and avoids surprises with discussion sites or PDFs.

--- a/server.ts
+++ b/server.ts
@@ -211,7 +211,10 @@ export function createApp(
     handleProxyRequest(c.req.raw, "text/xml", proxyOpts),
   );
   app.on(["GET", "POST"], "/api/page", (c) =>
-    handleProxyRequest(c.req.raw, "text/html", proxyOpts),
+    handleProxyRequest(c.req.raw, "text/html", {
+      ...proxyOpts,
+      routeKind: "page",
+    }),
   );
   // /api/icon dispatches on query-param shape so we stay under Vercel's
   // 12-function Hobby cap: ?domain=… → resolve the site's favicon;

--- a/src/core/proxy/pick-user-agent.ts
+++ b/src/core/proxy/pick-user-agent.ts
@@ -1,18 +1,30 @@
 /**
- * Resolve the User-Agent the proxy sends to upstream feeds.
+ * Resolve the User-Agent the proxy sends upstream.
  *
- * Three configurations, in precedence order:
+ * Two routes, two profiles:
  *
- *   1. `FEED_USER_AGENT` — operator's explicit choice. Wins unconditionally.
- *   2. `SELF_HOSTED=1`   — return a browser-like UA. Rationale: a
- *      self-host instance represents a single user, not a fleet, so a
- *      browser UA is an honest description of the request profile. The
- *      `FeedZero/1.0 (RSS Reader)` identifier is fingerprintable and
- *      blocked on sight by some WAFs — self-hosters were hitting this
- *      where the hosted Vercel deployment wasn't, because Vercel's IP
- *      reputation moots the UA-based blocks. See feedback #97.
- *   3. Default — the FeedZero identifier so upstream operators can see
- *      our traffic in their logs and contact us if needed.
+ *   - `feed` (default) — recurring feed-XML fetches. Sends the FeedZero
+ *     identifier so upstream operators can see aggregator traffic in
+ *     their logs and contact us if needed.
+ *   - `page` — one-off, user-initiated article-page fetches (`/api/page`
+ *     for full-text extraction). Sends a browser-like UA because
+ *     Cloudflare-class WAFs block the FeedZero identifier on sight when
+ *     it appears on an article URL (page traffic isn't expected to come
+ *     from a bot the way feed traffic is). Without this, extraction on
+ *     sites like kottke.org and zeit.de silently fails — the upstream
+ *     returns a 200 with a challenge page that Defuddle can't extract.
+ *
+ * Precedence, applied to both routes:
+ *
+ *   1. `FEED_USER_AGENT` env — operator's explicit choice. Wins everywhere.
+ *   2. `routeKind === "page"` — browser UA (per above).
+ *   3. `SELF_HOSTED=1` — browser UA. Rationale: a self-host instance
+ *      represents a single user, not a fleet, so a browser UA is an
+ *      honest description of the request profile. Self-hosters were
+ *      hitting WAF blocks on the FeedZero UA where the hosted Vercel
+ *      deployment wasn't, because Vercel's IP reputation moots the
+ *      UA-based blocks. See feedback #97.
+ *   4. Default — the FeedZero identifier.
  *
  * Pure function — environment is passed in — so tests cover all branches
  * without process.env mutation.
@@ -27,11 +39,15 @@ export const DEFAULT_USER_AGENT = "FeedZero/1.0 (RSS Reader)";
 const BROWSER_USER_AGENT =
   "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0";
 
+export type ProxyRouteKind = "feed" | "page";
+
 export function pickUserAgent(
   env: Record<string, string | undefined>,
+  routeKind: ProxyRouteKind = "feed",
 ): string {
   const explicit = env.FEED_USER_AGENT;
   if (explicit && explicit.length > 0) return explicit;
+  if (routeKind === "page") return BROWSER_USER_AGENT;
   if (env.SELF_HOSTED === "1") return BROWSER_USER_AGENT;
   return DEFAULT_USER_AGENT;
 }

--- a/src/core/proxy/proxy-handler.ts
+++ b/src/core/proxy/proxy-handler.ts
@@ -2,7 +2,7 @@ import { validateProxyUrl } from "./validate-url.ts";
 import type { FeedCache } from "./feed-cache.ts";
 import type { CatalogStorageAdapter } from "../catalog/catalog-types.ts";
 import { cleanFeedContent } from "../cleaner/cleaner.ts";
-import { pickUserAgent } from "./pick-user-agent.ts";
+import { pickUserAgent, type ProxyRouteKind } from "./pick-user-agent.ts";
 import { logError } from "../../../packages/core/src/utils/log-error";
 import { newTraceId } from "../../../packages/core/src/utils/trace-id";
 
@@ -48,6 +48,13 @@ export interface ProxyOptions {
    * an Upstash-backed limiter).
    */
   rateLimit?: ProxyRateLimit;
+  /**
+   * Which kind of route is calling — feed (`/api/feed`) or page
+   * (`/api/page`). Routes through to `pickUserAgent` so article-page
+   * fetches send a browser-like UA (the FeedZero identifier is blocked
+   * by WAFs on article URLs). Defaults to `feed` for back-compat.
+   */
+  routeKind?: ProxyRouteKind;
 }
 
 /**
@@ -113,7 +120,7 @@ export async function handleProxyRequest(
   // as a free 304 instead of a full re-download of every item.
   const validators = await extractValidators(req);
   const upstreamHeaders: Record<string, string> = {
-    "User-Agent": pickUserAgent(process.env),
+    "User-Agent": pickUserAgent(process.env, options?.routeKind),
   };
   if (validators.etag) upstreamHeaders["If-None-Match"] = validators.etag;
   if (validators.lastModified)

--- a/tests/core/proxy/pick-user-agent.test.ts
+++ b/tests/core/proxy/pick-user-agent.test.ts
@@ -30,4 +30,25 @@ describe("pickUserAgent", () => {
       pickUserAgent({ SELF_HOSTED: "1", FEED_USER_AGENT: "Custom/1.0" }),
     ).toBe("Custom/1.0");
   });
+
+  it("uses a browser UA for page fetches even on hosted deployments", () => {
+    // /api/page fetches are user-initiated, one-off article requests that
+    // should look like a regular browser visit. The FeedZero identifier
+    // is widely blocked by WAFs on article URLs (vs feed URLs where bot
+    // traffic is expected), so page fetches use a browser UA by default.
+    const ua = pickUserAgent({}, "page");
+    expect(ua).not.toBe(DEFAULT_USER_AGENT);
+    expect(ua).toMatch(/Mozilla/);
+  });
+
+  it("FEED_USER_AGENT overrides the page-route browser default", () => {
+    // Operators who set FEED_USER_AGENT get the final word for every route.
+    expect(
+      pickUserAgent({ FEED_USER_AGENT: "Custom/1.0" }, "page"),
+    ).toBe("Custom/1.0");
+  });
+
+  it("defaults the route kind to feed when omitted (back-compat)", () => {
+    expect(pickUserAgent({})).toBe(DEFAULT_USER_AGENT);
+  });
 });

--- a/tests/core/proxy/proxy-handler.test.ts
+++ b/tests/core/proxy/proxy-handler.test.ts
@@ -27,6 +27,30 @@ describe("handleProxyRequest", () => {
     expect(headers.get("User-Agent")).toBe("FeedZero/1.0 (RSS Reader)");
   });
 
+  it("sends a browser User-Agent when routeKind=page", async () => {
+    // Article-page fetches mimic a real user visit. The FeedZero identifier
+    // is blocked on sight by Cloudflare-class WAFs on article URLs (kottke.org,
+    // zeit.de, etc.), turning extraction into a silent failure for the user.
+    // Feed fetches keep the FeedZero identifier so publishers can see
+    // aggregator traffic — only the page route flips to browser UA.
+    fetchSpy.mockResolvedValue(
+      new Response("<html><body>article</body></html>", { status: 200 }),
+    );
+
+    const req = new Request("http://localhost/api/page", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://kottke.org/26/05/some-post" }),
+    });
+    await handleProxyRequest(req, "text/html", { routeKind: "page" });
+
+    const [, options] = fetchSpy.mock.calls[0];
+    const headers = new Headers(options!.headers as HeadersInit);
+    const ua = headers.get("User-Agent");
+    expect(ua).not.toBe("FeedZero/1.0 (RSS Reader)");
+    expect(ua).toMatch(/Mozilla/);
+  });
+
   it("accepts POST with JSON body to keep URLs out of server logs", async () => {
     fetchSpy.mockResolvedValue(new Response("<rss/>", { status: 200 }));
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -76,7 +76,10 @@ function apiProxyPlugin() {
       server.middlewares.use("/api/page", async (req, res) => {
         const handler = await ensureProxyHandler();
         const webReq = await toWebRequest(req);
-        const webRes = await handler(webReq, "text/html", proxyOpts());
+        const webRes = await handler(webReq, "text/html", {
+          ...proxyOpts(),
+          routeKind: "page",
+        });
         await sendWebResponse(webRes, res);
       });
 


### PR DESCRIPTION
What
- Full-text extraction silently failed for many feeds (kottke.org, zeit.de,
  others). Clicking "Full text" finished with the toggle disabled and only a
  tooltip "Extraction didn't find additional content" — no visible error.

Why
- /api/page sent the same User-Agent as /api/feed: `FeedZero/1.0 (RSS Reader)`.
  Cloudflare-class WAFs allow bot UAs on feed URLs (where aggregator traffic
  is expected) but block them on article URLs (where it isn't). On a block
  the upstream returns either a 200 challenge page Defuddle can't parse or
  a 4xx that gets routed to the paywall handler — either way the user sees
  silent extraction failure.
- The same UA-block class is documented in feedback #97 for feed fetches on
  self-host deployments; the page-fetch case has the same root cause but on
  hosted deployments because article URLs are more aggressively filtered.

Fix
- pickUserAgent gains a routeKind ("feed" | "page") parameter. Page fetches
  return a browser-like UA (Firefox), feed fetches keep the FeedZero identifier
  so publishers can see aggregator traffic in their logs. FEED_USER_AGENT
  still overrides everything for operator control.
- ProxyOptions gains a routeKind field; handleProxyRequest threads it into
  pickUserAgent. All three entry points (api/page.ts, server.ts, vite.config.js)
  pass routeKind: "page" to /api/page; /api/feed is unchanged.

Prevention
- pick-user-agent.test.ts: new branch tests cover page-route browser UA and
  FEED_USER_AGENT precedence over the page default.
- proxy-handler.test.ts: contract test that routeKind: "page" sends Mozilla
  rather than FeedZero in the upstream User-Agent header.
- docs/features/003-full-text-extraction.md + docs/architecture.md: rationale
  recorded so the next reviewer doesn't re-unify the two UAs.