### PR TITLE
feat(rules): backfill apply, run-now, live preview; drop group NOT

### DIFF
--- a/src/components/rules/rules-editor-dialog.tsx
+++ b/src/components/rules/rules-editor-dialog.tsx
@@ -8,9 +8,12 @@
  * `rulesEditorFeedId`; closing clears it.
  */
 
-import { useEffect, useState } from "react";
-import { Plus, Trash2, Pencil, ChevronLeft, Settings2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Trash2, Pencil, ChevronLeft, Play, Settings2 } from "lucide-react";
+import { toast } from "sonner";
 import { useFeedStore } from "@/stores/feed-store.ts";
+import { useArticleStore } from "@/stores/article-store.ts";
+import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
 import {
   Dialog,
   DialogContent,
@@ -25,7 +28,12 @@ import { Label } from "@/components/ui/label.tsx";
 import { Switch } from "@/components/ui/switch.tsx";
 import { ConditionGroupEditor } from "@/components/smart-filters/condition-group-editor.tsx";
 import { ActionPicker } from "./action-picker.tsx";
+import {
+  buildContext,
+  evaluateGroup,
+} from "@/core/filters/evaluator.ts";
 import type {
+  Article,
   ConditionGroup,
   Feed,
   Rule,
@@ -48,9 +56,26 @@ export function RulesEditorDialog() {
   const addFeedRule = useFeedStore((s) => s.addFeedRule);
   const updateFeedRule = useFeedStore((s) => s.updateFeedRule);
   const removeFeedRule = useFeedStore((s) => s.removeFeedRule);
+  const applyRuleToExistingArticles = useFeedStore(
+    (s) => s.applyRuleToExistingArticles,
+  );
 
   const feed: Feed | undefined = feeds.find((f) => f.id === feedId);
   const rules = feed?.rules ?? [];
+
+  async function runRuleNow(ruleId: string) {
+    if (!feedId) return;
+    const result = await applyRuleToExistingArticles(feedId, ruleId);
+    if (!result.ok) {
+      toast.error(`Couldn't apply rule: ${result.error}`);
+      return;
+    }
+    toast.success(
+      result.value.changed === 0
+        ? "No existing articles matched"
+        : `Applied to ${result.value.changed} of ${result.value.total} articles`,
+    );
+  }
 
   const [mode, setMode] = useState<Mode>({ kind: "list" });
 
@@ -79,6 +104,7 @@ export function RulesEditorDialog() {
               if (!feedId) return;
               await removeFeedRule(feedId, id);
             }}
+            onRunNow={runRuleNow}
             onClose={closeEditor}
           />
         ) : (
@@ -87,12 +113,18 @@ export function RulesEditorDialog() {
             target={mode.rule}
             folders={folders}
             onBack={() => setMode({ kind: "list" })}
-            onSave={async (next) => {
+            onSave={async (next, applyOnSave) => {
               if (!feedId) return;
+              let ruleId: string | null = null;
               if (mode.rule) {
                 await updateFeedRule(feedId, { ...mode.rule, ...next });
+                ruleId = mode.rule.id;
               } else {
-                await addFeedRule(feedId, next);
+                const result = await addFeedRule(feedId, next);
+                if (result.ok) ruleId = result.value.id;
+              }
+              if (applyOnSave && ruleId) {
+                await runRuleNow(ruleId);
               }
               setMode({ kind: "list" });
             }}
@@ -109,10 +141,19 @@ interface ListViewProps {
   onEdit: (rule: Rule) => void;
   onAdd: () => void;
   onDelete: (id: string) => void | Promise<void>;
+  onRunNow: (id: string) => void | Promise<void>;
   onClose: () => void;
 }
 
-function ListView({ feed, rules, onEdit, onAdd, onDelete, onClose }: ListViewProps) {
+function ListView({
+  feed,
+  rules,
+  onEdit,
+  onAdd,
+  onDelete,
+  onRunNow,
+  onClose,
+}: ListViewProps) {
   return (
     <>
       <DialogHeader>
@@ -151,6 +192,17 @@ function ListView({ feed, rules, onEdit, onAdd, onDelete, onClose }: ListViewPro
             {!rule.enabled && (
               <span className="text-xs text-muted-foreground">Paused</span>
             )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              aria-label={`Run "${rule.name}" now`}
+              data-testid={`rule-run-now-${rule.id}`}
+              onClick={() => onRunNow(rule.id)}
+            >
+              <Play className="size-4" />
+            </Button>
             <Button
               type="button"
               variant="ghost"
@@ -199,14 +251,24 @@ interface EditViewProps {
   folders: import("@feedzero/core/types").Folder[];
   onBack: () => void;
   onSave: (
-    next:
-      | { name: string; condition: ConditionGroup; actions: RuleAction[]; enabled?: boolean },
+    next: {
+      name: string;
+      condition: ConditionGroup;
+      actions: RuleAction[];
+      enabled?: boolean;
+    },
+    applyOnSave: boolean,
   ) => void | Promise<void>;
 }
 
 function EditView({ feed, target, folders, onBack, onSave }: EditViewProps) {
   const [name, setName] = useState(target?.name ?? "");
   const [enabled, setEnabled] = useState(target?.enabled ?? true);
+  // Default ON — the most common reason users open this dialog is to
+  // *retroactively* mute/star/route articles already in the feed. A
+  // silent default-off would reproduce the "I set a rule and nothing
+  // happened" gap that motivated this work.
+  const [applyOnSave, setApplyOnSave] = useState(true);
   const [condition, setCondition] = useState<ConditionGroup>(
     target?.condition ?? EMPTY_CONDITION,
   );
@@ -219,7 +281,10 @@ function EditView({ feed, target, folders, onBack, onSave }: EditViewProps) {
     if (!canSave) return;
     setSaving(true);
     try {
-      await onSave({ name: name.trim(), condition, actions, enabled });
+      await onSave(
+        { name: name.trim(), condition, actions, enabled },
+        applyOnSave,
+      );
     } finally {
       setSaving(false);
     }
@@ -289,6 +354,26 @@ function EditView({ feed, target, folders, onBack, onSave }: EditViewProps) {
             folders={folders}
           />
         </div>
+
+        <RuleMatchPreview feed={feed} condition={condition} />
+
+        <div className="flex items-center gap-2 rounded-md border bg-muted/30 p-3">
+          <Switch
+            id="rule-apply-on-save"
+            checked={applyOnSave}
+            onCheckedChange={setApplyOnSave}
+            data-testid="rule-apply-on-save-switch"
+          />
+          <Label
+            htmlFor="rule-apply-on-save"
+            className="text-sm cursor-pointer flex-1"
+          >
+            Apply to existing articles when saved
+            <span className="block text-xs text-muted-foreground font-normal">
+              Otherwise the rule only runs on articles fetched after this save.
+            </span>
+          </Label>
+        </div>
       </div>
 
       <DialogFooter>
@@ -324,4 +409,88 @@ function summariseActions(actions: RuleAction[]): string {
       }
     })
     .join(", ");
+}
+
+const PREVIEW_LIMIT = 8;
+// Stable reference for the empty-articles case so the selector doesn't
+// hand React a fresh `[]` literal each render — Zustand + useSyncExternalStore
+// treat the new reference as a state change and you get an infinite loop.
+const EMPTY_ARTICLES: Article[] = Object.freeze([] as Article[]) as Article[];
+
+/**
+ * Live "what will this rule catch?" preview. Reads the article store's
+ * in-memory snapshot for this feed, evaluates the condition against
+ * each article, and surfaces the count + a short list of titles. Pure
+ * front-end derivation — no DB read, no rule write.
+ *
+ * Empty conditions are vacuously true for `match: "all"`, which would
+ * "match every article" and is almost never what the user wants while
+ * they're still editing. We hide the list in that case and show a
+ * gentle hint instead.
+ */
+function RuleMatchPreview({
+  feed,
+  condition,
+}: {
+  feed: Feed | undefined;
+  condition: ConditionGroup;
+}) {
+  const articles =
+    useArticleStore((s) =>
+      feed ? s.articlesByFeedId[feed.id] : undefined,
+    ) ?? EMPTY_ARTICLES;
+  const feeds = useFeedStore((s) => s.feeds);
+  const filters = useSmartFilterStore((s) => s.filters);
+  const matches = useMemo(() => {
+    if (!feed) return [];
+    if (condition.children.length === 0) return [];
+    const ctx = buildContext({ feeds, filters });
+    const hits: Article[] = [];
+    for (const a of articles) {
+      if (evaluateGroup(condition, a, ctx)) hits.push(a);
+    }
+    return hits;
+  }, [feed, articles, condition, feeds, filters]);
+
+  const total = articles.length;
+  const isEmpty = condition.children.length === 0;
+  return (
+    <div className="space-y-1.5" data-testid="rule-preview">
+      <Label>Preview</Label>
+      <div className="rounded-md border bg-muted/30 p-3 text-sm">
+        {isEmpty ? (
+          <p className="text-xs text-muted-foreground italic">
+            Add a condition above to see which existing articles would match.
+          </p>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground mb-2">
+              Matches {matches.length} of {total} loaded article
+              {total === 1 ? "" : "s"}
+              {matches.length > PREVIEW_LIMIT
+                ? ` (showing first ${PREVIEW_LIMIT})`
+                : ""}
+            </p>
+            {matches.length === 0 ? (
+              <p className="text-xs text-muted-foreground italic">
+                Nothing in the loaded snapshot matches this condition.
+              </p>
+            ) : (
+              <ul className="space-y-1">
+                {matches.slice(0, PREVIEW_LIMIT).map((a) => (
+                  <li
+                    key={a.id}
+                    className="truncate text-xs"
+                    data-testid="rule-preview-match"
+                  >
+                    {a.title || "(untitled)"}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/src/components/settings/tabs/rules-audit-panel.tsx
+++ b/src/components/settings/tabs/rules-audit-panel.tsx
@@ -2,11 +2,14 @@
  * Read-only audit view of every rule across every subscribed feed.
  *
  * Answers the "what's hiding articles from me right now?" question.
- * Clicking a row opens the rules editor for that feed (write-side
- * happens in the editor dialog; this view never mutates).
+ * Clicking Edit opens the rules editor for that feed; clicking Run
+ * now applies the rule to articles already stored. Both write paths
+ * route through feed-store actions — this component owns no mutating
+ * logic of its own.
  */
 
-import { Settings2 } from "lucide-react";
+import { Play, Settings2 } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useFeedStore } from "@/stores/feed-store";
 import { useFeatureGate } from "@/hooks/use-feature-gate";
@@ -45,11 +48,31 @@ function summariseActions(actions: RuleAction[]): string {
 export function RulesAuditPanel() {
   const feeds = useFeedStore((s) => s.feeds);
   const openRulesEditor = useFeedStore((s) => s.openRulesEditor);
+  const applyRuleToExistingArticles = useFeedStore(
+    (s) => s.applyRuleToExistingArticles,
+  );
   const gate = useFeatureGate("rules");
   // Existing rules can linger after a downgrade; route Edit to upgrade
   // when the gate is closed rather than opening an editor that can't save.
   const editRules = (feedId: string) =>
     gate.enabled ? openRulesEditor(feedId) : gate.promptUpgrade();
+
+  async function runRuleNow(feedId: string, ruleId: string) {
+    if (!gate.enabled) {
+      gate.promptUpgrade();
+      return;
+    }
+    const result = await applyRuleToExistingArticles(feedId, ruleId);
+    if (!result.ok) {
+      toast.error(`Couldn't apply rule: ${result.error}`);
+      return;
+    }
+    toast.success(
+      result.value.changed === 0
+        ? "No existing articles matched"
+        : `Applied to ${result.value.changed} of ${result.value.total} articles`,
+    );
+  }
 
   const groups = flattenFeedRules(feeds);
   const totalRules = groups.reduce((sum, g) => sum + g.rules.length, 0);
@@ -117,6 +140,17 @@ export function RulesAuditPanel() {
                         (paused)
                       </span>
                     )}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0"
+                      aria-label={`Run "${rule.name}" now`}
+                      data-testid={`rules-audit-run-now-${rule.id}`}
+                      onClick={() => runRuleNow(feed.id, rule.id)}
+                    >
+                      <Play className="size-3.5" />
+                    </Button>
                   </li>
                 ))}
               </ul>

--- a/src/components/smart-filters/condition-group-editor.tsx
+++ b/src/components/smart-filters/condition-group-editor.tsx
@@ -1,7 +1,5 @@
 import { ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button.tsx";
-import { Label } from "@/components/ui/label.tsx";
-import { Switch } from "@/components/ui/switch.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,9 +26,14 @@ interface ConditionGroupEditorProps {
 
 /**
  * Recursive editor for a condition group. Renders a "match all/any"
- * toggle + an optional NOT inversion + a list of children, each of
- * which is either a leaf ConditionRow or another nested
- * ConditionGroupEditor.
+ * toggle + a list of children, each of which is either a leaf
+ * ConditionRow or another nested ConditionGroupEditor.
+ *
+ * Group-level NOT inversion was removed from the UI — the per-
+ * condition `not-contains` / `not-in` operators cover the common
+ * cases with a simpler mental model. The `not?` field on
+ * ConditionGroup stays on the type; the engine still evaluates it
+ * so older vaults keep filtering correctly.
  *
  * State lives in the parent — every change rebuilds the group from
  * the child's onChange callback. The component is a controlled
@@ -95,16 +98,6 @@ export function ConditionGroupEditor({
           <option value="any">any</option>
         </select>
         <span className="text-muted-foreground">of the following</span>
-        <Label className="flex items-center gap-2 ml-2 text-xs text-muted-foreground cursor-pointer">
-          <Switch
-            checked={Boolean(group.not)}
-            onCheckedChange={(checked) =>
-              onChange({ ...group, not: checked })
-            }
-            aria-label="Negate this group"
-          />
-          NOT
-        </Label>
         {onRemove && (
           <Button
             type="button"

--- a/src/core/rules/engine.ts
+++ b/src/core/rules/engine.ts
@@ -43,6 +43,30 @@ export function applyRules(
 }
 
 /**
+ * Run one rule against an array of stored articles and return the
+ * subset whose persisted shape changes. Idempotent actions (mute on an
+ * already-muted article, mark-read on a read article) drop out so the
+ * caller's `updateArticles` write touches only what actually changed —
+ * decryption + IndexedDB writes cost real time on big feeds.
+ *
+ * Disabled rules and rules with empty actions yield an empty diff. The
+ * input array is never mutated; each changed entry is a new object.
+ */
+export function applyRuleToExisting(
+  articles: Article[],
+  rule: Rule,
+  ctx: EvalContext,
+): { changed: Article[] } {
+  if (!rule.enabled || rule.actions.length === 0) return { changed: [] };
+  const changed: Article[] = [];
+  for (const article of articles) {
+    const next = applyRules(article, [rule], ctx);
+    if (next !== article) changed.push(next);
+  }
+  return { changed };
+}
+
+/**
  * Apply one action to one article. Exhaustive switch — TypeScript
  * forces every action kind to be covered, so adding a new kind to
  * `RuleAction` is a compile-time error until the engine handles it.

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -9,8 +9,12 @@ import {
   updateFolder as dbUpdateFolder,
   removeFolder as dbRemoveFolder,
   getAllArticles,
+  updateArticles as dbUpdateArticles,
 } from "../core/storage/db.ts";
 import { createRule } from "../core/storage/schema.ts";
+import { applyRuleToExisting } from "../core/rules/engine.ts";
+import { buildContext } from "../core/filters/evaluator.ts";
+import { useSmartFilterStore } from "./smart-filter-store.ts";
 import {
   addFeedFlow,
   addPlaceholderFeed as addPlaceholderFeedCore,
@@ -200,6 +204,17 @@ interface FeedStore {
   updateFeedRule: (feedId: string, rule: Rule) => Promise<Result<Rule>>;
   removeFeedRule: (feedId: string, ruleId: string) => Promise<void>;
   reorderFeedRules: (feedId: string, orderedIds: string[]) => Promise<void>;
+  /**
+   * Backfill one rule across the articles already stored for a feed.
+   * Loads the in-memory snapshot, runs the rule via the pure engine,
+   * persists only the diff via `updateArticles`, schedules a sync push
+   * if anything changed, and reloads the article store for the active
+   * view. Closes the "rule does nothing until next ingest" UX gap.
+   */
+  applyRuleToExistingArticles: (
+    feedId: string,
+    ruleId: string,
+  ) => Promise<Result<{ changed: number; total: number }>>;
   /**
    * When non-null, the rules-editor dialog is open against this feed.
    * Dialog mounts at the app root and reads this slice.
@@ -936,6 +951,33 @@ export const useFeedStore = create<FeedStore>((set, get) => ({
       },
       set,
     );
+  },
+
+  applyRuleToExistingArticles: async (feedId, ruleId) => {
+    if (!enforceFeature("rules"))
+      return err("Rules require the Personal tier");
+    const feedResult = await getFeed(feedId);
+    if (!feedResult.ok) return err(feedResult.error);
+    const target = (feedResult.value.rules ?? []).find((r) => r.id === ruleId);
+    if (!target) return err(`Rule ${ruleId} not found on feed ${feedId}`);
+
+    const articleStore = useArticleStore.getState();
+    const existing = articleStore.articlesByFeedId[feedId] ?? [];
+    const ctx = buildContext({
+      feeds: get().feeds,
+      filters: useSmartFilterStore.getState().filters,
+    });
+    const { changed } = applyRuleToExisting(existing, target, ctx);
+
+    if (changed.length > 0) {
+      const writeResult = await dbUpdateArticles(changed);
+      if (!writeResult.ok) return err(writeResult.error);
+      schedulePush();
+      // Re-read the article-store from the (now-updated) DB so the UI
+      // reflects the muted state without a navigation.
+      await reloadArticleStoreForView(get().selectedFeedId);
+    }
+    return ok({ changed: changed.length, total: existing.length });
   },
 }));
 

--- a/tests/components/rules/rules-audit-panel.test.tsx
+++ b/tests/components/rules/rules-audit-panel.test.tsx
@@ -130,4 +130,23 @@ describe("RulesAuditPanel", () => {
     );
     expect(useFeedStore.getState().rulesEditorFeedId).toBe("f1");
   });
+
+  it("Run-now button invokes applyRuleToExistingArticles for that rule", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [feed("f1", "Tech Crunchies", [rule("r1", "Mute sponsored")])],
+      folders: [],
+    });
+    const spy = vi
+      .spyOn(useFeedStore.getState(), "applyRuleToExistingArticles")
+      .mockResolvedValue({ ok: true, value: { changed: 2, total: 10 } });
+
+    render(
+      <MemoryRouter>
+        <RulesAuditPanel />
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByTestId("rules-audit-run-now-r1"));
+    expect(spy).toHaveBeenCalledWith("f1", "r1");
+  });
 });

--- a/tests/components/rules/rules-editor-dialog.test.tsx
+++ b/tests/components/rules/rules-editor-dialog.test.tsx
@@ -175,4 +175,93 @@ describe("RulesEditorDialog", () => {
     expect(screen.getByTestId("rule-list-item")).toBeInTheDocument();
     expect(screen.getByText("Mute spam")).toBeInTheDocument();
   });
+
+  describe("Apply-on-save toggle", () => {
+    it("renders an 'Apply to existing' switch in the editor, default on", async () => {
+      const user = userEvent.setup();
+      dbMock._seed(feed());
+      useFeedStore.setState({ feeds: [feed()], rulesEditorFeedId: "f1" });
+      renderDialog();
+      await user.click(screen.getByTestId("rule-add"));
+      const toggle = screen.getByTestId("rule-apply-on-save-switch");
+      expect(toggle).toBeInTheDocument();
+      // Radix Switch reflects state via aria-checked; default = on.
+      expect(toggle.getAttribute("aria-checked")).toBe("true");
+    });
+
+    it("calls applyRuleToExistingArticles after save when toggle is on", async () => {
+      const user = userEvent.setup();
+      dbMock._seed(feed());
+      useFeedStore.setState({ feeds: [feed()], rulesEditorFeedId: "f1" });
+      const spy = vi
+        .spyOn(useFeedStore.getState(), "applyRuleToExistingArticles")
+        .mockResolvedValue({ ok: true, value: { changed: 3, total: 10 } });
+
+      renderDialog();
+      await user.click(screen.getByTestId("rule-add"));
+      await user.type(screen.getByTestId("rule-name-input"), "Mute spam");
+      await user.click(screen.getByTestId("rule-action-add"));
+      await user.click(screen.getByText("Mute"));
+      await user.click(screen.getByTestId("rule-save"));
+
+      expect(spy).toHaveBeenCalledWith("f1", expect.any(String));
+    });
+
+    it("does NOT call applyRuleToExistingArticles when toggle is off", async () => {
+      const user = userEvent.setup();
+      dbMock._seed(feed());
+      useFeedStore.setState({ feeds: [feed()], rulesEditorFeedId: "f1" });
+      const spy = vi
+        .spyOn(useFeedStore.getState(), "applyRuleToExistingArticles")
+        .mockResolvedValue({ ok: true, value: { changed: 0, total: 0 } });
+
+      renderDialog();
+      await user.click(screen.getByTestId("rule-add"));
+      await user.type(screen.getByTestId("rule-name-input"), "Mute spam");
+      await user.click(screen.getByTestId("rule-action-add"));
+      await user.click(screen.getByText("Mute"));
+      // Flip the toggle off before save.
+      await user.click(screen.getByTestId("rule-apply-on-save-switch"));
+      await user.click(screen.getByTestId("rule-save"));
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Run-now button in list", () => {
+    it("renders a Run-now control on each rule row", () => {
+      useFeedStore.setState({
+        feeds: [feed([muteRule()])],
+        rulesEditorFeedId: "f1",
+      });
+      renderDialog();
+      expect(screen.getByTestId("rule-run-now-r-1")).toBeInTheDocument();
+    });
+
+    it("invokes applyRuleToExistingArticles for that rule", async () => {
+      const user = userEvent.setup();
+      useFeedStore.setState({
+        feeds: [feed([muteRule()])],
+        rulesEditorFeedId: "f1",
+      });
+      const spy = vi
+        .spyOn(useFeedStore.getState(), "applyRuleToExistingArticles")
+        .mockResolvedValue({ ok: true, value: { changed: 0, total: 0 } });
+
+      renderDialog();
+      await user.click(screen.getByTestId("rule-run-now-r-1"));
+
+      expect(spy).toHaveBeenCalledWith("f1", "r-1");
+    });
+  });
+
+  describe("Live preview", () => {
+    it("renders a preview region in the edit view", async () => {
+      const user = userEvent.setup();
+      useFeedStore.setState({ feeds: [feed()], rulesEditorFeedId: "f1" });
+      renderDialog();
+      await user.click(screen.getByTestId("rule-add"));
+      expect(screen.getByTestId("rule-preview")).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/components/smart-filters/condition-group-editor.test.tsx
+++ b/tests/components/smart-filters/condition-group-editor.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * The shared ConditionGroupEditor is used by both Smart Filters and
+ * per-feed Rules. The group-level NOT toggle was removed in favor of
+ * the per-condition `not-contains` / `not-in` operators — same
+ * expressive power, simpler mental model. The data field `not?` on
+ * ConditionGroup stays on the type so vaults written by older clients
+ * keep evaluating correctly; only the editor affordance is gone.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ConditionGroupEditor } from "@/components/smart-filters/condition-group-editor.tsx";
+import type { ConditionGroup } from "@feedzero/core/types";
+
+function emptyGroup(): ConditionGroup {
+  return { kind: "group", match: "all", children: [] };
+}
+
+describe("ConditionGroupEditor", () => {
+  it("does not render the group-level NOT toggle", () => {
+    render(
+      <ConditionGroupEditor group={emptyGroup()} onChange={() => {}} />,
+    );
+    expect(screen.queryByLabelText("Negate this group")).toBeNull();
+    // The "NOT" text label that lived next to the switch is also gone.
+    expect(screen.queryByText("NOT")).toBeNull();
+  });
+
+  it("still renders the Match all/any selector", () => {
+    render(
+      <ConditionGroupEditor group={emptyGroup()} onChange={() => {}} />,
+    );
+    expect(screen.getByLabelText("Match mode")).toBeInTheDocument();
+  });
+});

--- a/tests/core/rules/engine.test.ts
+++ b/tests/core/rules/engine.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { applyRules } from "../../../src/core/rules/engine.ts";
+import {
+  applyRules,
+  applyRuleToExisting,
+} from "../../../src/core/rules/engine.ts";
 import { buildContext } from "../../../src/core/filters/evaluator.ts";
 import type {
   Article,
@@ -186,5 +189,63 @@ describe("applyRules", () => {
     const r = rule(cond, [{ kind: "mute" }]);
     const out = applyRules(article(), [r], ctx);
     expect(out.muted).toBe(true);
+  });
+});
+
+describe("applyRuleToExisting", () => {
+  const ctx = buildContext({ feeds: [feed()], filters: [] });
+
+  it("returns the subset of articles the rule actually changes", () => {
+    const muteHello = rule(titleContains("Hello"), [{ kind: "mute" }]);
+    const articles = [
+      article({ id: "a", title: "Hello world", muted: false }),
+      article({ id: "b", title: "Goodbye world", muted: false }),
+      article({ id: "c", title: "Hello again", muted: false }),
+    ];
+    const { changed } = applyRuleToExisting(articles, muteHello, ctx);
+    expect(changed.map((a) => a.id).sort()).toEqual(["a", "c"]);
+    expect(changed.every((a) => a.muted === true)).toBe(true);
+  });
+
+  it("skips articles already in the rule's terminal state (idempotent)", () => {
+    // Articles where mute=true already need no update — including them in
+    // the changed set would cause needless re-encryption + IndexedDB writes
+    // on every Run-now click. The contract is "diff only".
+    const muteHello = rule(titleContains("Hello"), [{ kind: "mute" }]);
+    const articles = [
+      article({ id: "a", title: "Hello world", muted: true }),
+      article({ id: "b", title: "Hello again", muted: false }),
+    ];
+    const { changed } = applyRuleToExisting(articles, muteHello, ctx);
+    expect(changed.map((a) => a.id)).toEqual(["b"]);
+  });
+
+  it("returns the empty array when no article matches", () => {
+    const muteNever = rule(titleContains("never matches"), [{ kind: "mute" }]);
+    const { changed } = applyRuleToExisting(
+      [article({ id: "a", title: "Hello world" })],
+      muteNever,
+      ctx,
+    );
+    expect(changed).toEqual([]);
+  });
+
+  it("returns the empty array when the rule is disabled", () => {
+    const muteHello = rule(titleContains("Hello"), [{ kind: "mute" }], {
+      enabled: false,
+    });
+    const { changed } = applyRuleToExisting(
+      [article({ id: "a", title: "Hello world" })],
+      muteHello,
+      ctx,
+    );
+    expect(changed).toEqual([]);
+  });
+
+  it("does not mutate the input articles (pure function)", () => {
+    const input = [article({ id: "a", title: "Hello world", muted: false })];
+    const muteHello = rule(titleContains("Hello"), [{ kind: "mute" }]);
+    applyRuleToExisting(input, muteHello, ctx);
+    expect(input[0].muted).toBe(false);
   });
 });

--- a/tests/stores/feed-store-apply-rule.test.ts
+++ b/tests/stores/feed-store-apply-rule.test.ts
@@ -1,0 +1,272 @@
+/**
+ * feed-store action `applyRuleToExistingArticles`: backfills the named
+ * rule across the articles already stored for a feed. Closes the gap
+ * the engine docstring promises — until now, rules ran only at ingest,
+ * so a "[Sponsor] → mute" rule did nothing to entries already in the
+ * DB. The action loads from the article store, runs the rule against
+ * each article, persists only the diff via `updateArticles`, and
+ * schedules a sync push so muted state replicates.
+ *
+ * Per CLAUDE.md "mock at the boundary, not the collaborator", the db
+ * and sync modules are mocked at module level; the real feed-store,
+ * article-store, schema factories, and rule engine run end-to-end.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Article, Feed, Rule, RuleAction } from "@feedzero/core/types";
+
+vi.mock("../../src/core/storage/db.ts", () => {
+  const feeds = new Map<string, Feed>();
+  const articlesByFeedId = new Map<string, Article[]>();
+  return {
+    getFeeds: vi.fn(async () => ({ ok: true, value: [...feeds.values()] })),
+    getFeed: vi.fn(async (id: string) => {
+      const f = feeds.get(id);
+      return f
+        ? { ok: true as const, value: f }
+        : { ok: false as const, error: "not found" };
+    }),
+    updateFeed: vi.fn(async (feed: Feed) => {
+      feeds.set(feed.id, feed);
+      return { ok: true, value: true };
+    }),
+    getAllArticles: vi.fn(async () => {
+      const flat: Article[] = [];
+      for (const list of articlesByFeedId.values()) flat.push(...list);
+      return { ok: true as const, value: flat };
+    }),
+    getArticlesForFeed: vi.fn(async (feedId: string) => ({
+      ok: true as const,
+      value: articlesByFeedId.get(feedId) ?? [],
+    })),
+    updateArticles: vi.fn(async (updates: Article[]) => {
+      for (const u of updates) {
+        const list = articlesByFeedId.get(u.feedId);
+        if (!list) continue;
+        const i = list.findIndex((a) => a.id === u.id);
+        if (i >= 0) list[i] = u;
+      }
+      return { ok: true, value: true };
+    }),
+    addFolder: vi.fn(),
+    getFolders: vi.fn(async () => ({ ok: true, value: [] })),
+    updateFolder: vi.fn(),
+    removeFolder: vi.fn(),
+    removeFeed: vi.fn(async () => ({ ok: true, value: true })),
+    _feeds: feeds,
+    _articles: articlesByFeedId,
+    _seedFeed: (f: Feed) => feeds.set(f.id, f),
+    _seedArticles: (feedId: string, list: Article[]) =>
+      articlesByFeedId.set(feedId, list),
+    _reset: () => {
+      feeds.clear();
+      articlesByFeedId.clear();
+    },
+  };
+});
+
+vi.mock("../../src/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn(),
+  reloadFeed: vi.fn(),
+}));
+
+vi.mock("../../src/core/extractor/prefetch-service.ts", () => ({
+  prefetchStarredArticles: vi.fn().mockResolvedValue({
+    ok: true,
+    value: { extracted: 0, failed: 0 },
+  }),
+}));
+
+vi.mock("../../src/core/sync/sync-service", () => ({
+  pushVault: vi.fn().mockResolvedValue({ ok: true, value: Date.now() }),
+  pullVault: vi.fn(),
+  importVault: vi.fn(),
+}));
+
+vi.mock("../../src/core/features/paid-tier-active.ts", () => ({
+  isPaidTierActive: () => true,
+}));
+
+import { useFeedStore } from "../../src/stores/feed-store.ts";
+import { useLicenseStore } from "../../src/stores/license-store.ts";
+import { useSyncStore } from "../../src/stores/sync-store.ts";
+import { useArticleStore } from "../../src/stores/article-store.ts";
+import * as db from "../../src/core/storage/db.ts";
+
+const dbMock = db as unknown as {
+  _feeds: Map<string, Feed>;
+  _articles: Map<string, Article[]>;
+  _seedFeed: (f: Feed) => void;
+  _seedArticles: (feedId: string, list: Article[]) => void;
+  _reset: () => void;
+};
+
+function feed(id: string, rules?: Rule[]): Feed {
+  return {
+    id,
+    url: `https://example.com/${id}.xml`,
+    title: id,
+    description: "",
+    siteUrl: "",
+    createdAt: 0,
+    updatedAt: 0,
+    ...(rules ? { rules } : {}),
+  };
+}
+
+function article(id: string, feedId: string, overrides: Partial<Article> = {}): Article {
+  return {
+    id,
+    feedId,
+    guid: id,
+    title: id,
+    link: `https://example.com/${id}`,
+    content: "",
+    summary: "",
+    author: "",
+    publishedAt: 0,
+    read: false,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+function muteRule(id: string, titleSubstring: string, actions: RuleAction[] = [{ kind: "mute" }]): Rule {
+  return {
+    id,
+    name: `Mute ${titleSubstring}`,
+    enabled: true,
+    condition: {
+      kind: "group",
+      match: "all",
+      children: [{ kind: "title", op: "contains", value: titleSubstring }],
+    },
+    actions,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe("feed-store · applyRuleToExistingArticles", () => {
+  let schedulePushSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dbMock._reset();
+    vi.clearAllMocks();
+    useLicenseStore.setState({ tier: "personal" });
+    useFeedStore.setState({ feeds: [], folders: [] });
+    useArticleStore.setState({ articlesByFeedId: {}, articles: [] });
+    schedulePushSpy = vi
+      .spyOn(useSyncStore.getState(), "scheduleSyncPush")
+      .mockImplementation(() => {});
+  });
+
+  it("backfills mute on articles that match the rule's condition", async () => {
+    const rule = muteRule("r-1", "[Sponsor]");
+    const f = feed("f1", [rule]);
+    dbMock._seedFeed(f);
+    const articles = [
+      article("a-1", "f1", { title: "[Sponsor] exe.dev" }),
+      article("a-2", "f1", { title: "Talk Show #999" }),
+      article("a-3", "f1", { title: "[Sponsor] WorkOS" }),
+    ];
+    dbMock._seedArticles("f1", articles);
+    useFeedStore.setState({ feeds: [f] });
+    useArticleStore.setState({
+      articlesByFeedId: { f1: articles.map((a) => ({ ...a })) },
+    });
+
+    const result = await useFeedStore
+      .getState()
+      .applyRuleToExistingArticles("f1", "r-1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.changed).toBe(2);
+      expect(result.value.total).toBe(3);
+    }
+    const persisted = dbMock._articles.get("f1")!;
+    expect(persisted.find((a) => a.id === "a-1")!.muted).toBe(true);
+    expect(persisted.find((a) => a.id === "a-2")!.muted).toBeFalsy();
+    expect(persisted.find((a) => a.id === "a-3")!.muted).toBe(true);
+  });
+
+  it("is idempotent — running again returns changed=0", async () => {
+    const rule = muteRule("r-1", "[Sponsor]");
+    dbMock._seedFeed(feed("f1", [rule]));
+    const articles = [article("a-1", "f1", { title: "[Sponsor] exe.dev" })];
+    dbMock._seedArticles("f1", articles);
+    useFeedStore.setState({ feeds: [feed("f1", [rule])] });
+    useArticleStore.setState({
+      articlesByFeedId: { f1: articles.map((a) => ({ ...a })) },
+    });
+
+    await useFeedStore.getState().applyRuleToExistingArticles("f1", "r-1");
+    // Re-seed the article-store with the now-muted state (mirrors the
+    // reload that would happen between two real user clicks).
+    useArticleStore.setState({
+      articlesByFeedId: {
+        f1: dbMock._articles.get("f1")!.map((a) => ({ ...a })),
+      },
+    });
+    const second = await useFeedStore
+      .getState()
+      .applyRuleToExistingArticles("f1", "r-1");
+
+    expect(second.ok).toBe(true);
+    if (second.ok) expect(second.value.changed).toBe(0);
+  });
+
+  it("schedules a sync push when at least one article changes", async () => {
+    const rule = muteRule("r-1", "[Sponsor]");
+    dbMock._seedFeed(feed("f1", [rule]));
+    const articles = [article("a-1", "f1", { title: "[Sponsor] exe.dev" })];
+    dbMock._seedArticles("f1", articles);
+    useFeedStore.setState({ feeds: [feed("f1", [rule])] });
+    useArticleStore.setState({
+      articlesByFeedId: { f1: articles.map((a) => ({ ...a })) },
+    });
+
+    await useFeedStore.getState().applyRuleToExistingArticles("f1", "r-1");
+    expect(schedulePushSpy).toHaveBeenCalled();
+  });
+
+  it("does NOT schedule a sync push when no article changes (zero-diff write avoided)", async () => {
+    const rule = muteRule("r-1", "never-matches");
+    dbMock._seedFeed(feed("f1", [rule]));
+    const articles = [article("a-1", "f1", { title: "Normal post" })];
+    dbMock._seedArticles("f1", articles);
+    useFeedStore.setState({ feeds: [feed("f1", [rule])] });
+    useArticleStore.setState({
+      articlesByFeedId: { f1: articles.map((a) => ({ ...a })) },
+    });
+
+    await useFeedStore.getState().applyRuleToExistingArticles("f1", "r-1");
+    expect(schedulePushSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns an error result when the feed has no rule with that id", async () => {
+    dbMock._seedFeed(feed("f1"));
+    useFeedStore.setState({ feeds: [feed("f1")] });
+
+    const result = await useFeedStore
+      .getState()
+      .applyRuleToExistingArticles("f1", "r-ghost");
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses when the rules feature is gate-locked (free user)", async () => {
+    useLicenseStore.setState({ tier: "free" });
+    const rule = muteRule("r-1", "[Sponsor]");
+    dbMock._seedFeed(feed("f1", [rule]));
+
+    const result = await useFeedStore
+      .getState()
+      .applyRuleToExistingArticles("f1", "r-1");
+
+    expect(result.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Four asks against the per-feed rules surface, all rooted in the **"set a mute rule, nothing happens"** gap. The engine ran on ingest only; articles already in IndexedDB never saw newly-created rules.

1. **Apply-on-save toggle** in the rules editor (default on) — back-fills the new rule across existing articles after save.
2. **Run-now button** per rule, in both the rules-editor list AND the Settings → Rules audit panel.
3. **NOT group toggle removed** from the shared ConditionGroupEditor — `not-contains` / `not-in` on each condition already covers the common cases. Data field `not?` stays on the type so older vaults keep working.
4. **Live "matches" preview** in the edit view — "Matches N of M loaded articles" + up to 8 sample titles, updating as you edit the condition.

Backend primitive: pure `applyRuleToExisting(articles, rule, ctx)` + feed-store action `applyRuleToExistingArticles(feedId, ruleId)` that persists diffs only, schedules a sync push, and reloads the article store.

## Test plan
- [ ] CI green (3728+ tests, type check, gitleaks, CodeQL, builds).
- [ ] Manual: create a `title contains "[Sponsor]" → mute` rule on Daring Fireball with the apply-on-save toggle ON. Confirm existing sponsor entries disappear from the list AND a toast says "Applied to N of M articles."
- [ ] Manual: open Settings → Rules, click the Play button on the same rule. Confirm idempotent — "No existing articles matched" toast (or "Applied to 0").
- [ ] Manual: open the editor with no condition. Preview shows the gentle hint. Add a condition that matches nothing. Preview shows "Nothing in the loaded snapshot matches this condition."
- [ ] Manual: open the smart-filter editor. Confirm the NOT switch is gone; per-condition `not-contains` is the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)