### PR TITLE
test(e2e): repair seven post-merge desktop failures (E2E #176)

### DIFF
--- a/tests/e2e/briefings.spec.ts
+++ b/tests/e2e/briefings.spec.ts
@@ -20,7 +20,13 @@ import { test, expect } from "./fixtures";
  */
 
 test.describe("Signal Briefings — sidebar + free-tier upgrade splash", () => {
-  test("sidebar entry navigates to /briefings", async ({ feedPage: page }) => {
+  test("Signal sidebar entry + Briefings sub-tab routes free users to the upgrade splash", async ({
+    feedPage: page,
+  }) => {
+    // Briefings is a sub-tab under Signal (PR #190): the sidebar entry
+    // is "Signal" (testId `sidebar-signal-link`), clicking it lands on
+    // /signal, and the "Briefings" sub-tab navigates to /signal/briefings
+    // where the gate-locked upgrade splash renders for free-tier users.
     const isMobile = page.viewportSize() && page.viewportSize()!.width < 768;
     if (isMobile) {
       const drawerHandle = page
@@ -30,15 +36,17 @@ test.describe("Signal Briefings — sidebar + free-tier upgrade splash", () => {
         await drawerHandle.click();
       }
     }
-    const briefingsLink = page.getByTestId("sidebar-briefings-link").first();
-    await expect(briefingsLink).toBeVisible({ timeout: 10000 });
-    await briefingsLink.click();
-    // Free-tier user — the gate routes them to the upgrade splash but
-    // the URL doesn't change to /briefings (gate intercepts in the
-    // click handler). Either path is acceptable as long as they see
-    // the upgrade affordance.
+    const signalLink = page.getByTestId("sidebar-signal-link").first();
+    await expect(signalLink).toBeVisible({ timeout: 10000 });
+    await signalLink.click();
+    await page.getByRole("radio", { name: "Briefings" }).click();
+    // Free-tier user — UpgradeSplash for `signal-briefings` renders
+    // "Unlock Signal Briefings" + a "Pro" tier label.
     await expect(
-      page.getByText(/Pro/i).or(page.getByText(/Signal Briefings/i)).first(),
+      page
+        .getByText(/Pro/i)
+        .or(page.getByText(/Signal Briefings/i))
+        .first(),
     ).toBeVisible({ timeout: 10000 });
   });
 
@@ -75,12 +83,15 @@ test.describe("Signal Briefings — sidebar + free-tier upgrade splash", () => {
     await keyInput.fill("sk-ant-test-key-from-e2e");
     await page.getByRole("button", { name: /^Save$/i }).first().click();
 
-    // Toast confirmation OR the inline "saved" badge.
+    // Successful save renders BOTH the sonner toast AND the inline
+    // emerald "saved" badge next to the field. The toast is the more
+    // specific signal — assert on it directly to avoid a strict-mode
+    // violation against the two simultaneous matches.
     await expect(
       page
         .locator("[data-sonner-toast]")
         .filter({ hasText: /saved/i })
-        .or(page.getByText(/saved/i).first()),
+        .first(),
     ).toBeVisible({ timeout: 10000 });
   });
 

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -39,6 +39,19 @@ async function goToImportExportTab(page: Page) {
   await expect(page.getByRole("heading", { name: /^Export$/i })).toBeVisible();
 }
 
+/**
+ * Confirm the import-preview step that PR #192 inserted between the
+ * initial "Import feeds" click and the addFeed loop. The preview's
+ * confirm button is "Import N feed(s)" — wait for it, click it.
+ */
+async function confirmImportPreview(page: Page) {
+  const confirm = page
+    .getByTestId("import-preview")
+    .getByRole("button", { name: /^Import \d+ feeds?$/ });
+  await expect(confirm).toBeVisible({ timeout: 5000 });
+  await confirm.click();
+}
+
 test.describe("Import/Export navigation", () => {
   test("Explore 'Import / Export' button navigates to Settings → Data", async ({
     feedPage: page,
@@ -67,12 +80,15 @@ test.describe("Import feeds", () => {
     // Switch the Import card to text-paste mode.
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder("Paste OPML XML, Pocket HTML export, or feed URLs (one per line)")
+      .getByPlaceholder(/^Paste OPML XML/)
       .fill(SAMPLE_OPML);
     await page.getByRole("button", { name: "Import feeds" }).click();
+    await confirmImportPreview(page);
 
     await expect(page.getByText(/Adding feed/)).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText(/feed.*added/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/\d+ feeds? added/i)).toBeVisible({
+      timeout: 15000,
+    });
 
     // "Done" returns to the input view.
     await page.getByRole("button", { name: "Done" }).click();
@@ -84,11 +100,14 @@ test.describe("Import feeds", () => {
 
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder("Paste OPML XML, Pocket HTML export, or feed URLs (one per line)")
+      .getByPlaceholder(/^Paste OPML XML/)
       .fill(SAMPLE_URL_LIST);
     await page.getByRole("button", { name: "Import feeds" }).click();
+    await confirmImportPreview(page);
 
-    await expect(page.getByText(/feed.*added/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/\d+ feeds? added/i)).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test("Import button is disabled with empty text input", async ({
@@ -106,7 +125,7 @@ test.describe("Import feeds", () => {
     await goToImportExportTab(page);
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder("Paste OPML XML, Pocket HTML export, or feed URLs (one per line)")
+      .getByPlaceholder(/^Paste OPML XML/)
       .fill("# just a comment\n\n# another comment");
     await page.getByRole("button", { name: "Import feeds" }).click();
 
@@ -119,11 +138,14 @@ test.describe("Import feeds", () => {
 
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder("Paste OPML XML, Pocket HTML export, or feed URLs (one per line)")
+      .getByPlaceholder(/^Paste OPML XML/)
       .fill("https://example.com/feed");
     await page.getByRole("button", { name: "Import feeds" }).click();
+    await confirmImportPreview(page);
 
-    await expect(page.getByText(/feed.*added/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/\d+ feeds? added/i)).toBeVisible({
+      timeout: 15000,
+    });
     await page.getByRole("button", { name: "Import more" }).click();
     await expect(
       page.getByRole("radio", { name: "Upload file" }),

--- a/tests/e2e/import-recovery.spec.ts
+++ b/tests/e2e/import-recovery.spec.ts
@@ -44,9 +44,13 @@ test.describe("Import recovery — placeholder for rate-limited URLs", () => {
       }
       if (targetHost === "rate-limited.example.com") {
         if (phase === "rate-limited") {
+          // Retry-After: 1 (not 60) keeps the host-pause window
+          // (src/core/feeds/host-pause.ts) under the test runtime
+          // budget. The recovery phase below waits the pause out
+          // before pressing "r" so the keypress fires a real fetch.
           route.fulfill({
             status: 429,
-            headers: { "retry-after": "60" },
+            headers: { "retry-after": "1" },
             body: "Too Many Requests",
           });
           return;
@@ -75,11 +79,14 @@ test.describe("Import recovery — placeholder for rate-limited URLs", () => {
     await page.waitForURL(/\/settings\?tab=sync-and-data/);
     await page.getByRole("radio", { name: "Paste text" }).click();
     await page
-      .getByPlaceholder(
-        "Paste OPML XML, Pocket HTML export, or feed URLs (one per line)",
-      )
+      .getByPlaceholder(/^Paste OPML XML/)
       .fill(URL_LIST);
     await page.getByRole("button", { name: "Import feeds" }).click();
+    // Confirm the preview step (added in PR #192) so the actual import runs.
+    await page
+      .getByTestId("import-preview")
+      .getByRole("button", { name: /^Import \d+ feeds?$/ })
+      .click();
 
     // Results summary shows the 3-bucket breakdown: 1 added, 1 queued.
     await expect(
@@ -115,6 +122,12 @@ test.describe("Import recovery — placeholder for rate-limited URLs", () => {
     await expect(
       page.getByRole("button", { name: "Refresh", exact: true }),
     ).toBeEnabled({ timeout: 15000 });
+
+    // The boot refresh's 429 registered a host-pause for ~1s (see the
+    // Retry-After header on the mock). Wait it out before pressing "r"
+    // so the next refreshFeed call clears `hostPausedUntil` and issues
+    // a real fetch instead of skipping with "Skipped: host paused".
+    await page.waitForTimeout(1500);
 
     // Phase 2: flip the mock so rate-limited.* now returns 200. Hit "r"
     // to refresh all feeds. The placeholder upgrades in place: indicator


### PR DESCRIPTION
What
- E2E run #176 on main (commit 09de6b8) failed on shards 1, 3, and 4.
  Seven tests were red across briefings, import-export, and
  import-recovery; the failures had accumulated unnoticed because E2E
  only runs post-merge and the breaking PRs preceded the noticing one.

Why
- briefings.spec.ts:23 looked up `sidebar-briefings-link`, but PR #190
  folded Briefings under the Signal entry (`sidebar-signal-link` plus a
  Briefings sub-tab on /signal). The test never matched the merged
  sidebar after #190.
- briefings.spec.ts:65 used `.or()` between the toast and an inline
  "saved" badge, both of which render simultaneously on save — strict
  mode rejected the two-element match.
- import-export.spec.ts (4 tests) + import-recovery.spec.ts (1 test)
  hard-coded the textarea placeholder to the pre-Omnivore copy. PR #179
  added Pocket CSV + Omnivore JSON to the placeholder string, so the
  `getByPlaceholder(...)` lookup stopped matching. They also predated
  PR #192's preview step, so even when the placeholder matched, the
  flow stayed on the preview screen.
- import-recovery additionally relied on a 60s `Retry-After`; PR #178's
  `host-pause.ts` then made the recovery `r` keypress no-op for the
  full window. The test could not pass within its 30s budget.

Fix
- Replace literal placeholder strings with `getByPlaceholder(/^Paste OPML XML/)`
  so future import-format additions don't re-break the same tests.
- Extract `confirmImportPreview(page)` and click "Import N feeds" on
  the preview surface before asserting results. Tighten the results
  assertion from `/feed.*added/i` to `/\d+ feeds? added/i` so it
  matches the results screen, not the preview's "N feeds will be added".
- Update the Signal sidebar test to click `sidebar-signal-link`, then
  the "Briefings" sub-tab radio, and assert the upgrade splash.
- Drop the toast-or-badge `.or()` and pin the assertion to the toast.
- Shorten the recovery mock's `Retry-After` to 1s and wait it out
  before pressing `r`, so the refresh fires after the host-pause has
  expired and the recovered phase serves the real feed.

Prevention
- All seven tests now go red on the regressions above and green after.
  Verified locally via `npx playwright test --project=desktop`; only
  the pre-existing env-specific `keyboard-navigation.spec.ts:100`
  popup test still fails locally (sandboxed network can't reach
  example.com), and that should remain green in CI.