### PR TITLE
fix(sync-badge): split refresh state from sync mode + go subtle

### DIFF
--- a/src/components/sync/sync-status-badge.tsx
+++ b/src/components/sync/sync-status-badge.tsx
@@ -1,38 +1,39 @@
 /**
- * The persistent "are we synced?" affordance in the top-right of the
- * app shell.
+ * Sidebar-header status badge.
  *
- * Lives outside the sidebar (which collapses on /settings + mobile
- * Sheet) so the sync state is visible on every route. The badge is a
- * link to Settings → Sync & Data so a single click takes the user
- * from "I'm not sure" to "let me configure it".
+ * Surfaces two independent facts on one line:
  *
- * Visual rules — see {@link SyncStatus}:
- *   local-only → amber dot, "Local only"
- *   syncing    → spinner,   "Syncing…"
- *   synced     → emerald dot, "Synced · <relative>"
- *   error      → rose dot,  "Sync error"
+ *   <refresh state> · <sync mode>
  *
- * Any in-flight async work (vault pull, publisher refresh, license
- * verify) overrides the underlying sync status to "syncing" — showing
- * "Synced · just now" in green while refreshAll is still fetching
- * today's articles is a lie. The override applies to local-only users
- * too: a refresh in flight is real work worth surfacing. Vault errors
- * win over the override (the user needs to see the failure).
+ * - **Refresh state** describes the publisher fetch — "Refreshing…"
+ *   while `feed-store.isRefreshingAll` is true, otherwise
+ *   "Refreshed Xm ago" derived from `lastRefreshAllAt`. Absent when
+ *   the user has never refreshed (fresh local install).
  *
- * The "is anything in flight?" check goes through {@link useIsAppBusy}
- * — the single selector that aggregates per-store busy signals so this
- * component never has to know which stores contribute.
+ * - **Sync mode** is the underlying sync-store status — `local`,
+ *   `synced`, `syncing` (vault push in flight), or `error`.
  *
- * The relative-time string ticks itself on a 30s interval so a synced
- * badge doesn't get stuck at "just now" for hours on a quiet tab.
+ * Splitting them came out of "Local only" being misleading: under the
+ * old badge, a routine publisher refresh on a local-only user flipped
+ * the pill to "Syncing…" via `useIsAppBusy`, which read as "your data
+ * is syncing to the cloud" — exactly the opposite of what was true.
+ *
+ * Visual rules:
+ *   - Idle states use muted-foreground text and a small dot — quiet.
+ *   - Active states (refresh in flight, vault push in flight) lean
+ *     on the sky/spinner colour to signal motion.
+ *   - The error state stays loud rose: the user needs to see it.
+ *
+ * License `verifying` is intentionally NOT folded in here — license
+ * recheck is background plumbing, not a cloud event. Settings →
+ * Account is the right surface for it.
  */
 import { useEffect, useState } from "react";
 import { Link } from "react-router";
 import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSyncStore } from "@/stores/sync-store";
