### PR TITLE
fix(articles): keep cog reachable and surface lastError on empty feeds

### DIFF
--- a/src/components/articles/article-list.tsx
+++ b/src/components/articles/article-list.tsx
@@ -235,9 +235,18 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
     // load settles with nothing — or while a user-initiated refresh runs — the
     // empty state with its refresh affordance stays put so the user has a
     // prominent way to pull this feed/folder/filter again.
+    //
+    // Always mount ArticleListControls so the settings cog stays reachable
+    // when a feed is selected — even when the article list is empty. Without
+    // this, a failed-fetch placeholder feed has no settings entry point on
+    // desktop, so the user can't refresh-with-cache-cleared or delete it.
     const showBlank = isLoading && !isRefreshing;
     return (
       <div ref={scrollRef} className="h-full overflow-y-auto">
+        <ArticleListControls
+          sortMode={articleSortMode}
+          onSortChange={setArticleSortMode}
+        />
         {showBlank ? null : <EmptyArticleList feedId={selectedFeedId} />}
       </div>
     );
@@ -318,16 +327,34 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
  * Empty-list state. An empty feed is most often a feed that just hasn't been
  * fetched yet (or one whose cache was cleared), so the primary action is to
  * refresh — scoped to whatever the user is viewing via `refreshView`.
+ *
+ * When the selected single feed has never successfully fetched and has a
+ * stored `lastError`, surface that error so the user sees *why* refresh keeps
+ * doing nothing — the same red-X placeholder condition the sidebar uses.
+ * Without this, a placeholder feed's refresh button silently re-runs the same
+ * failing fetch on every tap. Use the cog above the list (always mounted now)
+ * to delete the feed if recovery isn't possible.
  */
 function EmptyArticleList({ feedId }: { feedId: string }) {
   const refreshView = useFeedStore((s) => s.refreshView);
   const isRefreshing = useFeedStore((s) => s.isRefreshingAll);
+  const feed = useFeedStore((s) => s.feeds.find((f) => f.id === feedId));
+  const hasNeverFetched =
+    !!feed?.lastError && !feed.lastSuccessfulFetchAt;
 
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
       <p className="text-sm text-muted-foreground">
-        No articles here yet.
+        {hasNeverFetched ? "This feed hasn't loaded yet." : "No articles here yet."}
       </p>
+      {hasNeverFetched && (
+        <p
+          data-testid="empty-last-error"
+          className="text-xs text-destructive max-w-sm break-words"
+        >
+          {feed!.lastError}
+        </p>
+      )}
       <Button
         data-testid="empty-refresh"
         variant="secondary"
@@ -338,6 +365,11 @@ function EmptyArticleList({ feedId }: { feedId: string }) {
         <RefreshCw className={cn("size-4", isRefreshing && "animate-spin")} />
         {isRefreshing ? "Refreshing…" : "Refresh"}
       </Button>
+      {hasNeverFetched && (
+        <p className="text-xs text-muted-foreground max-w-sm">
+          If refresh keeps failing, use the cog above the list to delete this feed.
+        </p>
+      )}
     </div>
   );
 }

--- a/tests/components/articles/article-list.test.tsx
+++ b/tests/components/articles/article-list.test.tsx
@@ -153,6 +153,80 @@ describe("ArticleList", () => {
     expect(refreshFeed).toHaveBeenCalledWith(f1);
   });
 
