### PR TITLE
fix(layout): move desktop sync badge into sidebar header

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -34,6 +34,7 @@ import { SidebarBody } from "@/components/layout/sidebar-body.tsx";
 import { QuotaIndicator } from "@/components/feeds/quota-indicator.tsx";
 import { goToSettings, goToSyncSetup } from "@/lib/go-to-settings.ts";
 import { BrandMark } from "@/components/brand/brand-mark.tsx";
+import { SyncStatusBadge } from "@/components/sync/sync-status-badge.tsx";
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onFeedSelect?: (feedId: string) => void;
@@ -229,6 +230,11 @@ export function AppSidebar({ onFeedSelect, ...props }: AppSidebarProps) {
                   </Tooltip>
                 )}
               </div>
+            </div>
+            {/* Anchored to the sidebar so it can't overlap the reader's
+                article title in the stage panel. */}
+            <div>
+              <SyncStatusBadge />
             </div>
           </div>
         </SidebarHeader>

--- a/src/pages/app-layout.tsx
+++ b/src/pages/app-layout.tsx
@@ -118,35 +118,7 @@ export function AppLayout() {
     );
   }
 
-  return (
-    <>
-      <DesktopShell onFeedSelect={handleFeedSelect} />
-      <FloatingSyncBadge />
-    </>
-  );
-}
-
-/**
- * Floating sync-status pill, pinned to the top-right of the viewport
- * on every route. Lives outside the ResizablePanelGroup so it never
- * triggers a panel-children-changed remount (ADR 013).
- *
- * z-index sits ABOVE Radix dialogs (z-50) so the badge stays visible
- * even when a modal is open — same role as a macOS menu-bar status
- * icon. The pointer-events-none on the outer wrapper means it never
- * blocks clicks except on the badge itself.
- */
-function FloatingSyncBadge() {
-  return (
-    <div
-      className="pointer-events-none fixed right-4 top-3 z-[60]"
-      data-testid="floating-sync-badge"
-    >
-      <div className="pointer-events-auto">
-        <SyncStatusBadge />
-      </div>
-    </div>
-  );
+  return <DesktopShell onFeedSelect={handleFeedSelect} />;
 }
 
 function DesktopShell({ onFeedSelect }: { onFeedSelect: (id: string) => void }) {

--- a/tests/components/layout/app-sidebar-layout.test.tsx
+++ b/tests/components/layout/app-sidebar-layout.test.tsx
@@ -188,7 +188,11 @@ describe("AppSidebar layout structure", () => {
     it("still renders the Synced pill when sync is active", () => {
       useSyncStore.setState({ status: "synced" });
       renderSidebar();
-      expect(screen.getByText(/^Synced$/)).toBeInTheDocument();
+      // Two renderings share the word "Synced" now: the rich header
+      // SyncStatusBadge and the tiny footer chip on the Settings button.
+      // Both are valid sync surfaces; the test just needs to confirm the
+      // status text is present, not that there is exactly one.
+      expect(screen.getAllByText(/^Synced$/).length).toBeGreaterThan(0);
     });
 
     it("renders the Settings label centered (single-line) when no chip is visible", () => {

--- a/tests/components/layout/feeds-page-layout.test.tsx
+++ b/tests/components/layout/feeds-page-layout.test.tsx
@@ -524,6 +524,23 @@ describe("FeedsPage layout — desktop", () => {
     const style = (wrapper as HTMLElement).getAttribute("style") ?? "";
     expect(style).toMatch(/--sidebar-width:\s*18rem/);
   });
+
+  it("sync status badge lives inside the sidebar header on desktop, not as a viewport overlay", () => {
+    // Before this change the badge was rendered by FloatingSyncBadge as a
+    // `fixed right-4 top-3` pill — on narrow desktop widths it overlapped
+    // the reader's article title in the right-hand stage panel. Anchoring
+    // the badge to the sidebar header (which never overlaps the stage)
+    // removes the overlap while keeping the affordance always visible.
+    const { container } = renderPage();
+    const sidebarHeader = container.querySelector("[data-slot='sidebar-header']");
+    expect(sidebarHeader).not.toBeNull();
+    const badgeInHeader = sidebarHeader!.querySelector(
+      "[data-testid='sync-status-badge']",
+    );
+    expect(badgeInHeader).not.toBeNull();
+    // No floating viewport overlay anywhere.
+    expect(container.querySelector("[data-testid='floating-sync-badge']")).toBeNull();
+  });
 });
 
 describe("FeedsPage layout — mobile", () => {


### PR DESCRIPTION
## Summary
- The desktop sync-status badge was rendered as a fixed top-right viewport overlay (`right-4 top-3 z-[60]`) and overlapped the reader's article title in the stage panel on narrow desktop widths.
- Moved it into the sidebar header (a second row below the brand + Search/Refresh icons). Still satisfies ADR 013 (the sidebar is the stable left panel, never re-mounted on route changes) — the constraint was "don't change the route-bound panel's children," not "must stay floating."
- Mobile inline badge unchanged.
- Footer chip on the Settings button intentionally retained: it's the only sync signal in the collapsed-sidebar state and for local-only online users.

## Test plan
- [ ] CI: full suite green (3708+ tests, type check, gitleaks, CodeQL, builds).
- [ ] New structural test asserts badge lives in `[data-slot='sidebar-header']` and no `[data-testid='floating-sync-badge']` exists.
- [ ] Manual: open any /feeds/:feedId/articles/:articleId on a 1280–1440px desktop viewport and confirm the sync badge sits in the sidebar (not over the article title).
- [ ] Manual: confirm the badge text/click destination still works (click → /settings?tab=sync-and-data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)