-import { useIsAppBusy } from "@/stores/work-status";
+import { useFeedStore } from "@/stores/feed-store";
 
 function formatRelative(ts: number, now: number): string {
   const delta = Math.max(0, now - ts);
@@ -48,77 +49,85 @@ function formatRelative(ts: number, now: number): string {
 
 const TICK_INTERVAL_MS = 30 * 1000;
 
+type DisplayState = "local-only" | "syncing" | "synced" | "error";
+
 export function SyncStatusBadge() {
-  const rawStatus = useSyncStore((s) => s.status);
-  const lastSyncedAt = useSyncStore((s) => s.lastSyncedAt);
-  const isBusy = useIsAppBusy();
-  // Any in-flight async work surfaces as syncing so the badge can't
-  // claim "Synced · just now" while real work is still happening.
-  // Errors win — the user needs to see the failure regardless.
-  const status = isBusy && rawStatus !== "error" ? "syncing" : rawStatus;
+  const status = useSyncStore((s) => s.status);
+  const lastRefreshAllAt = useFeedStore((s) => s.lastRefreshAllAt);
+  const isRefreshingAll = useFeedStore((s) => s.isRefreshingAll);
   const [now, setNow] = useState(() => Date.now());
 
+  // Tick once a "Refreshed Xm ago" label is on screen so it doesn't
+  // get stuck at "just now" on a tab that's been idle for an hour.
+  const hasRefreshHistory = lastRefreshAllAt !== null;
   useEffect(() => {
-    if (status !== "synced") return;
+    if (!hasRefreshHistory) return;
+    if (isRefreshingAll) return;
     const id = setInterval(() => setNow(Date.now()), TICK_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [status]);
+  }, [hasRefreshHistory, isRefreshingAll]);
 
-  const colorRing = {
-    "local-only":
-      "bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-amber-500/30",
-    syncing:
-      "bg-sky-500/10 text-sky-700 dark:text-sky-300 ring-sky-500/30",
-    synced:
-      "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 ring-emerald-500/30",
-    error: "bg-rose-500/10 text-rose-700 dark:text-rose-300 ring-rose-500/30",
-  }[status];
+  const displayState: DisplayState = status;
+  const modeWord =
+    status === "synced" || status === "syncing" ? "synced" : "local";
 
-  const dotColor = {
-    "local-only": "bg-amber-500",
-    syncing: "bg-sky-500",
-    synced: "bg-emerald-500",
-    error: "bg-rose-500",
-  }[status];
+  // Compose the left half. Refresh state takes precedence when the
+  // publisher fetch is in flight; otherwise we surface a relative
+  // timestamp when one exists, and nothing when the user has never
+  // refreshed.
+  let leftLabel: string | null = null;
+  if (isRefreshingAll) leftLabel = "Refreshing…";
+  else if (status === "syncing") leftLabel = "Syncing…";
+  else if (lastRefreshAllAt !== null)
+    leftLabel = `Refreshed ${formatRelative(lastRefreshAllAt, now)}`;
+
+  const isError = status === "error";
+  const isActive = isRefreshingAll || status === "syncing";
 
   const label = (() => {
-    switch (status) {
-      case "local-only":
-        return "Local only";
-      case "syncing":
-        return "Syncing…";
-      case "synced":
-        return lastSyncedAt
-          ? `Synced · ${formatRelative(lastSyncedAt, now)}`
-          : "Synced";
-      case "error":
-        return "Sync error";
+    if (isError) return "Sync error";
+    if (leftLabel === null) {
+      // Fresh install — only the mode word is meaningful.
+      return status === "synced" ? "Synced" : "Local";
     }
+    return `${leftLabel} · ${modeWord}`;
+  })();
+
+  // Color theming: only the active and error states have a strong
+  // pill background; idle is text-muted-foreground on transparent.
+  const tone = (() => {
+    if (isError)
+      return "text-rose-700 dark:text-rose-300 ring-rose-500/30 bg-rose-500/10 ring-1 ring-inset";
+    if (isActive)
+      return "text-sky-700 dark:text-sky-300 ring-sky-500/30 bg-sky-500/10 ring-1 ring-inset";
+    return "text-muted-foreground";
+  })();
+
+  const dotColor = (() => {
+    if (isError) return "bg-rose-500";
+    if (isActive) return "bg-sky-500";
+    if (status === "synced") return "bg-emerald-500/70";
+    return "bg-muted-foreground/50";
   })();
 
   return (
     <Link
       to="/settings?tab=sync-and-data"
       data-testid="sync-status-badge"
-      data-state={status}
+      data-state={displayState}
       aria-label={`Cloud sync: ${label}`}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset shadow-sm",
-        "backdrop-blur-sm transition-colors",
-        "hover:brightness-95 dark:hover:brightness-110",
-        colorRing,
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
+        "hover:text-foreground transition-colors",
+        tone,
       )}
     >
-      {status === "syncing" ? (
+      {isActive ? (
         <Loader2 className="size-3 animate-spin" />
       ) : (
         <span
           aria-hidden
-          className={cn(
-            "size-1.5 rounded-full",
-            dotColor,
-            status === "synced" && "shadow-[0_0_6px_currentColor]",
-          )}
+          className={cn("size-1.5 rounded-full", dotColor)}
         />
       )}
       <span className="leading-none">{label}</span>

--- a/tests/components/layout/app-sidebar-layout.test.tsx
+++ b/tests/components/layout/app-sidebar-layout.test.tsx
@@ -179,10 +179,14 @@ describe("AppSidebar layout structure", () => {
   describe("sync chip visibility", () => {
     it("does not render the SyncBadge for local-only online users", () => {
       useSyncStore.setState({ status: "local-only" });
-      renderSidebar();
-      // The amber sidebar-footer chip is the one we want suppressed; ensure
-      // no element with the visible 'Local' label is in the document.
-      expect(screen.queryByText(/^Local$/)).not.toBeInTheDocument();
+      const { container } = renderSidebar();
+      // The amber sidebar-footer chip is the one we want suppressed.
+      // Scope the check to the footer — the header SyncStatusBadge also
+      // renders the word "Local" for local-only users with no refresh
+      // history, and that surface is a different decision.
+      const footer = container.querySelector("[data-sidebar='footer']");
+      expect(footer).not.toBeNull();
+      expect(footer!.textContent).not.toMatch(/\bLocal\b/);
     });
 
     it("still renders the Synced pill when sync is active", () => {
@@ -214,9 +218,13 @@ describe("AppSidebar layout structure", () => {
       // After the dropdown→button refactor, the chip is suppressed for
       // local-only + online users — the amber "Cloud sync" launcher lives
       // inside Settings → Account instead. The button just says "Settings".
+      // Scoped to the footer so the header SyncStatusBadge's "Local"
+      // (a different surface, different decision) doesn't interfere.
       useSyncStore.setState({ status: "local-only" });
-      renderSidebar();
-      expect(screen.queryByText(/^Local$/)).toBeNull();
+      const { container } = renderSidebar();
+      const footer = container.querySelector("[data-sidebar='footer']");
+      expect(footer).not.toBeNull();
+      expect(footer!.textContent).not.toMatch(/\bLocal\b/);
     });
   });
 });

--- a/tests/components/sync/sync-status-badge.test.tsx
+++ b/tests/components/sync/sync-status-badge.test.tsx
@@ -7,16 +7,25 @@ import { useFeedStore } from "@/stores/feed-store";
 import { useLicenseStore } from "@/stores/license-store";
 
 /**
- * The persistent "are we synced?" affordance in the top-right of the
- * app shell. Lives outside the sidebar so it's visible on every route
- * — including /settings where the sidebar might be tucked behind a
- * Sheet on narrow viewports.
+ * The persistent "what's happening with my data?" affordance in the
+ * sidebar header. It surfaces two independent facts in one line:
  *
- * Visual states match the underlying SyncStatus union:
- *   local-only → amber dot, "Local only"
- *   syncing    → animated dot, "Syncing…"
- *   synced     → emerald dot, "Synced · 2 min ago" (relative)
- *   error      → rose dot, "Sync error" + retry chevron
+ *   <refresh state> · <sync mode>
+ *
+ * `refresh state` is about the publisher fetch — "Refreshing…" /
+ * "Refreshed 5 min ago". It changes every ~30 min.
+ *
+ * `sync mode` is whether the user has cloud sync turned on — "local"
+ * or "synced". It usually changes once.
+ *
+ * Conflating them (which the old "Local only" / "Synced" pill did,
+ * via useIsAppBusy) made the badge look like it was always "Syncing…"
+ * during routine refreshes, which buried the actual mode.
+ *
+ * Visual rules:
+ *   - Idle states are visually subtle (muted text + small dot).
+ *   - Active states use the sky/spinner colour to signal "in flight".
+ *   - Errors stay loud rose — that's a signal the user needs to see.
  */
 function renderBadge() {
   return render(
@@ -30,67 +39,120 @@ describe("SyncStatusBadge", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-24T20:00:00Z"));
-    useFeedStore.setState({ isRefreshingAll: false });
+    useFeedStore.setState({ isRefreshingAll: false, lastRefreshAllAt: null });
     useLicenseStore.setState({ verifying: false });
   });
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("shows amber 'Local only' when sync is off", () => {
-    useSyncStore.setState({ status: "local-only", lastSyncedAt: null });
-    renderBadge();
-    const badge = screen.getByTestId("sync-status-badge");
-    expect(badge).toHaveAttribute("data-state", "local-only");
-    expect(badge).toHaveTextContent(/local only/i);
-  });
-
-  it("shows emerald 'Synced · just now' when freshly synced", () => {
-    useSyncStore.setState({
-      status: "synced",
-      lastSyncedAt: Date.now() - 5_000,
+  describe("idle states", () => {
+    it("shows just 'Local' when local-only with no refresh history", () => {
+      useSyncStore.setState({ status: "local-only", lastSyncedAt: null });
+      renderBadge();
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge).toHaveAttribute("data-state", "local-only");
+      expect(badge).toHaveTextContent(/^Local$/);
     });
-    renderBadge();
-    const badge = screen.getByTestId("sync-status-badge");
-    expect(badge).toHaveAttribute("data-state", "synced");
-    expect(badge).toHaveTextContent(/just now/i);
-  });
 
-  it("shows the relative timestamp in minutes when older than a minute", () => {
-    useSyncStore.setState({
-      status: "synced",
-      lastSyncedAt: Date.now() - 3 * 60 * 1000,
+    it("shows just 'Synced' when sync-on with no refresh history", () => {
+      useSyncStore.setState({ status: "synced", lastSyncedAt: Date.now() });
+      renderBadge();
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge).toHaveAttribute("data-state", "synced");
+      expect(badge).toHaveTextContent(/^Synced$/);
     });
-    renderBadge();
-    expect(screen.getByTestId("sync-status-badge")).toHaveTextContent(
-      /3 min ago/i,
-    );
-  });
 
-  it("shows a spinner and 'Syncing…' during sync", () => {
-    useSyncStore.setState({ status: "syncing", lastSyncedAt: null });
-    const { container } = renderBadge();
-    expect(screen.getByTestId("sync-status-badge")).toHaveAttribute(
-      "data-state",
-      "syncing",
-    );
-    expect(container.querySelector(".animate-spin")).not.toBeNull();
-  });
-
-  it("shows 'Sync error' state in red", () => {
-    useSyncStore.setState({
-      status: "error",
-      lastSyncedAt: null,
-      error: "fetch failed",
+    it("shows 'Refreshed 5 min ago · local' for local-only with refresh history", () => {
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 5 * 60_000 });
+      useSyncStore.setState({ status: "local-only", lastSyncedAt: null });
+      renderBadge();
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge).toHaveTextContent("Refreshed 5 min ago · local");
     });
-    renderBadge();
-    expect(screen.getByTestId("sync-status-badge")).toHaveAttribute(
-      "data-state",
-      "error",
-    );
-    expect(screen.getByTestId("sync-status-badge")).toHaveTextContent(
-      /sync error/i,
-    );
+
+    it("shows 'Refreshed 5 min ago · synced' for sync users with refresh history", () => {
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 5 * 60_000 });
+      useSyncStore.setState({ status: "synced", lastSyncedAt: Date.now() });
+      renderBadge();
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge).toHaveTextContent("Refreshed 5 min ago · synced");
+    });
+
+    it("shows 'Refreshed just now' for a freshly-completed refresh", () => {
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 5_000 });
+      useSyncStore.setState({ status: "local-only", lastSyncedAt: null });
+      renderBadge();
+      expect(screen.getByTestId("sync-status-badge")).toHaveTextContent(
+        /Refreshed just now/,
+      );
+    });
+
+    it("idle states render the muted-foreground text colour (subtle)", () => {
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 60_000 });
+      useSyncStore.setState({ status: "synced", lastSyncedAt: Date.now() });
+      renderBadge();
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge.className).toContain("text-muted-foreground");
+    });
+  });
+
+  describe("active states", () => {
+    it("shows 'Refreshing… · local' with spinner while refreshing locally", () => {
+      useFeedStore.setState({ isRefreshingAll: true });
+      useSyncStore.setState({ status: "local-only", lastSyncedAt: null });
+      const { container } = renderBadge();
+      expect(screen.getByTestId("sync-status-badge")).toHaveTextContent(
+        "Refreshing… · local",
+      );
+      expect(container.querySelector(".animate-spin")).not.toBeNull();
+    });
+
+    it("shows 'Refreshing… · synced' with spinner while refreshing under sync", () => {
+      useFeedStore.setState({ isRefreshingAll: true });
+      useSyncStore.setState({ status: "synced", lastSyncedAt: Date.now() });
+      renderBadge();
+      expect(screen.getByTestId("sync-status-badge")).toHaveTextContent(
+        "Refreshing… · synced",
+      );
+    });
+
+    it("shows 'Syncing… · synced' when the vault push is in flight", () => {
+      useSyncStore.setState({ status: "syncing", lastSyncedAt: null });
+      renderBadge();
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge).toHaveAttribute("data-state", "syncing");
+      expect(badge).toHaveTextContent("Syncing… · synced");
+    });
+
+    it("license verify does NOT promote the badge to the active state", () => {
+      // License re-check is background plumbing — surfacing it as
+      // "Syncing…" the way the old badge did made every license refresh
+      // look like a cloud event. The badge ignores it now; the license
+      // store has its own surfaces (Settings → Account).
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 60_000 });
+      useSyncStore.setState({ status: "synced", lastSyncedAt: Date.now() });
+      useLicenseStore.setState({ verifying: true });
+      renderBadge();
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge).toHaveAttribute("data-state", "synced");
+      expect(badge).not.toHaveTextContent(/Syncing/);
+    });
+  });
+
+  describe("error state", () => {
+    it("shows 'Sync error' in rose regardless of refresh state", () => {
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 60_000 });
+      useSyncStore.setState({
+        status: "error",
+        lastSyncedAt: null,
+        error: "fetch failed",
+      });
+      renderBadge();
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge).toHaveAttribute("data-state", "error");
+      expect(badge).toHaveTextContent(/Sync error/);
+    });
   });
 
   it("is a link to the Sync & Data settings tab", () => {
@@ -99,50 +161,5 @@ describe("SyncStatusBadge", () => {
     const badge = screen.getByTestId("sync-status-badge");
     expect(badge.tagName).toBe("A");
     expect(badge).toHaveAttribute("href", "/settings?tab=sync-and-data");
-  });
-
-  it("shows 'Syncing…' while feeds are refreshing even when the vault is synced", () => {
-    // The cloud vault is up to date, but refreshAll is still fetching new
-    // articles from publishers. Showing "Synced · just now" in green here
-    // is a lie — the user is looking at yesterday's articles until the
-    // fetches land. The badge must reflect work in progress, not the
-    // narrow "is the vault byte-equal to the cloud?" question.
-    useSyncStore.setState({
-      status: "synced",
-      lastSyncedAt: Date.now() - 5_000,
-    });
-    useFeedStore.setState({ isRefreshingAll: true });
-    const { container } = renderBadge();
-    const badge = screen.getByTestId("sync-status-badge");
-    expect(badge).toHaveAttribute("data-state", "syncing");
-    expect(badge).toHaveTextContent(/syncing/i);
-    expect(container.querySelector(".animate-spin")).not.toBeNull();
-  });
-
-  it("shows 'Syncing…' while feeds are refreshing for local-only users too", () => {
-    // Local-only users don't have a cloud vault, but a publisher refresh
-    // is still meaningful work. While it's in flight the badge should
-    // reflect that, not the static "Local only" descriptor.
-    useSyncStore.setState({ status: "local-only", lastSyncedAt: null });
-    useFeedStore.setState({ isRefreshingAll: true });
-    renderBadge();
-    expect(screen.getByTestId("sync-status-badge")).toHaveAttribute(
-      "data-state",
-      "syncing",
-    );
-  });
-
-  it("shows 'Syncing…' while the license is being verified — work-status contract", () => {
-    // License recheck is the third busy source aggregated by
-    // useIsAppBusy. The badge trusts the selector, so verifying must
-    // surface here without the badge knowing about license-store
-    // directly. Locks the badge↔selector contract.
-    useSyncStore.setState({ status: "synced", lastSyncedAt: Date.now() });
-    useLicenseStore.setState({ verifying: true });
-    renderBadge();
-    expect(screen.getByTestId("sync-status-badge")).toHaveAttribute(
-      "data-state",
-      "syncing",
-    );
   });
 });


