### PR TITLE
release: bump version to 0.12.0, vendor 0.12.0 release feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedzero",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Privacy-first RSS reader",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/tests/fixtures/release-feed.xml
+++ b/tests/fixtures/release-feed.xml
@@ -3,12 +3,36 @@
   <title>FeedZero Release Notes</title>
   <subtitle>What changed in FeedZero.</subtitle>
   <id>feedzero:changelog</id>
-  <updated>2026-05-22T12:00:00Z</updated>
+  <updated>2026-05-31T12:00:00Z</updated>
   <link rel="self" href="https://feedzero.app/releases.xml" />
   <link rel="alternate" type="text/html" href="https://feedzero.app/#releases" />
   <author>
     <name>FeedZero</name>
   </author>
+  <entry>
+    <id>feedzero:release:0.12.0</id>
+    <title>v0.12.0: Paywall false-positive fix and automatic TLS for LAN self-hosts</title>
+    <link rel="alternate" href="https://feedzero.app/#releases" />
+    <published>2026-05-31T12:00:00Z</published>
+    <updated>2026-05-31T12:00:00Z</updated>
+    <summary>Free, fully-readable articles no longer show a false paywall box, and self-hosted deployments on a LAN or bare IP now serve HTTPS without manual certificate setup.</summary>
+    <content type="html"><![CDATA[<p>Free, fully-readable articles no longer show a false paywall box, and self-hosted deployments on a LAN or bare IP now serve HTTPS without manual certificate setup.</p>
+<h3>Added</h3>
+<ul>
+  <li>Added the running application version to Settings, so the installed build is visible at a glance.</li>
+  <li>Added Windows PowerShell parity to the self-host script. <code>feedzero.ps1</code> now classifies the host and selects self-signed internal TLS for IP, localhost, and .local deployments, matching the existing shell script.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+  <li>Simplified the README and self-hosting guide to a one-command Docker quickstart from the public image, with the longer day-2 and troubleshooting material kept behind it.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+  <li>Fixed free, fully-readable articles being flagged as paywalled. Full-text extraction now treats a substantial extraction as the definitive readable signal and runs paywall heuristics only as a fallback on the extracted teaser, so subscribe prompts in page navigation and footers no longer trigger a false paywall box.</li>
+  <li>Fixed self-hosted deployments on a LAN or bare IP serving plain HTTP on the HTTPS port, which produced <code>SSL_ERROR_RX_RECORD_TOO_LONG</code>. The server CLI now classifies the host and serves self-signed internal TLS automatically for IP, localhost, and .local hostnames.</li>
+</ul>]]></content>
+    <author><name>FeedZero</name></author>
+  </entry>
   <entry>
     <id>feedzero:release:0.11.0</id>
     <title>v0.11.0: Signal, free cloud sync, per-feed rules, and auto-refresh</title>


### PR DESCRIPTION
Bumps `package.json` 0.11.0 → 0.12.0 and refreshes `tests/fixtures/release-feed.xml` from the regenerated landing changelog.

## Why
After the 0.11.0 notes were published, six commits landed on `main` — including a user-facing paywall fix (#211) and self-host LAN/IP TLS work (#212/#217, #220). This cuts 0.12.0 to capture them and keeps the app's reported version tied to the published release notes.

## Verification
- `tests/scripts/release-version-sync.test.ts` (the #211/#212 drift guard) — green: `package.json` == newest fixture entry == 0.12.0.
- `tests/core/parser/release-feed-fixture.test.ts` — green: the app's parser consumes the new fixture.
- Full suite: **3768 passed, 0 failed**. `tsc --noEmit` clean.

## ⚠ Merge order
Merge **after** feedzero-landing#24 (the changelog must publish first so first-launch auto-subscribe sees 0.12.0). The vendored fixture here was generated from that PR's `releases.xml`.

## Follow-up (separate, with your go-ahead)
The `v0.11.0` git tag points at `c9317c2` (package.json 0.9.0 there), so the published 0.11.0 Docker image reports 0.9.0. You approved re-pointing `v0.11.0` → `3ab8ffb`; I'll do that tag force-push after these merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)