+  it("mounts the article-list controls even when the feed has no articles", () => {
+    // Without this, a failed-fetch placeholder feed has no settings entry
+    // point on desktop — the cog only mounted when articles existed, so
+    // users had no way to refresh-with-cleared-cache or delete the feed.
+    useFeedStore.setState({
+      feeds: [mockFeed("f1", "Feed 1")],
+      selectedFeedId: "f1",
+      isLoading: false,
+      error: null,
+    });
+    useArticleStore.setState({
+      articles: [],
+      selectedArticle: null,
+      isLoading: false,
+    });
+
+    render(<ArticleList />);
+
+    expect(screen.getByTestId("article-list-controls")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-pill")).toBeInTheDocument();
+  });
+
+  it("surfaces the feed's last error in the empty state when the feed has never fetched", () => {
+    // The empty-state refresh re-runs the same fetch — if the publisher is
+    // returning 404 / 5xx, it silently fails and the user sees nothing
+    // change. Surface lastError so they know why their refresh doesn't help.
+    const failedFeed = {
+      ...mockFeed("f1", "Feed 1"),
+      lastError: "HTTP 404: Not Found",
+      lastSuccessfulFetchAt: undefined,
+    };
+    useFeedStore.setState({
+      feeds: [failedFeed],
+      selectedFeedId: "f1",
+      isLoading: false,
+      error: null,
+    });
+    useArticleStore.setState({
+      articles: [],
+      selectedArticle: null,
+      isLoading: false,
+    });
+
+    render(<ArticleList />);
+
+    expect(screen.getByText(/HTTP 404: Not Found/)).toBeInTheDocument();
+  });
+
+  it("does not surface lastError when the feed has previously fetched successfully", () => {
+    // A feed that fetched fine once and is currently empty (all read /
+    // cache cleared) should not raise an alarm just because its most-recent
+    // refresh hit a transient error.
+    const sometimesFlakyFeed = {
+      ...mockFeed("f1", "Feed 1"),
+      lastError: "HTTP 500: Server Error",
+      lastSuccessfulFetchAt: Date.now() - 60_000,
+    };
+    useFeedStore.setState({
+      feeds: [sometimesFlakyFeed],
+      selectedFeedId: "f1",
+      isLoading: false,
+      error: null,
+    });
+    useArticleStore.setState({
+      articles: [],
+      selectedArticle: null,
+      isLoading: false,
+    });
+
+    render(<ArticleList />);
+
+    expect(screen.queryByText(/HTTP 500/)).toBeNull();
+  });
+
   it("never renders a Load more button — the display cap has been removed", () => {
     useFeedStore.setState({
       feeds: [],


### PR DESCRIPTION
**What**

A feed that fails its very first fetch (added via OPML/URL-list, then
404/CORS/DNS-fail on initial load) lights up the red-X "failed-feed"
indicator in the sidebar but the user can't recover from it. On desktop:
- The settings cog (`ArticleListControls`/`SettingsPill`) only mounts
  when `articles.length > 0`, so it's invisible for placeholder feeds.
- The empty-state "Refresh" button silently re-runs the same failing
  fetch with no error feedback — the spinner blinks and the empty state
  returns, so the button appears to do nothing.
- With no cog, there's no path to delete the feed either. Users worked
  around it by re-adding the feed from Settings, leaving an orphan they
  couldn't remove.

**Why**

`article-list.tsx` short-circuited to a bare empty state before reaching
the render path that mounts `ArticleListControls`. The empty state had
no awareness of `feed.lastError` either, so the underlying failure
reason — already stored on the feed by `feed-service.ts` — never reached
the user. The sidebar's red X is the only visible signal; its
`aria-label` carries the message but most users won't discover it.

**Fix**

- Hoist `ArticleListControls` into the empty-list branch so the cog
  stays mounted whenever a feed is selected, regardless of article
  count. The cog opens `FeedSettingsDialog`, which already has "Refresh
  now", "Clear cached articles", and "Delete feed".
- In `EmptyArticleList`, when the selected feed has `lastError` and no
  `lastSuccessfulFetchAt` (the same placeholder condition the sidebar
  uses), surface the error text and a one-line pointer to the cog for
  deletion. Feeds that have fetched successfully at least once don't
  raise the alarm on a transient most-recent failure.

**Prevention**

- New test: `mounts the article-list controls even when the feed has
  no articles` — guards the cog mount against future short-circuits.
- New test: `surfaces the feed's last error in the empty state when
  the feed has never fetched` — locks the lastError surface.
- New test: `does not surface lastError when the feed has previously
  fetched successfully` — gates the alarm on the placeholder condition,
  not any error.