### PR TITLE
fix(#211): free articles wrongly paywalled + show app version in Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedzero",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "description": "Privacy-first RSS reader",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src/components/settings/tabs/help-tab.tsx
+++ b/src/components/settings/tabs/help-tab.tsx
@@ -18,6 +18,7 @@ import { PreflightPanel } from "@/components/settings/preflight-panel";
 import { getLicenseToken } from "@/core/license/license-token-store";
 import { isSelfHosted } from "@/core/features/self-hosted";
 import { runSelfHostPreflight } from "@/core/diagnostics/self-host-preflight";
+import { getAppVersion } from "@/core/version";
 
 const isMac =
   typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
@@ -72,6 +73,7 @@ interface HelpTabProps {
 export function HelpTab({ onWhatsNew }: HelpTabProps) {
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const token = getLicenseToken();
+  const version = getAppVersion();
 
   return (
     <div className="space-y-4 py-2">
@@ -129,8 +131,15 @@ export function HelpTab({ onWhatsNew }: HelpTabProps) {
 
       <ContactSupport
         token={token}
-        diagnosticContext={{ Source: "settings-help" }}
+        diagnosticContext={{ Source: "settings-help", Version: version }}
       />
+
+      <p
+        data-testid="app-version"
+        className="text-center text-xs text-muted-foreground"
+      >
+        FeedZero v{version}
+      </p>
 
       {isSelfHosted() ? (
         <PreflightPanel

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,24 @@
+/**
+ * Build-identifying version string for display in the UI.
+ *
+ * Baked at build time by Vite's `VITE_APP_VERSION` define, which is sourced
+ * from package.json (see vite.config.js). The serverless side reports the
+ * same number via `process.env.APP_VERSION` (scripts/build-api.js) and the
+ * `/api/health` endpoint; this accessor is the browser/UI counterpart so the
+ * Settings screen can show which build is running.
+ *
+ * Falls back to "dev" when the define is absent — e.g. unit tests, where
+ * Vitest does not apply the Vite `define` — so the UI always shows something
+ * concrete instead of `undefined`. Mirrors the defensive read in
+ * health-handler.ts so neither path crashes when `import.meta.env` is missing.
+ */
+export function getAppVersion(): string {
+  try {
+    const env = (import.meta as ImportMeta & { env?: Record<string, string> })
+      .env;
+    const version = env?.VITE_APP_VERSION;
+    return typeof version === "string" && version.length > 0 ? version : "dev";
+  } catch {
+    return "dev";
+  }
+}

--- a/src/stores/extraction-store.ts
+++ b/src/stores/extraction-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { proxyFetch } from "../core/proxy/proxy-fetch.ts";
 import { detectPaywall, type PaywallVerdict } from "../core/extractor/paywall-detectors/index.ts";
 import { publisherHost } from "../core/extractor/paywall-detectors/host.ts";
+import { visibleTextLength } from "../core/extractor/paywall-detectors/visible-text.ts";
 import { fetchArticle as extensionFetchArticle } from "../core/extension/protocol.ts";
 import { useExtensionStore } from "./extension-store.ts";
 
@@ -176,6 +177,36 @@ function recordCacheEntry(url: string, html: string): void {
   cacheMeta.set(url, { ts: Date.now(), bytes: html.length });
 }
 
+/**
+ * Visible-character count above which an extraction is treated as a real,
+ * readable article — at which point any "Subscribe" CTA in the surrounding
+ * page chrome is irrelevant and we render without consulting paywall
+ * heuristics at all. Applied to the *extracted* content, not the raw page;
+ * that distinction is the fix for issue #211, where free articles were
+ * flagged paywalled because the full page's nav/footer contained
+ * industry-standard subscribe phrases.
+ */
+const MIN_ARTICLE_CHARS = 600;
+
+/** Cache extracted content and mark the URL available (eviction-aware). */
+function cacheExtracted(
+  url: string,
+  content: string,
+  set: (
+    partial: Partial<{
+      cache: Record<string, string>;
+      statusMap: Record<string, ExtractionStatus>;
+    }>,
+  ) => void,
+  get: () => ExtractionStore,
+): void {
+  recordCacheEntry(url, content);
+  set({
+    cache: evictCache({ ...get().cache, [url]: content }),
+    statusMap: { ...get().statusMap, [url]: "available" },
+  });
+}
+
 export const useExtractionStore = create<ExtractionStore>((set, get) => ({
   cache: {},
   statusMap: {},
@@ -241,19 +272,35 @@ export const useExtractionStore = create<ExtractionStore>((set, get) => ({
       }
       const anonymousHtml = await response.text();
 
-      const verdict = detectPaywall(anonymousHtml, url);
-      if (verdict.paywalled) {
+      // Extract FIRST. A substantial extraction is the definitive signal
+      // that the article is readable, so the surrounding page chrome (nav,
+      // footer, newsletter prompts) is irrelevant — render and stop. This
+      // ordering is the fix for issue #211: paywall heuristics used to run
+      // against the raw page before extraction, so a free article whose
+      // chrome contained a stock "Subscribe to continue" / "Already a
+      // subscriber?" phrase was wrongly gated.
+      const result = extract(anonymousHtml, url);
+      const content = result?.ok ? result.value.content : "";
+
+      if (content && visibleTextLength(content) >= MIN_ARTICLE_CHARS) {
+        cacheExtracted(url, content, set, get);
+        return;
+      }
+
+      // Thin or empty extraction. Only NOW consult the paywall heuristics,
+      // and scope them to the extracted teaser when we have one so the
+      // page chrome can't false-positive. A `body-too-short` verdict never
+      // overrides content we *did* extract — a short free post still renders.
+      const verdict = detectPaywall(content || anonymousHtml, url);
+      const gated =
+        verdict.paywalled && !(content && verdict.reason === "body-too-short");
+      if (gated) {
         await handlePaywalledFetch(url, verdict, extract, set, get);
         return;
       }
 
-      const result = extract(anonymousHtml, url);
-      if (result.ok && result.value.content) {
-        recordCacheEntry(url, result.value.content);
-        set({
-          cache: evictCache({ ...get().cache, [url]: result.value.content }),
-          statusMap: { ...get().statusMap, [url]: "available" },
-        });
+      if (content) {
+        cacheExtracted(url, content, set, get);
       } else {
         set({
           statusMap: { ...get().statusMap, [url]: "failed" },
@@ -337,11 +384,7 @@ async function handlePaywalledFetch(
 
   const extracted = extract(retry.value.html, url);
   if (extracted.ok && extracted.value.content) {
-    recordCacheEntry(url, extracted.value.content);
-    set({
-      cache: evictCache({ ...get().cache, [url]: extracted.value.content }),
-      statusMap: { ...get().statusMap, [url]: "available" },
-    });
+    cacheExtracted(url, extracted.value.content, set, get);
     // Clear any stale verdict from a prior anonymous fetch.
     if (get().paywallMap[url]) {
       const next = { ...get().paywallMap };

--- a/tests/components/settings/help-tab.test.tsx
+++ b/tests/components/settings/help-tab.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/core/license/license-token-store", () => ({
   setLicenseToken: () => undefined,
   LICENSE_TOKEN_STORAGE_KEY: "feedzero:license-token",
 }));
+vi.mock("@/core/version", () => ({ getAppVersion: () => "9.9.9" }));
 
 describe("<HelpTab>", () => {
   it("renders the keyboard shortcuts inline (was its own modal)", () => {
@@ -43,5 +44,10 @@ describe("<HelpTab>", () => {
     render(<HelpTab onWhatsNew={onWhatsNew} />);
     fireEvent.click(screen.getByRole("button", { name: /what's new/i }));
     expect(onWhatsNew).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays the installed app version (#211)", () => {
+    render(<HelpTab onWhatsNew={() => {}} />);
+    expect(screen.getByTestId("app-version")).toHaveTextContent(/9\.9\.9/);
   });
 });

--- a/tests/stores/extraction-store-paywall.test.ts
+++ b/tests/stores/extraction-store-paywall.test.ts
@@ -57,6 +57,13 @@ describe("extraction-store paywall handling", () => {
     resetExtraction();
     resetExtension();
     vi.clearAllMocks();
+    // Realistic baseline: an *anonymous* fetch of a gated page yields no
+    // usable extraction — only an authenticated retry does. The store now
+    // extracts before deciding paywall (issue #211 fix), so tests that
+    // exercise the gated path must start from "nothing extracted" unless
+    // they explicitly model a readable body. (clearAllMocks resets call
+    // history but not return values, so set the default here every test.)
+    vi.mocked(extract).mockReturnValue(err("no extraction"));
   });
 
   describe("paywall detection on proxy fetch", () => {
@@ -116,6 +123,85 @@ describe("extraction-store paywall handling", () => {
       expect(state.paywallMap["https://example.com/free"]).toBeUndefined();
       expect(state.cache["https://example.com/free"]).toBe("<p>Full</p>");
     });
+
+    // Regression: issue #211. Many free articles (Wired, NYT, lttlabs, …)
+    // ship industry-standard "Subscribe" CTAs in their nav/footer/newsletter
+    // chrome. Detection used to run against the *raw page* before extraction,
+    // so that chrome phrase-matched and the fully-readable article was wrongly
+    // flagged paywalled. The article must render; the chrome is irrelevant.
+    it("renders a fully-readable article even when page chrome contains subscribe CTAs (#211)", async () => {
+      const articleBody = `<article>${"<p>A real, readable paragraph of the article body. </p>".repeat(40)}</article>`;
+      const pageWithChrome = `
+        <html><body>
+          <nav><a href="/subscribe">Subscribe</a></nav>
+          ${articleBody}
+          <footer>
+            <p>Subscribe to continue reading our award-winning journalism.</p>
+            <a href="/login">Already a subscriber?</a>
+          </footer>
+        </body></html>
+      `;
+      const extractedArticle =
+        "<article>" +
+        "<p>A real, readable paragraph of the article body. </p>".repeat(40) +
+        "</article>";
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(pageWithChrome),
+      }) as unknown as typeof fetch;
+      vi.mocked(extract).mockReturnValue({
+        ok: true,
+        value: { content: extractedArticle, title: "", author: "", excerpt: "" },
+      });
+      useExtensionStore.setState({ status: "absent" });
+
+      await useExtractionStore
+        .getState()
+        .fetchExtracted("https://www.wired.com/story/free-article");
+
+      const state = useExtractionStore.getState();
+      expect(
+        state.paywallMap["https://www.wired.com/story/free-article"],
+      ).toBeUndefined();
+      expect(state.cache["https://www.wired.com/story/free-article"]).toBe(
+        extractedArticle,
+      );
+      expect(
+        state.statusMap["https://www.wired.com/story/free-article"],
+      ).toBe("available");
+    });
+
+    // Regression: issue #211. A genuinely short but free post (below the
+    // real-article threshold) with no gate phrases must still render — the
+    // raw-page `body-too-short` heuristic used to flag it as paywalled.
+    it("renders a short but free article with no gate phrases (#211)", async () => {
+      const html =
+        "<html><body><article><p>Tiny but completely free post.</p></article></body></html>";
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(html),
+      }) as unknown as typeof fetch;
+      vi.mocked(extract).mockReturnValue({
+        ok: true,
+        value: {
+          content: "<p>Tiny but completely free post.</p>",
+          title: "",
+          author: "",
+          excerpt: "",
+        },
+      });
+      useExtensionStore.setState({ status: "absent" });
+
+      await useExtractionStore
+        .getState()
+        .fetchExtracted("https://blog.example.com/tiny");
+
+      const state = useExtractionStore.getState();
+      expect(state.paywallMap["https://blog.example.com/tiny"]).toBeUndefined();
+      expect(state.cache["https://blog.example.com/tiny"]).toBe(
+        "<p>Tiny but completely free post.</p>",
+      );
+    });
   });
 
   describe("authenticated retry through the extension", () => {
@@ -127,10 +213,21 @@ describe("extraction-store paywall handling", () => {
       vi.mocked(fetchArticle).mockResolvedValue(
         ok({ html: FULL_HTML, finalUrl: "https://nytimes.com/article-3", status: 200 }),
       );
-      vi.mocked(extract).mockReturnValue({
-        ok: true,
-        value: { content: "<p>Authenticated full article</p>", title: "", author: "", excerpt: "" },
-      });
+      // Anonymous PAYWALL_HTML extracts to nothing; the authenticated
+      // FULL_HTML extracts to the full body.
+      vi.mocked(extract).mockImplementation((html: string) =>
+        html === FULL_HTML
+          ? {
+              ok: true,
+              value: {
+                content: "<p>Authenticated full article</p>",
+                title: "",
+                author: "",
+                excerpt: "",
+              },
+            }
+          : err("no extraction"),
+      );
       useExtensionStore.setState({
         status: "installed",
         authorizedDomains: ["nytimes.com"],


### PR DESCRIPTION
Closes #211. Two distinct bugs, one commit each.

## 1. Articles incorrectly flagged as paywalled (`c993ccd`)
**Root cause:** `extraction-store.fetchExtracted` ran `detectPaywall()` against the **raw page** *before* extraction. The default detector substring-matches the entire markup, so industry-standard "Subscribe to continue" / "Already a subscriber?" CTAs in the nav/footer/newsletter chrome of *every* page (Wired, NYT, lttlabs, …) — free or gated — produced a false `phrase-match` verdict. The raw-page `body-too-short` rule mis-fired similarly.

**Fix:** Extract first. A substantial extraction (≥600 visible chars of *extracted* content) renders immediately and ignores page chrome. Paywall heuristics now run only as a fallback for thin/empty extraction, scoped to the extracted teaser, and `body-too-short` never overrides content we did extract (short free posts still render). HTTP gated status (401/402/403/451) stays a first-class signal.

**Tests:** two regression cases (full article wrapped in subscribe chrome → renders, no verdict; short free post → renders). Existing paywall suite (stub→prompt, 403→prompt, authorized retry) stays green; its baseline now models reality (anonymous fetch of a gated page yields no extraction).

## 2. Settings doesn't show the installed version + version drift (`3f318d2`)
**Root cause:** No UI surface read the version. Separately, the 0.10.0/0.11.0 releases never bumped `package.json` (still 0.9.0) — the single source for `VITE_APP_VERSION` (SPA) and inlined `process.env.APP_VERSION` (serverless) — so prod `/api/health` reported `0.9.0` while the changelog said v0.11.0.

**Fix:** `getAppVersion()` accessor + "FeedZero v{version}" in Settings → Help (and in the support diagnostic context). Bump `package.json` → `0.11.0` so the SPA display, `/api/health`, and the `health-version` smoke invariant agree. Committed `api/*.ts` bundles are regenerated by `build:api` at deploy, so no hand-edit needed.

**Tests:** `help-tab.test.tsx` asserts the version renders; existing `tests/smoke/health-version.test.ts` already enforces prod version == `package.json` version.

## Verification
- `npx vitest run` → 3735 passed, 35 skipped, 0 failed.
- `tsc --noEmit` (TS 6.0.3, the pinned version) → clean.

> ⚠️ Follow-up for the maintainer: the `/new-release` flow must bump `package.json` (it was skipped for 0.10/0.11). Not auto-merging — yours to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)