### PR DESCRIPTION
## Summary

The "Local only" pill was misleading: it conflated refresh state, sync mode, and busy state into one label and one bright colour. A routine publisher refresh flipped it to "Syncing…" via the busy aggregator, which read as "your data is syncing to the cloud" — exactly the opposite for a local-only user.

New format is `<refresh state> · <sync mode>` where each half lives independently:

| Mode | Refreshing? | Last refresh | Vault error? | Label |
|---|---|---|---|---|
| local-only | no | never | — | `Local` |
| local-only | no | 5m ago | — | `Refreshed 5 min ago · local` |
| local-only | yes | — | — | `Refreshing… · local` |
| synced | no | never | no | `Synced` |
| synced | no | 5m ago | no | `Refreshed 5 min ago · synced` |
| synced | yes | — | no | `Refreshing… · synced` |
| synced | — | — | (vault push) | `Syncing… · synced` |
| any | — | — | yes | `Sync error` (rose, unchanged) |

Visual subtlety: idle states render `text-muted-foreground` on a transparent background — quiet by default. Active states keep the sky pill + spinner so motion is visible. Error stays loud rose because the user needs to see it.

License `verifying` is intentionally dropped from this surface (Settings → Account is the right home for it).

## Test plan
- [x] CI: 3731+ tests pass, type check + gitleaks + CodeQL + builds clean.
- [ ] Manual: open the app fresh local-only — badge reads `Local` quietly.
- [ ] Manual: click Refresh — badge shows `Refreshing… · local` with spinner, then `Refreshed just now · local` (ticks to `Refreshed 1 min ago · local` after a minute).
- [ ] Manual: enable sync — badge reads `Refreshed Xm ago · synced` after the next refresh.
- [ ] Manual: trigger a sync error (e.g. break BLOB_READ_WRITE_TOKEN in dev) — badge goes loud rose with `Sync error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)