### PR TITLE
fix(csp): allow 'wasm-unsafe-eval' so Argon2id sync KDF works

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -138,7 +138,11 @@ export function createApp(
 
   const CSP = [
     "default-src 'self'",
-    "script-src 'self'",
+    // 'wasm-unsafe-eval' lets hash-wasm instantiate its Argon2id
+    // WebAssembly module — required for the sync-vault KDF. We use
+    // the narrow directive (not 'unsafe-eval') so eval() and new
+    // Function() stay blocked.
+    "script-src 'self' 'wasm-unsafe-eval'",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https:",
     "connect-src 'self'",

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -65,6 +65,20 @@ describe("server", () => {
       expect(csp).toContain("img-src 'self' data: https:");
     });
 
+    it("allows WebAssembly instantiation in CSP (Argon2id KDF needs hash-wasm)", async () => {
+      // The Argon2id sync-vault KDF uses hash-wasm, which calls
+      // WebAssembly.instantiate. Browsers gate that behind
+      // 'wasm-unsafe-eval' in script-src. Without it, every sync
+      // enable / restore fails with "Refused to create a WebAssembly
+      // object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an
+      // allowed source of script". We use 'wasm-unsafe-eval' rather
+      // than 'unsafe-eval' so eval() and new Function() stay blocked
+      // — the narrow directive is exactly the one we want.
+      const res = await createApp().request("/");
+      const csp = res.headers.get("Content-Security-Policy");
+      expect(csp).toContain("'wasm-unsafe-eval'");
+    });
+
     it("does not set CSP on API responses", async () => {
       const res = await createApp().request("/api/feed");
       const csp = res.headers.get("Content-Security-Policy");

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self'; object-src 'none'; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self'; object-src 'none'; frame-ancestors 'none'"
         },
         {
           "key": "Strict-Transport-Security",


### PR DESCRIPTION
## Summary

**Production sync is broken.** Every new sync user (and every restore attempt by an existing one) hits:

> Sync error: Argon2id key derivation failed: Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \"script-src 'self'\".

PR #193 (Argon2id memory-hard KDF, August) switched vault encryption to hash-wasm, which calls \`WebAssembly.instantiate\`. The CSP in \`vercel.json\` + \`server.ts\` was never widened — Vite dev doesn't enforce CSP, so the bug never surfaced in PR #193's local testing.

This adds **\`'wasm-unsafe-eval'\`** (the narrow directive — \`eval()\` and \`new Function()\` stay blocked) to \`script-src\` in both places, plus a regression test.

**Urgency:** all new sync sign-ups and all device-restore flows on prod are failing right now. Recommend landing ASAP.

## Test plan
- [x] CI: full suite green (3729+ tests, type check, gitleaks, CodeQL, builds).
- [x] New test asserts \`script-src\` contains \`'wasm-unsafe-eval'\`.
- [ ] Manual on preview: enable Cloud sync end-to-end — passphrase confirm → vault push succeeds → reload → restore works.
- [ ] Manual on preview: confirm console has **no** \`'unsafe-eval'\` CSP violations during sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)