### PR TITLE
UX batch 2: swipe-to-mark-read, dock shortcuts, 44px targets, reader typography, skeletons, native share

### DIFF
--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -46,6 +46,7 @@ the vault with timestamp last-write-wins — see [ADR 022](decisions/022-prefere
 | articleSortMode   | `"newest" \| "oldest" \| "unread-first"` | Article list ordering          |
 | groupArticleFloods| boolean                               | Collapse same-feed bursts         |
 | theme             | `"light" \| "dark" \| "system"`       | Color scheme (synced; bridged into next-themes by `<ThemeBridge>`) |
+| readerTextSize    | `"small" \| "medium" \| "large"` (optional) | Reader body text scale; absent on rows from older clients → treated as "medium" |
 
 ### Meta (internal)
 

--- a/docs/features/010-mobile-navigation.md
+++ b/docs/features/010-mobile-navigation.md
@@ -1,34 +1,50 @@
 # Feature 010: Mobile Navigation
 
 ## Status
-Implemented
+Implemented (reader-as-overlay model, 2026-08)
 
 ## Summary
 
-On mobile devices (< 1024px viewport), FeedZero uses a single-panel navigation pattern with a Back button to navigate between views. The navigation follows a drill-down hierarchy: Feed List → Article List → Article Reader. The Back button respects user intent and does not auto-redirect to articles when the user explicitly navigates back.
+On mobile (< 1024px viewport) the article list fills the viewport and the reader is an **overlay layer** on top of it. Navigation is asymmetric by design: **tap goes in, swipe goes out**. Tapping an article mounts the reader layer (slides in from the right); an edge-swipe right (starting within ~28px of the left edge) follows the finger and dismisses it, as does the back pill. The list never horizontal-swipes into the reader and never unmounts while reading, so its scroll position survives the round trip. The URL stays the source of truth: the reader layer exists iff the route carries an `articleId`.
+
+This replaced two earlier models: the original drill-down-with-back-buttons, and a horizontal snap-x pager (list and reader as side-by-side panels). The pager made the two surfaces feel physically connected — a leftward swipe on the list dragged the reader in — which fought the swipe-right-to-mark-read row gesture and lost list scroll position (PR #237 feedback).
 
 ## Behaviour
 
 ```gherkin
 Feature: Mobile navigation
 
-  Rule: Back button navigates up the hierarchy
+  Rule: Tap goes in, swipe goes out
 
-  Scenario: Back from article shows article list
+  Scenario: Tap opens the reader overlay
+    Given the user is viewing an article list on mobile
+    When the user taps an article row
+    Then the reader layer slides in over the list
+    And the URL gains the articleId segment
+
+  Scenario: Edge-swipe dismisses the reader
+    Given the reader layer is open
+    When the user drags rightward starting at the left screen edge
+    Then the layer follows the finger
+    And releasing past a third of the screen width returns to the list
+    And the article list is unchanged (scroll position intact)
+
+  Scenario: Mid-screen swipes belong to the content
+    Given the reader layer is open
+    When the user drags starting away from the left edge
+    Then the reader does not dismiss
+
+  Scenario: The list cannot swipe into the reader
+    Given the user is viewing an article list on mobile
+    When the user swipes leftward on the list
+    Then no reader appears (rows own rightward swipe-to-mark-read;
+      nothing owns leftward)
+
+  Scenario: Back pill returns to the list without auto-redirect
     Given the user is viewing an article on mobile
-    When the user taps the Back button
+    When the user taps the back pill
     Then the article list is displayed
     And the user is not auto-redirected to an article
-
-  Scenario: Back from article list shows feed sidebar prompt
-    Given the user is viewing an article list on mobile
-    When the user taps the Back button
-    Then the user is navigated to /feeds
-    And a prompt to open the sidebar is shown
-
-  Scenario: Back button is hidden at root
-    Given the user is at the /feeds root on mobile
-    Then the Back button is not displayed
 
   Rule: Auto-select is suppressed after Back navigation
 
@@ -53,14 +69,14 @@ Feature: Mobile navigation
     Then the user stays on that URL (the reader shows its own empty state)
     And no automatic back-navigation occurs
 
-  Rule: Mobile layout is single-panel
+  Rule: The reader is a layer, not a sibling panel
 
-  Scenario: Mobile shows one content panel at a time
+  Scenario: Mobile shows the reader above the mounted list
     Given the user is on a mobile device (< 1024px)
     When viewing /feeds/:feedId/articles/:articleId
-    Then only the reader panel is visible
-    And the article list is not visible
-    And the sidebar is collapsed to offcanvas
+    Then the reader layer covers the viewport
+    And the article list stays mounted beneath it
+    And a deeplink to this URL shows the reader immediately
 
   Scenario: Desktop shows multi-panel layout
     Given the user is on a desktop device (>= 1024px)
@@ -73,8 +89,15 @@ Feature: Mobile navigation
   Scenario: Closed drawer surfaces recent feeds instead of the current feed name
     Given the user is on mobile with the bottom drawer closed
     Then the strip shows an anchored "All items" button
-    And the favicons of the most-recently-viewed feeds, newest first
+    And the favicons of the most-recently-viewed feeds in stable sidebar order
+    And fixed Explore and Settings shortcuts beside the chevron
     And it does not repeat the current feed name (the header already shows it)
+
+  Scenario: Dock slots never reorder under the thumb
+    Given the dock shows a set of feed favicons
+    When the user taps one of them
+    Then the dock's buttons keep their positions
+    And only viewing a feed from outside the dock swaps a slot
 
   Scenario: Tapping a dock favicon switches feed without opening the drawer
     Given the closed drawer dock shows a feed's favicon
@@ -90,22 +113,29 @@ Feature: Mobile navigation
 
 ## Architecture
 
-### Flow
+### Flow (closing the reader)
 
-1. User taps Back button in mobile header
-2. `handleBack()` sets `skipAutoSelectRef.current = true`
-3. Navigation occurs via `navigate()` to parent route
+1. User edge-swipes right on the reader layer (or taps the back pill)
+2. `closeReader()` sets `skipAutoSelectRef.current = true` and navigates
+   to the parent route (`/feeds/:feedId`)
+3. The reader layer unmounts (its existence is derived from `articleId`)
 4. Auto-select effect checks `skipAutoSelectRef` and skips if true
-5. Ref is reset only when user explicitly navigates to an article
+5. Ref is reset only when the user explicitly navigates to an article
+
+Gesture ownership map (mobile):
+- **List rows**: rightward drag → toggle read; vertical → scroll; leftward → nothing.
+- **Reader layer**: edge-zone rightward drag → dismiss; elsewhere → content scroll.
+- **Article list top**: downward overscroll → pull-to-refresh.
 
 ### Files
 
 | File | Role |
 |------|------|
-| `src/pages/feeds-route.tsx` | Mobile/desktop layout switching, scroll-snap nav, auto-select suppression, and the empty-stage→list fallback (present→absent transition guard) |
+| `src/pages/feeds-route.tsx` | Mobile branch renders `<main>` (list) + conditional `<MobileReaderLayer>`; auto-select suppression; empty-stage→list fallback (present→absent transition guard) |
+| `src/hooks/use-swipe-back.ts` | Edge-zone arming, finger-following `dragX`, commit past ⅓ width; non-passive touchmove for `preventDefault` |
 | `src/hooks/use-media-query.ts` | `useIsDesktop()` hook for responsive breakpoint detection |
-| `src/components/layout/mobile-nav-drawer.tsx` | Bottom drawer. Closed state = quick-switch favicon dock; open state = full feed list + Refresh/Settings footer |
-| `src/lib/recent-feeds.ts` | Pure `orderFeedsByRecency()` / `recordRecentFeed()` helpers + `MOBILE_DOCK_FEED_CAP` |
+| `src/components/layout/mobile-nav-drawer.tsx` | Bottom drawer. Closed state = quick-switch favicon dock + Explore/Settings shortcuts; open state = full feed list + Refresh/Settings footer |
+| `src/lib/recent-feeds.ts` | Pure `stableDockFeeds()` / `recordRecentFeed()` helpers + `MOBILE_DOCK_FEED_CAP` |
 | `src/stores/feed-store.ts` | Tracks `recentFeedIds` (device-local, persisted) — recorded in `selectFeed`, pruned in `removeFeed` |
 
 ### Tests
@@ -139,7 +169,7 @@ Test guards (Tier 2 structural): `tests/index-html-viewport.test.ts` (PWA meta t
 
 - **Ref-based skip flag** — Using a ref (`skipAutoSelectRef`) instead of state avoids re-renders while still persisting across the async article load cycle. The ref is reset only when `articleId` appears in the URL, ensuring the skip persists through multiple effect runs.
 
-- **Stack-based navigation** — Mobile navigation follows the standard iOS/Android pattern: Article → Article List → Feed List. This matches user mental models for drill-down interfaces.
+- **Reader as a layer, not a peer** — The snap-pager model made the list and reader feel like two connected panels; users read that as "swiping the list drags the reader in," which collided with row swipe-actions. A layer matches the iOS mental model (detail slides over master), frees every list gesture, and keeps the list mounted so scroll position is preserved for free. Entry is tap-only; exit is edge-swipe or back pill — asymmetric on purpose.
 
 - **Auto-select only on feed switch** — Auto-selecting the first article when switching feeds improves UX by showing content immediately. But auto-select is suppressed after Back navigation because the user explicitly wanted to see the article list (to pick a different article).
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -178,6 +178,9 @@ export const ARTICLE_SORT_MODES: readonly ArticleSortMode[] = [
  * `theme` is declared here but not yet wired (next-themes bridge lands in a
  * follow-up PR); until then it stays undefined.
  */
+/** Reader body text scale. "medium" is the historical default. */
+export type ReaderTextSize = "small" | "medium" | "large";
+
 export interface UserPreferences {
   feedSortMode: FeedSortMode;
   feedCustomOrder: string[];
@@ -185,6 +188,11 @@ export interface UserPreferences {
   articleSortMode: ArticleSortMode;
   groupArticleFloods: boolean;
   theme?: "light" | "dark" | "system";
+  /**
+   * Optional so preference rows synced from older clients still parse;
+   * readers treat `undefined` as "medium".
+   */
+  readerTextSize?: ReaderTextSize;
 }
 
 /** Baseline preferences used before hydration and for first-run defaults. */
@@ -199,6 +207,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   // from next-themes' own localStorage (its <head> script runs before
   // React) so this default only takes effect on a brand-new install.
   theme: "system",
+  readerTextSize: "medium",
 };
 
 export interface CreateArticleInput {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -35,6 +35,7 @@ import { isExtensionEnabled } from "@/core/extension/extension-enabled.ts";
 import { Button } from "@/components/ui/button.tsx";
 import { InvalidKeysScreen } from "@/components/recovery/invalid-keys-screen";
 import { AppShellSkeleton } from "@/components/loading/app-shell-skeleton.tsx";
+import { StageSkeleton } from "@/components/loading/stage-skeleton.tsx";
 import { OnboardingModal } from "@/components/onboarding/onboarding-modal.tsx";
 
 const ExploreCatalog = lazy(() =>
@@ -67,7 +68,7 @@ function ExploreRoute() {
   const navigate = useNavigate();
   return (
     <StageView>
-      <Suspense>
+      <Suspense fallback={<StageSkeleton />}>
         <ExploreCatalog onFeedAdded={(id) => navigate(`/feeds/${id}`)} />
       </Suspense>
     </StageView>
@@ -77,7 +78,7 @@ function ExploreRoute() {
 function StatsRoute() {
   return (
     <StageView>
-      <Suspense>
+      <Suspense fallback={<StageSkeleton />}>
         <StatsPage />
       </Suspense>
     </StageView>
@@ -87,7 +88,7 @@ function StatsRoute() {
 function SettingsRoute() {
   return (
     <StageView>
-      <Suspense>
+      <Suspense fallback={<StageSkeleton />}>
         <SettingsPage />
       </Suspense>
     </StageView>
@@ -97,7 +98,7 @@ function SettingsRoute() {
 function SignalRoute() {
   return (
     <StageView>
-      <Suspense>
+      <Suspense fallback={<StageSkeleton />}>
         <SignalPage />
       </Suspense>
     </StageView>
@@ -107,7 +108,7 @@ function SignalRoute() {
 function BriefingRoute() {
   return (
     <StageView>
-      <Suspense>
+      <Suspense fallback={<StageSkeleton />}>
         <BriefingPage />
       </Suspense>
     </StageView>

--- a/src/components/articles/article-list-controls.tsx
+++ b/src/components/articles/article-list-controls.tsx
@@ -140,7 +140,7 @@ export function MobileHeaderPills() {
   return (
     <div
       data-testid="mobile-header-pills"
-      className="flex items-center gap-2"
+      className="ml-auto flex items-center gap-2"
     >
       <ViewOptionsPill />
     </div>

--- a/src/components/articles/article-list-controls.tsx
+++ b/src/components/articles/article-list-controls.tsx
@@ -1,12 +1,11 @@
-import { Layers, Star, Filter, Folder as FolderIcon, RefreshCw } from "lucide-react";
-import { useArticleStore } from "@/stores/article-store.ts";
+import { Layers, Star, Filter, Folder as FolderIcon } from "lucide-react";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
 import { useIsMobile } from "@/hooks/use-mobile.ts";
 import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
-import { ExpandingPill } from "@/components/ui/expanding-pill.tsx";
 import { SortPill } from "./sort-pill.tsx";
 import { SettingsPill } from "./settings-pill.tsx";
+import { ViewOptionsPill } from "./view-options-pill.tsx";
 import {
   ALL_FEEDS_ID,
   STARRED_FEED_ID,
@@ -129,54 +128,21 @@ function Label({
 }
 
 /**
- * Bare pair of pills (cog + sort), no title, no sticky positioning.
- * Mounted in the mobile global header alongside HeaderBreadcrumbs so
- * the user reaches feed/folder/filter settings from the same bar that
- * shows where they are. The full title-bar shape
- * (ArticleListControls) is desktop-only.
+ * The mobile global header's control slot: one ViewOptionsPill holding
+ * sort + contextual settings in a single menu. The old row of three
+ * same-looking pills mixed scopes (refresh action / feed settings /
+ * list sort) and read as inconsistent; refresh on mobile is the
+ * pull-to-refresh gesture's job (plus "Refresh all" in the drawer
+ * footer). The full title-bar shape (ArticleListControls) is
+ * desktop-only.
  */
 export function MobileHeaderPills() {
-  const articleSortMode = useArticleStore((s) => s.articleSortMode);
-  const setArticleSortMode = useArticleStore((s) => s.setArticleSortMode);
   return (
     <div
       data-testid="mobile-header-pills"
       className="flex items-center gap-2"
     >
-      <RefreshPill />
-      <SettingsPill />
-      <SortPill mode={articleSortMode} onChange={setArticleSortMode} />
+      <ViewOptionsPill />
     </div>
-  );
-}
-
-/**
- * Refresh control for the mobile header. The desktop refresh lives in the
- * sidebar header, which mobile never renders — without this the only way to
- * refresh on mobile was the (also-hidden) keyboard `r`. Scoped to the current
- * view via `refreshView`: a single feed refreshes only that feed, a folder
- * only its members, an aggregated view (All / Starred / filter) every feed.
- * Hidden when there are no feeds, mirroring the desktop button.
- */
-function RefreshPill() {
-  const feeds = useFeedStore((s) => s.feeds);
-  const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
-  const refreshView = useFeedStore((s) => s.refreshView);
-  const refreshAll = useFeedStore((s) => s.refreshAll);
-  const isRefreshingAll = useFeedStore((s) => s.isRefreshingAll);
-
-  if (feeds.length === 0) return null;
-
-  return (
-    <ExpandingPill
-      icon={<RefreshCw className={isRefreshingAll ? "animate-spin" : ""} />}
-      label={isRefreshingAll ? "Refreshing…" : "Refresh"}
-      aria-label="Refresh"
-      dataTestId="mobile-refresh"
-      disabled={isRefreshingAll}
-      onClick={() =>
-        void (selectedFeedId ? refreshView(selectedFeedId) : refreshAll())
-      }
-    />
   );
 }

--- a/src/components/articles/article-list.tsx
+++ b/src/components/articles/article-list.tsx
@@ -15,6 +15,7 @@ import { markAllReadWithUndo } from "@/lib/mark-all-read-with-undo.ts";
 import { useIsDesktop } from "@/hooks/use-media-query.ts";
 import { usePullToRefresh } from "@/hooks/use-pull-to-refresh.ts";
 import { PullToRefreshIndicator } from "@/components/layout/pull-to-refresh-indicator.tsx";
+import { ArticleListSkeleton } from "@/components/loading/article-list-skeleton.tsx";
 import type { Article } from "@feedzero/core/types";
 
 /**
@@ -270,7 +271,11 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
           sortMode={articleSortMode}
           onSortChange={setArticleSortMode}
         />
-        {showBlank ? null : <EmptyArticleList feedId={selectedFeedId} />}
+        {showBlank ? (
+          <ArticleListSkeleton />
+        ) : (
+          <EmptyArticleList feedId={selectedFeedId} />
+        )}
       </div>
     );
   }

--- a/src/components/articles/article-list.tsx
+++ b/src/components/articles/article-list.tsx
@@ -16,6 +16,7 @@ import { useIsDesktop } from "@/hooks/use-media-query.ts";
 import { usePullToRefresh } from "@/hooks/use-pull-to-refresh.ts";
 import { PullToRefreshIndicator } from "@/components/layout/pull-to-refresh-indicator.tsx";
 import { ArticleListSkeleton } from "@/components/loading/article-list-skeleton.tsx";
+import { SwipeToReadRow } from "./swipe-to-read-row.tsx";
 import type { Article } from "@feedzero/core/types";
 
 /**
@@ -328,13 +329,15 @@ export function ArticleList({ onArticleSelect }: ArticleListProps) {
               }}
             >
               {entry.kind === "article" ? (
-                <ArticleItem
-                  article={entry.article}
-                  isSelected={entry.article.id === selectedArticle?.id}
-                  onSelect={handleSelect}
-                  feedTitle={itemFeedTitle}
-                  feedSiteUrl={itemFeedSiteUrl}
-                />
+                <SwipeToReadRow article={entry.article} enabled={!isDesktop}>
+                  <ArticleItem
+                    article={entry.article}
+                    isSelected={entry.article.id === selectedArticle?.id}
+                    onSelect={handleSelect}
+                    feedTitle={itemFeedTitle}
+                    feedSiteUrl={itemFeedSiteUrl}
+                  />
+                </SwipeToReadRow>
               ) : (
                 <ArticleGroupSummaryRow
                   open={entry.open}

--- a/src/components/articles/settings-pill.tsx
+++ b/src/components/articles/settings-pill.tsx
@@ -19,6 +19,32 @@ import {
  * references (folder/filter whose target was deleted).
  */
 export function SettingsPill() {
+  const { target, open } = useSettingsTarget();
+
+  if (!target) return null;
+
+  return (
+    <ExpandingPill
+      icon={<SettingsIcon />}
+      label={target.label}
+      aria-label={target.label}
+      dataTestId="settings-pill"
+      onClick={open}
+    />
+  );
+}
+
+/**
+ * Context-aware settings dispatch for the current view. `target` is
+ * null on aggregated views with nothing to configure (All / Starred)
+ * and on broken references; `open` routes to the matching dialog.
+ * Shared by the desktop SettingsPill and the mobile ViewOptionsPill so
+ * both surfaces agree on what "settings for this view" means.
+ */
+export function useSettingsTarget(): {
+  target: Target | null;
+  open: () => void;
+} {
   const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
   const feeds = useFeedStore((s) => s.feeds);
   const folders = useFeedStore((s) => s.folders);
@@ -34,9 +60,7 @@ export function SettingsPill() {
     filters,
   });
 
-  if (!target) return null;
-
-  function handleClick() {
+  function open() {
     if (!target) return;
     switch (target.kind) {
       case "feed":
@@ -51,15 +75,7 @@ export function SettingsPill() {
     }
   }
 
-  return (
-    <ExpandingPill
-      icon={<SettingsIcon />}
-      label={target.label}
-      aria-label={target.label}
-      dataTestId="settings-pill"
-      onClick={handleClick}
-    />
-  );
+  return { target, open };
 }
 
 type Target =

--- a/src/components/articles/swipe-to-read-row.tsx
+++ b/src/components/articles/swipe-to-read-row.tsx
@@ -128,7 +128,13 @@ export function SwipeToReadRow({
     <div
       ref={rootRef}
       data-testid="swipe-to-read-row"
-      className="relative overflow-hidden"
+      // touch-pan-y: without it, real mobile browsers claim the drag as
+      // a native scroll after their own slop and stop dispatching
+      // touchmove — the arming logic loses the race on hardware even
+      // though synthetic-event tests pass. pan-y keeps vertical
+      // scrolling native and hands horizontal drags to JS. Safe now
+      // that no ancestor needs horizontal touch gestures on the list.
+      className="relative overflow-hidden touch-pan-y"
     >
       <div
         aria-hidden

--- a/src/components/articles/swipe-to-read-row.tsx
+++ b/src/components/articles/swipe-to-read-row.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { CheckCheck, Undo2 } from "lucide-react";
+import { cn } from "@/lib/utils.ts";
+import { useArticleStore } from "@/stores/article-store.ts";
+import type { Article } from "@feedzero/core/types";
+
+/** Rightward travel (px) required to commit the read/unread toggle. */
+const COMMIT_THRESHOLD = 64;
+/** Movement (px) before we decide whether the gesture is ours. */
+const ARM_SLOP = 12;
+/** Cap on the visual translate so the row can't fly off-screen. */
+const MAX_PULL = 120;
+
+interface SwipeToReadRowProps {
+  article: Article;
+  /** Off on desktop — mouse users have hover affordances and keyboard. */
+  enabled: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Swipe-RIGHT on an article row toggles read/unread (Mail muscle
+ * memory). Only rightward, deliberately: on mobile the article list is
+ * the leftmost snap-pager panel, so leftward swipes page to the reader
+ * — a leftward row action would fight that gesture. Rightward has no
+ * pager meaning (nothing further left), making it conflict-free.
+ *
+ * Gesture arbitration: we arm only once the drag proves
+ * rightward-dominant (dx > 1.5·|dy| past a small slop); vertical
+ * drags stay with the list scroller and leftward drags with the pager.
+ * After arming we preventDefault() further touchmoves so the browser
+ * doesn't pan mid-drag — that requires a NON-passive native listener
+ * (React's root touch listeners are passive, so this cannot use
+ * synthetic onTouchMove).
+ */
+export function SwipeToReadRow({
+  article,
+  enabled,
+  children,
+}: SwipeToReadRowProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [dx, setDx] = useState(0);
+  const dxRef = useRef(0);
+  const gestureRef = useRef<{
+    startX: number;
+    startY: number;
+    armed: boolean;
+    aborted: boolean;
+  } | null>(null);
+  // article.read at gesture-commit time, read via ref so the listeners
+  // (bound once per enabled-toggle) never capture a stale flag.
+  const readRef = useRef(article.read);
+  readRef.current = article.read;
+  const idRef = useRef(article.id);
+  idRef.current = article.id;
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!enabled || !el) return;
+
+    function setPull(value: number) {
+      dxRef.current = value;
+      setDx(value);
+    }
+
+    function handleStart(e: TouchEvent) {
+      const t = e.touches[0];
+      if (!t) return;
+      gestureRef.current = {
+        startX: t.clientX,
+        startY: t.clientY,
+        armed: false,
+        aborted: false,
+      };
+    }
+
+    function handleMove(e: TouchEvent) {
+      const g = gestureRef.current;
+      const t = e.touches[0];
+      if (!g || g.aborted || !t) return;
+      const rawDx = t.clientX - g.startX;
+      const rawDy = t.clientY - g.startY;
+
+      if (!g.armed) {
+        if (Math.abs(rawDx) < ARM_SLOP && Math.abs(rawDy) < ARM_SLOP) return;
+        if (rawDx > 0 && rawDx > Math.abs(rawDy) * 1.5) {
+          g.armed = true;
+        } else {
+          // Leftward or vertical-dominant: the pager / scroller owns it.
+          g.aborted = true;
+          return;
+        }
+      }
+
+      if (e.cancelable) e.preventDefault();
+      setPull(Math.max(0, Math.min(rawDx, MAX_PULL)));
+    }
+
+    function handleEnd() {
+      const g = gestureRef.current;
+      gestureRef.current = null;
+      const commit = Boolean(g?.armed) && dxRef.current >= COMMIT_THRESHOLD;
+      setPull(0);
+      if (!commit) return;
+      const { markAsRead, markUnread } = useArticleStore.getState();
+      if (readRef.current) void markUnread([idRef.current]);
+      else void markAsRead(idRef.current);
+    }
+
+    el.addEventListener("touchstart", handleStart, { passive: true });
+    el.addEventListener("touchmove", handleMove, { passive: false });
+    el.addEventListener("touchend", handleEnd);
+    el.addEventListener("touchcancel", handleEnd);
+    return () => {
+      el.removeEventListener("touchstart", handleStart);
+      el.removeEventListener("touchmove", handleMove);
+      el.removeEventListener("touchend", handleEnd);
+      el.removeEventListener("touchcancel", handleEnd);
+    };
+  }, [enabled]);
+
+  if (!enabled) return <>{children}</>;
+
+  const pastThreshold = dx >= COMMIT_THRESHOLD;
+  const Icon = article.read ? Undo2 : CheckCheck;
+
+  return (
+    <div
+      ref={rootRef}
+      data-testid="swipe-to-read-row"
+      className="relative overflow-hidden"
+    >
+      <div
+        aria-hidden
+        className={cn(
+          "absolute inset-0 flex items-center pl-4 transition-colors",
+          pastThreshold
+            ? "bg-primary text-primary-foreground"
+            : "bg-primary/15 text-primary",
+          dx === 0 && "hidden",
+        )}
+      >
+        <Icon className="size-4" />
+      </div>
+      <div
+        className="relative bg-background"
+        style={{
+          transform: dx > 0 ? `translateX(${dx}px)` : undefined,
+          transition: dx === 0 ? "transform 150ms ease-out" : "none",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/articles/view-options-pill.tsx
+++ b/src/components/articles/view-options-pill.tsx
@@ -1,0 +1,64 @@
+import { Check, SlidersHorizontal } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu.tsx";
+import { ExpandingPill } from "@/components/ui/expanding-pill.tsx";
+import { useArticleStore } from "@/stores/article-store.ts";
+import { useSettingsTarget } from "./settings-pill.tsx";
+import { ARTICLE_SORT_MODES } from "@feedzero/core/types";
+import type { ArticleSortMode } from "@feedzero/core/types";
+
+const SORT_LABELS: Record<ArticleSortMode, string> = {
+  newest: "Newest first",
+  oldest: "Oldest first",
+  "unread-first": "Unread first",
+};
+
+/**
+ * The mobile header's single control: one menu holding everything that
+ * configures the current view — sort order plus the contextual
+ * feed/folder/filter settings entry. Replaces the previous row of
+ * three same-looking pills whose scopes silently differed (refresh
+ * action / feed settings / list sort); refresh belongs to the
+ * pull-to-refresh gesture on mobile.
+ */
+export function ViewOptionsPill() {
+  const sortMode = useArticleStore((s) => s.articleSortMode);
+  const setSortMode = useArticleStore((s) => s.setArticleSortMode);
+  const { target, open } = useSettingsTarget();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <ExpandingPill
+          icon={<SlidersHorizontal />}
+          label="View options"
+          aria-label="View options"
+          dataTestId="view-options-pill"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-40">
+        {ARTICLE_SORT_MODES.map((m) => (
+          <DropdownMenuItem key={m} onClick={() => setSortMode(m)}>
+            <Check
+              className={`size-3.5 mr-1.5 ${
+                sortMode === m ? "opacity-100" : "opacity-0"
+              }`}
+            />
+            {SORT_LABELS[m]}
+          </DropdownMenuItem>
+        ))}
+        {target && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={open}>{target.label}…</DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -83,7 +83,7 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
             aria-label="All items"
             aria-pressed={allActive}
             onClick={() => onFeedSelect(ALL_FEEDS_ID)}
-            className={`flex items-center justify-center size-10 shrink-0 rounded-md ${
+            className={`flex items-center justify-center size-11 shrink-0 rounded-md ${
               allActive
                 ? "bg-accent text-foreground"
                 : "text-muted-foreground hover:bg-accent/50"
@@ -100,7 +100,7 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
                 aria-label={feed.title}
                 aria-pressed={active}
                 onClick={() => onFeedSelect(feed.id)}
-                className={`flex items-center justify-center size-10 shrink-0 rounded-md hover:bg-accent/50 ${
+                className={`flex items-center justify-center size-11 shrink-0 rounded-md hover:bg-accent/50 ${
                   active
                     ? "ring-2 ring-primary ring-offset-1 ring-offset-background"
                     : ""
@@ -121,7 +121,7 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
           type="button"
           aria-label="Explore"
           onClick={() => navigate("/explore")}
-          className="flex items-center justify-center size-10 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
+          className="flex items-center justify-center size-11 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
         >
           <Compass className="size-5" />
         </button>
@@ -129,7 +129,7 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
           type="button"
           aria-label="Settings"
           onClick={() => goToSettings(navigate)}
-          className="flex items-center justify-center size-10 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
+          className="flex items-center justify-center size-11 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
         >
           <Settings className="size-5" />
         </button>
@@ -137,7 +137,7 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
           <button
             type="button"
             aria-label="Open feed list"
-            className="flex items-center justify-center size-10 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
+            className="flex items-center justify-center size-11 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
           >
             <ChevronUp
               data-testid="drawer-open-chevron"

--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -4,7 +4,7 @@ import { ChevronUp, Compass, Layers, RefreshCw, Settings } from "lucide-react";
 import { Drawer } from "vaul";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { ALL_FEEDS_ID } from "@feedzero/core/utils/constants";
-import { orderFeedsByRecency, MOBILE_DOCK_FEED_CAP } from "@/lib/recent-feeds.ts";
+import { stableDockFeeds, MOBILE_DOCK_FEED_CAP } from "@/lib/recent-feeds.ts";
 import { FeedFavicon } from "@/components/feeds/feed-favicon.tsx";
 import { SidebarMenu, SidebarProvider } from "@/components/ui/sidebar.tsx";
 import { SidebarBody } from "@/components/layout/sidebar-body.tsx";
@@ -45,12 +45,10 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
   const recentFeedIds = useFeedStore((s) => s.recentFeedIds);
   // The closed strip is a quick-switch dock, not a status line: showing the
   // current feed name here just echoed the header. Instead, surface the
-  // feeds the user actually hops between — All-items plus their most
-  // recently viewed feeds, capped so the open-list chevron stays reachable.
-  const dockFeeds = orderFeedsByRecency(feeds, recentFeedIds).slice(
-    0,
-    MOBILE_DOCK_FEED_CAP,
-  );
+  // feeds the user actually hops between. Recency picks WHICH feeds are
+  // here; sidebar order picks WHERE — see stableDockFeeds for why the
+  // dock must never reorder on a tap.
+  const dockFeeds = stableDockFeeds(feeds, recentFeedIds, MOBILE_DOCK_FEED_CAP);
   const allActive = selectedFeedId === ALL_FEEDS_ID;
 
   return (

--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
-import { ChevronUp, Layers, RefreshCw, Settings } from "lucide-react";
+import { ChevronUp, Compass, Layers, RefreshCw, Settings } from "lucide-react";
 import { Drawer } from "vaul";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { ALL_FEEDS_ID } from "@feedzero/core/utils/constants";
@@ -112,6 +112,27 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
           })}
         </div>
 
+        {/* Fixed shortcuts: Explore and Settings ride the dock instead of
+            hiding behind the drawer chevron — the bottom edge is the
+            cheapest thumb real estate on a phone, and these are the two
+            most-reached non-feed surfaces. Signal/Stats stay in the
+            drawer to keep the strip from crowding out feed favicons. */}
+        <button
+          type="button"
+          aria-label="Explore"
+          onClick={() => navigate("/explore")}
+          className="flex items-center justify-center size-10 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
+        >
+          <Compass className="size-5" />
+        </button>
+        <button
+          type="button"
+          aria-label="Settings"
+          onClick={() => goToSettings(navigate)}
+          className="flex items-center justify-center size-10 shrink-0 rounded-md text-muted-foreground hover:bg-accent/50"
+        >
+          <Settings className="size-5" />
+        </button>
         <Drawer.Trigger asChild>
           <button
             type="button"

--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 import { ChevronUp, Compass, Layers, RefreshCw, Settings } from "lucide-react";
 import { Drawer } from "vaul";
@@ -11,6 +11,7 @@ import { SidebarBody } from "@/components/layout/sidebar-body.tsx";
 import { NewFolderInput } from "@/components/sidebar/new-folder-input.tsx";
 import { AutoOrganizePill } from "@/components/folders/auto-organize-pill.tsx";
 import { goToSettings } from "@/lib/go-to-settings.ts";
+import { SyncStatusBadge } from "@/components/sync/sync-status-badge.tsx";
 
 interface MobileNavDrawerProps {
   onFeedSelect: (feedId: string) => void;
@@ -19,6 +20,26 @@ interface MobileNavDrawerProps {
 export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
+  // The strip's handle pill advertises "drag me up" — honor it: an
+  // upward-dominant drag on the strip opens the drawer (tapping the
+  // chevron still works). Tracked per-gesture so a horizontal scrub
+  // across the favicons doesn't trigger it.
+  const stripTouchRef = useRef<{ x: number; y: number } | null>(null);
+  function handleStripTouchStart(e: React.TouchEvent) {
+    const t = e.touches[0];
+    stripTouchRef.current = t ? { x: t.clientX, y: t.clientY } : null;
+  }
+  function handleStripTouchMove(e: React.TouchEvent) {
+    const start = stripTouchRef.current;
+    const t = e.touches[0];
+    if (!start || !t) return;
+    const dx = t.clientX - start.x;
+    const dy = t.clientY - start.y;
+    if (dy < -20 && Math.abs(dy) > Math.abs(dx)) {
+      stripTouchRef.current = null;
+      setOpen(true);
+    }
+  }
   const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
   const feeds = useFeedStore((s) => s.feeds);
   const refreshAll = useFeedStore((s) => s.refreshAll);
@@ -62,6 +83,8 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
     <Drawer.Root open={open} onOpenChange={setOpen}>
       <div
         data-testid="drawer-handle-strip"
+        onTouchStart={handleStripTouchStart}
+        onTouchMove={handleStripTouchMove}
         // iOS safe-area clearance:
         //   pb-[env(safe-area-inset-bottom)] + matching h-[calc()] keeps the
         //   60px dock content area above the home indicator.
@@ -209,6 +232,12 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
                 <Settings className="size-4 shrink-0 text-muted-foreground" />
                 Settings
               </button>
+              {/* Full refresh/sync status line — the mobile header only
+                  shows the color dot, the words live here next to the
+                  refresh control they describe. */}
+              <div className="px-2 pb-1">
+                <SyncStatusBadge onClick={() => setOpen(false)} />
+              </div>
             </div>
           </SidebarProvider>
         </Drawer.Content>

--- a/src/components/loading/article-list-skeleton.tsx
+++ b/src/components/loading/article-list-skeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton.tsx";
+
+/**
+ * Placeholder rows for the article list's initial silent load. Mirrors
+ * ArticleItem's shape (title line + meta line at row padding) so the
+ * real rows land without a layout jump. Rendered only while the first
+ * load is in flight — settled-empty states keep the refresh affordance.
+ */
+export function ArticleListSkeleton({ rows = 8 }: { rows?: number }) {
+  return (
+    <div role="status" aria-label="Loading articles" className="px-2">
+      {Array.from({ length: rows }, (_, i) => (
+        <div key={i} className="px-2 py-3 border-b border-border space-y-2">
+          <Skeleton className="h-4 w-4/5" />
+          <Skeleton className="h-3 w-2/5" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/loading/stage-skeleton.tsx
+++ b/src/components/loading/stage-skeleton.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton.tsx";
+
+/**
+ * Suspense fallback for lazy stage routes (Explore, Stats, Settings,
+ * Signal, Briefing). Mirrors a generic stage layout — heading, then
+ * content cards — so the route transition reads as "loading" instead
+ * of the blank flash the empty <Suspense> used to produce.
+ */
+export function StageSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading page"
+      className="mx-auto max-w-3xl px-4 py-6 sm:px-6 space-y-4"
+    >
+      <Skeleton className="h-7 w-40" />
+      <Skeleton className="h-24 w-full rounded-lg" />
+      <Skeleton className="h-24 w-full rounded-lg" />
+      <Skeleton className="h-24 w-full rounded-lg" />
+    </div>
+  );
+}

--- a/src/components/reader/reader-panel.tsx
+++ b/src/components/reader/reader-panel.tsx
@@ -11,6 +11,19 @@ import {
 import { decodeEntities } from "@/lib/decode-entities.ts";
 import { shareArticle } from "@/lib/share-article.ts";
 import { TAP_TARGET_EXPAND, TAP_TARGET_EXPAND_Y } from "@/lib/tap-target.ts";
+import { usePreferencesStore } from "@/stores/preferences-store.ts";
+import type { ReaderTextSize } from "@feedzero/core/types";
+
+/**
+ * Body scale per readerTextSize preference. Headings keep their absolute
+ * sizes from ArticleContent — the preference tunes reading comfort of
+ * body copy, not the whole hierarchy.
+ */
+const TEXT_SIZE_CLASS: Record<ReaderTextSize, string> = {
+  small: "text-sm",
+  medium: "",
+  large: "text-lg",
+};
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useExtractionStore } from "@/stores/extraction-store.ts";
@@ -61,6 +74,9 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
   const isDesktop = useIsDesktop();
   const article = useArticleStore((s) => s.selectedArticle);
   const toggleStar = useArticleStore((s) => s.toggleStar);
+  const readerTextSize = usePreferencesStore(
+    (s) => s.preferences.readerTextSize ?? "medium",
+  );
   const isLoading = useArticleStore((s) => s.isLoading);
   const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
   const feeds = useFeedStore((s) => s.feeds);
@@ -258,7 +274,15 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
 
   const articleBody = (
     <div data-testid="article-content-area" className="overflow-x-hidden">
-      <article className="p-4 px-6">
+      {/* max-w-180 matches ArticleContent's internal measure; mx-auto
+          centers the column so wide desktop panels get margins instead
+          of left-hugging text with dead space on the right. */}
+      <article
+        className={cn(
+          "p-4 px-6 max-w-180 mx-auto",
+          TEXT_SIZE_CLASS[readerTextSize],
+        )}
+      >
         <header className="mb-3">
           <h2 className="text-2xl font-semibold tracking-tight mb-2 break-words">
             {article.link ? (

--- a/src/components/reader/reader-panel.tsx
+++ b/src/components/reader/reader-panel.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { decodeEntities } from "@/lib/decode-entities.ts";
 import { shareArticle } from "@/lib/share-article.ts";
+import { TAP_TARGET_EXPAND, TAP_TARGET_EXPAND_Y } from "@/lib/tap-target.ts";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useExtractionStore } from "@/stores/extraction-store.ts";
@@ -320,6 +321,7 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
               onClick={() => handleModeChange("feed")}
               className={cn(
                 "px-3 py-1 transition-colors",
+                TAP_TARGET_EXPAND_Y,
                 viewMode === "feed"
                   ? "bg-foreground text-background font-medium"
                   : "text-muted-foreground hover:text-foreground",
@@ -341,6 +343,7 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
                   }
                   className={cn(
                     "inline-flex items-center gap-1 px-3 py-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed",
+                    TAP_TARGET_EXPAND_Y,
                     viewMode === "extracted"
                       ? "bg-foreground text-background font-medium"
                       : "text-muted-foreground hover:text-foreground",
@@ -365,7 +368,10 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
                   type="button"
                   onClick={() => void shareArticle(article)}
                   aria-label="Share article"
-                  className="inline-flex items-center justify-center h-7 w-7 rounded-full border border-border text-muted-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
+                  className={cn(
+                    "inline-flex items-center justify-center h-7 w-7 rounded-full border border-border text-muted-foreground/70 hover:text-foreground hover:bg-accent transition-colors",
+                    TAP_TARGET_EXPAND,
+                  )}
                 >
                   <Share2 className="size-3.5" />
                 </button>
@@ -383,6 +389,7 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
                 aria-pressed={Boolean(article.starred)}
                 className={cn(
                   "inline-flex items-center justify-center h-7 w-7 rounded-full border border-border transition-colors",
+                  TAP_TARGET_EXPAND,
                   article.starred
                     ? "text-amber-500 hover:text-amber-600 hover:bg-amber-500/10"
                     : "text-muted-foreground/70 hover:text-foreground hover:bg-accent",

--- a/src/components/reader/reader-panel.tsx
+++ b/src/components/reader/reader-panel.tsx
@@ -5,9 +5,11 @@ import {
   ChevronRight,
   ExternalLink,
   Loader2,
+  Share2,
   Star,
 } from "lucide-react";
 import { decodeEntities } from "@/lib/decode-entities.ts";
+import { shareArticle } from "@/lib/share-article.ts";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useExtractionStore } from "@/stores/extraction-store.ts";
@@ -355,6 +357,22 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
               </TooltipContent>
             </Tooltip>
           </div>
+          {article.link && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  data-testid="share-button"
+                  type="button"
+                  onClick={() => void shareArticle(article)}
+                  aria-label="Share article"
+                  className="inline-flex items-center justify-center h-7 w-7 rounded-full border border-border text-muted-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
+                >
+                  <Share2 className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Share</TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger asChild>
               <button

--- a/src/components/settings/tabs/reading-tab.tsx
+++ b/src/components/settings/tabs/reading-tab.tsx
@@ -10,11 +10,20 @@
  * own surface. Reading tab is the launcher.
  */
 import { useState } from "react";
-import { Layers, Wand2, Palette } from "lucide-react";
+import { Layers, Type, Wand2, Palette } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
 import { useAppStore } from "@/stores/app-store";
 import { useFeedStore } from "@/stores/feed-store";
+import { usePreferencesStore } from "@/stores/preferences-store";
+import type { ReaderTextSize } from "@feedzero/core/types";
+
+const TEXT_SIZES: { value: ReaderTextSize; label: string }[] = [
+  { value: "small", label: "Small" },
+  { value: "medium", label: "Medium" },
+  { value: "large", label: "Large" },
+];
 import { AutoOrganizeDialog } from "@/components/folders/auto-organize-dialog";
 import { ThemeToggle } from "../theme-toggle";
 import { RulesAuditPanel } from "./rules-audit-panel";
@@ -23,6 +32,10 @@ import { SignalSection } from "../signal-section";
 export function ReadingTab() {
   const groupArticleFloods = useAppStore((s) => s.groupArticleFloods);
   const setGroupArticleFloods = useAppStore((s) => s.setGroupArticleFloods);
+  const readerTextSize = usePreferencesStore(
+    (s) => s.preferences.readerTextSize ?? "medium",
+  );
+  const updatePreferences = usePreferencesStore((s) => s.update);
   const hasFeeds = useFeedStore((s) => s.feeds.length > 0);
   const [autoOrganizeOpen, setAutoOrganizeOpen] = useState(false);
 
@@ -37,6 +50,34 @@ export function ReadingTab() {
           Light, dark, or follow your system.
         </p>
         <ThemeToggle />
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <Type className="size-4 text-muted-foreground" />
+          <p className="text-sm font-medium">Text size</p>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Body text size in the reader.
+        </p>
+        <div className="flex rounded-md border border-border overflow-hidden w-fit">
+          {TEXT_SIZES.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={readerTextSize === value}
+              onClick={() => void updatePreferences({ readerTextSize: value })}
+              className={cn(
+                "px-3 py-1.5 text-xs transition-colors",
+                readerTextSize === value
+                  ? "bg-foreground text-background font-medium"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className="rounded-lg border border-border bg-card p-4 space-y-3">

--- a/src/components/sync/sync-status-badge.tsx
+++ b/src/components/sync/sync-status-badge.tsx
@@ -51,7 +51,18 @@ const TICK_INTERVAL_MS = 30 * 1000;
 
 type DisplayState = "local-only" | "syncing" | "synced" | "error";
 
-export function SyncStatusBadge() {
+interface SyncStatusBadgeProps {
+  /**
+   * Dot-only rendering for the mobile header: the color carries the
+   * state, the full text stays in the accessible label, and the
+   * verbose "Refreshed X ago · mode" line lives in the drawer footer.
+   */
+  compact?: boolean;
+  /** Optional click hook (e.g. close the drawer before navigating). */
+  onClick?: () => void;
+}
+
+export function SyncStatusBadge({ compact = false, onClick }: SyncStatusBadgeProps = {}) {
   const status = useSyncStore((s) => s.status);
   const lastRefreshAllAt = useFeedStore((s) => s.lastRefreshAllAt);
   const isRefreshingAll = useFeedStore((s) => s.isRefreshingAll);
@@ -116,9 +127,11 @@ export function SyncStatusBadge() {
       data-testid="sync-status-badge"
       data-state={displayState}
       aria-label={`Cloud sync: ${label}`}
+      onClick={onClick}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
+        "inline-flex items-center gap-1.5 rounded-full text-xs font-medium",
         "hover:text-foreground transition-colors",
+        compact ? "p-2" : "px-2.5 py-1",
         tone,
       )}
     >
@@ -127,10 +140,14 @@ export function SyncStatusBadge() {
       ) : (
         <span
           aria-hidden
-          className={cn("size-1.5 rounded-full", dotColor)}
+          className={cn(
+            "rounded-full",
+            compact ? "size-2" : "size-1.5",
+            dotColor,
+          )}
         />
       )}
-      <span className="leading-none">{label}</span>
+      {!compact && <span className="leading-none">{label}</span>}
     </Link>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -27,7 +27,10 @@ const buttonVariants = cva(
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
         "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
+        // size-8 (32px) + after:-inset-1.5 (2×6px) = 44px effective tap
+        // target (Apple HIG floor) while the button stays visually compact.
+        "icon-sm":
+          "size-8 relative after:absolute after:-inset-1.5 after:content-['']",
         "icon-lg": "size-10",
       },
     },

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -15,6 +15,12 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={(resolvedTheme ?? "system") as ToasterProps["theme"]}
       className="toaster group"
+      // On phones the persistent dock strip owns the bottom edge
+      // (60px + home-indicator inset); bottom-center toasts must land
+      // above it, not on it.
+      mobileOffset={{
+        bottom: "calc(76px + env(safe-area-inset-bottom))",
+      }}
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,

--- a/src/hooks/use-swipe-back.ts
+++ b/src/hooks/use-swipe-back.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+/** Width of the left-edge zone (px) where a back-swipe may begin. */
+const EDGE_ZONE = 28;
+/** Movement (px) before we decide whether the gesture is ours. */
+const ARM_SLOP = 10;
+/** Fallback commit distance when the element width is unknown. */
+const COMMIT_MIN = 96;
+
+interface Options {
+  ref: RefObject<HTMLElement | null>;
+  enabled: boolean;
+  onBack: () => void;
+}
+
+/**
+ * iOS-style edge-swipe-back for an overlay layer: a rightward drag that
+ * STARTS in the left edge zone follows the finger (`dragX`) and commits
+ * `onBack` when released past a third of the layer width. Drags starting
+ * anywhere else belong to the layer's content (vertical scroll,
+ * horizontally scrollable code blocks) and are never intercepted.
+ *
+ * touchmove is registered non-passive so an armed drag can
+ * preventDefault() browser panning — React's root touch listeners are
+ * passive, so this cannot be done with synthetic handlers.
+ */
+export function useSwipeBack({ ref, enabled, onBack }: Options): {
+  dragX: number;
+} {
+  const [dragX, setDragX] = useState(0);
+  const dragXRef = useRef(0);
+  const gestureRef = useRef<{
+    startX: number;
+    startY: number;
+    armed: boolean;
+    aborted: boolean;
+  } | null>(null);
+  const onBackRef = useRef(onBack);
+  onBackRef.current = onBack;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!enabled || !el) return;
+
+    function setDrag(value: number) {
+      dragXRef.current = value;
+      setDragX(value);
+    }
+
+    function handleStart(e: TouchEvent) {
+      const t = e.touches[0];
+      if (!t || t.clientX > EDGE_ZONE) {
+        gestureRef.current = null;
+        return;
+      }
+      gestureRef.current = {
+        startX: t.clientX,
+        startY: t.clientY,
+        armed: false,
+        aborted: false,
+      };
+    }
+
+    function handleMove(e: TouchEvent) {
+      const g = gestureRef.current;
+      const t = e.touches[0];
+      if (!g || g.aborted || !t) return;
+      const dx = t.clientX - g.startX;
+      const dy = t.clientY - g.startY;
+
+      if (!g.armed) {
+        if (Math.abs(dx) < ARM_SLOP && Math.abs(dy) < ARM_SLOP) return;
+        if (dx > 0 && dx > Math.abs(dy)) {
+          g.armed = true;
+        } else {
+          g.aborted = true;
+          return;
+        }
+      }
+
+      if (e.cancelable) e.preventDefault();
+      setDrag(Math.max(0, dx));
+    }
+
+    function handleEnd() {
+      const g = gestureRef.current;
+      gestureRef.current = null;
+      const width = el?.clientWidth ?? 0;
+      const threshold = width > 0 ? Math.min(COMMIT_MIN, width / 3) : COMMIT_MIN;
+      const commit = Boolean(g?.armed) && dragXRef.current >= threshold;
+      setDrag(0);
+      if (commit) onBackRef.current();
+    }
+
+    el.addEventListener("touchstart", handleStart, { passive: true });
+    el.addEventListener("touchmove", handleMove, { passive: false });
+    el.addEventListener("touchend", handleEnd);
+    el.addEventListener("touchcancel", handleEnd);
+    return () => {
+      el.removeEventListener("touchstart", handleStart);
+      el.removeEventListener("touchmove", handleMove);
+      el.removeEventListener("touchend", handleEnd);
+      el.removeEventListener("touchcancel", handleEnd);
+    };
+  }, [ref, enabled]);
+
+  return { dragX };
+}

--- a/src/hooks/use-swipe-back.ts
+++ b/src/hooks/use-swipe-back.ts
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 
-/** Width of the left-edge zone (px) where a back-swipe may begin. */
-const EDGE_ZONE = 28;
 /** Movement (px) before we decide whether the gesture is ours. */
 const ARM_SLOP = 10;
 /** Fallback commit distance when the element width is unknown. */
@@ -14,11 +12,15 @@ interface Options {
 }
 
 /**
- * iOS-style edge-swipe-back for an overlay layer: a rightward drag that
- * STARTS in the left edge zone follows the finger (`dragX`) and commits
- * `onBack` when released past a third of the layer width. Drags starting
- * anywhere else belong to the layer's content (vertical scroll,
- * horizontally scrollable code blocks) and are never intercepted.
+ * Swipe-back for an overlay layer: a rightward-dominant drag ANYWHERE
+ * on the layer follows the finger (`dragX`) and commits `onBack` when
+ * released past a third of the layer width.
+ *
+ * Deliberately not edge-gated: real mobile browsers run their own
+ * back-navigation gesture in the left edge zone, so an edge-only
+ * dismiss is unreachable on device. Vertical-dominant drags stay with
+ * the content scroller, and drags starting inside a `<pre>` are left
+ * alone so horizontally scrollable code blocks keep their native pan.
  *
  * touchmove is registered non-passive so an armed drag can
  * preventDefault() browser panning — React's root touch listeners are
@@ -49,7 +51,10 @@ export function useSwipeBack({ ref, enabled, onBack }: Options): {
 
     function handleStart(e: TouchEvent) {
       const t = e.touches[0];
-      if (!t || t.clientX > EDGE_ZONE) {
+      // Code blocks scroll horizontally; their pans are not back-swipes.
+      const inHorizontalScroller =
+        e.target instanceof Element && e.target.closest("pre") !== null;
+      if (!t || inHorizontalScroller) {
         gestureRef.current = null;
         return;
       }

--- a/src/lib/recent-feeds.ts
+++ b/src/lib/recent-feeds.ts
@@ -23,28 +23,30 @@ export function recordRecentFeed(recent: string[], feedId: string): string[] {
 }
 
 /**
- * Order `feeds` most-recently-viewed first. Feeds present in `recentIds`
- * lead, in recency order; feeds never viewed follow in their incoming
- * order. Recency ids with no matching feed (deleted since last view) are
- * dropped.
+ * Pick the feeds for the mobile dock's quick-switch slots.
+ *
+ * Recency decides MEMBERSHIP (the `cap` most-recently-viewed feeds,
+ * padded with never-viewed feeds); the sidebar `feeds` order decides
+ * POSITION. Splitting the two is the point: tapping a feed that is
+ * already in the dock changes its recency but not the dock's makeup,
+ * so the buttons never reorder under the user's thumb. Only viewing a
+ * feed from outside the dock swaps a member out — a rare, expected
+ * change instead of a shuffle on every selection.
  */
-export function orderFeedsByRecency(feeds: Feed[], recentIds: string[]): Feed[] {
-  const byId = new Map(feeds.map((f) => [f.id, f]));
-  const seen = new Set<string>();
-  const ordered: Feed[] = [];
-
+export function stableDockFeeds(
+  feeds: Feed[],
+  recentIds: string[],
+  cap: number,
+): Feed[] {
+  const knownIds = new Set(feeds.map((f) => f.id));
+  const members = new Set<string>();
   for (const id of recentIds) {
-    const feed = byId.get(id);
-    if (feed && !seen.has(id)) {
-      ordered.push(feed);
-      seen.add(id);
-    }
+    if (members.size >= cap) break;
+    if (knownIds.has(id)) members.add(id);
   }
   for (const feed of feeds) {
-    if (!seen.has(feed.id)) {
-      ordered.push(feed);
-      seen.add(feed.id);
-    }
+    if (members.size >= cap) break;
+    members.add(feed.id);
   }
-  return ordered;
+  return feeds.filter((f) => members.has(f.id));
 }

--- a/src/lib/recent-feeds.ts
+++ b/src/lib/recent-feeds.ts
@@ -6,7 +6,10 @@ import type { Feed } from "@feedzero/core/types";
  * strip is only 60px tall and a fixed cap keeps the open-list trigger
  * reachable on the narrowest phones.
  */
-export const MOBILE_DOCK_FEED_CAP = 6;
+// 4, not 6: the strip now also carries fixed Explore + Settings icons.
+// 4 favicons + All-items + the three fixed buttons fit a 360px-wide
+// phone without clipping inside the overflow-hidden favicon area.
+export const MOBILE_DOCK_FEED_CAP = 4;
 
 /** Upper bound on the persisted recency list. */
 export const RECENT_LIST_CAP = 20;

--- a/src/lib/share-article.ts
+++ b/src/lib/share-article.ts
@@ -1,0 +1,27 @@
+import { toast } from "sonner";
+
+/**
+ * Share an article through the OS share sheet where available
+ * (`navigator.share` — mobile browsers, some desktops), falling back to
+ * copying the link with a confirming toast. A dismissed share sheet is
+ * a non-event, not an error. Privacy-clean: user-initiated, the raw
+ * article URL only, no tracking parameters added.
+ */
+export async function shareArticle(article: {
+  title: string;
+  link?: string;
+}): Promise<void> {
+  if (!article.link) return;
+
+  if (typeof navigator.share === "function") {
+    try {
+      await navigator.share({ title: article.title, url: article.link });
+    } catch {
+      // AbortError when the user closes the sheet — nothing to do.
+    }
+    return;
+  }
+
+  await navigator.clipboard.writeText(article.link);
+  toast("Link copied");
+}

--- a/src/lib/tap-target.ts
+++ b/src/lib/tap-target.ts
@@ -1,0 +1,19 @@
+/**
+ * Expanded hit areas for visually-compact controls (Apple HIG: 44pt
+ * minimum effective tap target). The control keeps its rendered size;
+ * an invisible ::after pseudo-element absorbs nearby taps.
+ *
+ * Sizing math: a h-7 (28px) control + `-inset-2` (2 × 8px) = 44px.
+ */
+
+/** All-direction expansion — for isolated round buttons (star, share). */
+export const TAP_TARGET_EXPAND =
+  "relative after:absolute after:-inset-2 after:content-['']";
+
+/**
+ * Vertical-only expansion — for buttons inside a horizontal group
+ * (segmented controls, pill rows) where sideways growth would overlap
+ * the neighbouring segment and bias taps to the later sibling.
+ */
+export const TAP_TARGET_EXPAND_Y =
+  "relative after:absolute after:-inset-y-2 after:inset-x-0 after:content-['']";

--- a/src/pages/app-layout.tsx
+++ b/src/pages/app-layout.tsx
@@ -107,10 +107,13 @@ export function AppLayout() {
   if (!isDesktop) {
     return (
       <div className="flex flex-col h-dvh overflow-hidden bg-background">
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-3 z-10 bg-background">
+        <header className="flex h-12 shrink-0 items-center gap-1 border-b px-3 z-10 bg-background">
           <HeaderBreadcrumbs fallback={feedId ? "Articles" : "Feeds"} />
+          {/* Dot-only status: the verbose "Refreshed X ago · mode" line
+              lives in the drawer footer now; the single view-options
+              control anchors the right corner. */}
+          <SyncStatusBadge compact />
           <MobileHeaderPills />
-          <SyncStatusBadge />
         </header>
         <Outlet />
         <MobileNavDrawer onFeedSelect={handleFeedSelect} />

--- a/src/pages/feeds-route.tsx
+++ b/src/pages/feeds-route.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useCallback, lazy, Suspense } from "react";
+import { useEffect, useRef, lazy, Suspense, type ReactNode } from "react";
 import { useParams, useNavigate } from "react-router";
+import { useSwipeBack } from "@/hooks/use-swipe-back.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useIsDesktop } from "@/hooks/use-media-query.ts";
@@ -24,10 +25,16 @@ const ExploreCatalog = lazy(() =>
  * The feeds surface: article list + reader pane.
  *
  * Desktop: inner ResizablePanelGroup [article-list | reader].
- * Mobile: horizontal scroll-snap container [list | reader].
+ * Mobile: the list fills the viewport; the reader is an OVERLAY LAYER
+ * on top of it whenever the URL carries an articleId. Tap goes in,
+ * edge-swipe-right (or the back pill) goes out — the list never
+ * horizontal-swipes into the reader and never unmounts, so its scroll
+ * position survives reading. (Replaces the earlier snap-x pager,
+ * which made the two panels feel physically connected and fought the
+ * row swipe-actions — user feedback on PR #237.)
  *
- * Drives article selection from URL params, auto-selects the first
- * article on desktop, and handles the mobile back-swipe gesture.
+ * Drives article selection from URL params and auto-selects the first
+ * article on desktop.
  *
  * When the user has no feeds, redirects to /explore — the empty state
  * for "feeds" is the catalog itself.
@@ -60,25 +67,6 @@ export function FeedsRoute() {
   // loads when the effect re-fires for the same param.
   const loadedFeedRef = useRef<string | null>(null);
 
-  // Scroll-snap container ref (mobile only)
-  const snapContainerRef = useRef<HTMLDivElement>(null);
-  const programmaticScrollRef = useRef(false);
-
-  const scrollToReader = useCallback(() => {
-    const el = snapContainerRef.current;
-    if (!el) return;
-    programmaticScrollRef.current = true;
-    el.scrollTo({ left: el.clientWidth, behavior: "smooth" });
-  }, []);
-
-  const scrollToList = useCallback(() => {
-    const el = snapContainerRef.current;
-    if (!el) return;
-    programmaticScrollRef.current = true;
-    skipAutoSelectRef.current = true;
-    el.scrollTo({ left: 0, behavior: "smooth" });
-  }, []);
-
   // Feed switch: select feed and start loading when feedId changes
   useEffect(() => {
     if (!feedId || feedId === loadedFeedRef.current) return;
@@ -86,10 +74,6 @@ export function FeedsRoute() {
     lastSyncedArticleIdRef.current = undefined;
     selectFeed(feedId);
     selectArticle(null);
-    // On mobile, if the reader panel is visible (container scrolled right),
-    // snap back to the article list so the user lands on panel 1 for the
-    // new feed.
-    if (snapContainerRef.current?.scrollLeft) scrollToList();
     loadArticles(feedId).then(() => {
       // Only auto-select the first article on desktop, where the 3-panel
       // layout would otherwise show an empty reader pane. On mobile the
@@ -103,7 +87,7 @@ export function FeedsRoute() {
         });
       }
     });
-  }, [feedId, selectFeed, selectArticle, loadArticles, articleId, navigate, isDesktop, scrollToList]);
+  }, [feedId, selectFeed, selectArticle, loadArticles, articleId, navigate, isDesktop]);
 
   // Article sync + auto-select. Waits until loading completes, then either
   // syncs articleId from URL or auto-selects the first article on desktop.
@@ -148,49 +132,8 @@ export function FeedsRoute() {
     if (!viewedArticlePresentRef.current) return;
     viewedArticlePresentRef.current = false;
     skipAutoSelectRef.current = true;
-    scrollToList();
     navigate(`/feeds/${feedId}`, { replace: true });
-  }, [isDesktop, feedId, articleId, articles, isLoadingArticles, navigate, scrollToList]);
-
-  // Scroll to the reader panel when the user explicitly navigates to an article.
-  // snapScrollMountedRef skips the initial render so loading the app with an
-  // articleId already in the URL lands on the article list, not the reader.
-  // Depending only on articleId means a desktop→mobile viewport transition
-  // never fires this scroll.
-  const snapScrollMountedRef = useRef(false);
-  useEffect(() => {
-    if (!snapScrollMountedRef.current) {
-      snapScrollMountedRef.current = true;
-      return;
-    }
-    if (!isDesktop && articleId && feedId) {
-      requestAnimationFrame(() => scrollToReader());
-    }
-    // isDesktop intentionally excluded: viewport changes should not trigger scroll.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [articleId]);
-
-  // Detect user-initiated swipe-back via scrollend. When the user swipes
-  // from the reader panel back to the list, drop the articleId from the URL
-  // so the back navigation is reflected in history.
-  useEffect(() => {
-    const el = snapContainerRef.current;
-    if (!el || isDesktop) return;
-
-    function handleScrollEnd() {
-      if (programmaticScrollRef.current) {
-        programmaticScrollRef.current = false;
-        return;
-      }
-      if (el!.scrollLeft < el!.clientWidth / 2 && articleId && feedId) {
-        skipAutoSelectRef.current = true;
-        navigate(`/feeds/${feedId}`, { replace: true });
-      }
-    }
-
-    el.addEventListener("scrollend", handleScrollEnd);
-    return () => el.removeEventListener("scrollend", handleScrollEnd);
-  }, [isDesktop, articleId, feedId, navigate]);
+  }, [isDesktop, feedId, articleId, articles, isLoadingArticles, navigate]);
 
   function handleArticleSelect(article: { id: string }) {
     if (!feedId) return;
@@ -219,32 +162,30 @@ export function FeedsRoute() {
   }
 
   if (!isDesktop) {
+    const closeReader = () => {
+      skipAutoSelectRef.current = true;
+      navigate(`/feeds/${feedId}`);
+    };
     return (
-      <div
-        ref={snapContainerRef}
-        className="flex flex-1 min-h-0 overflow-x-auto snap-x snap-mandatory"
-        style={{ scrollbarWidth: "none", WebkitOverflowScrolling: "touch" }}
-      >
-        {/* Panel 1: Article list — owns its own scroll for virtualization */}
-        <main role="main" className="shrink-0 w-full snap-start">
+      <div className="relative flex-1 min-h-0 overflow-hidden">
+        {/* The list fills the viewport and stays mounted while reading,
+            so its scroll position survives the round trip. */}
+        <main role="main" className="h-full">
           <ArticleList onArticleSelect={handleArticleSelect} />
         </main>
 
-        {/* Panel 2: Reader — ReaderPanel owns its own scroll and nav bar */}
-        <div
-          data-testid="reader-scroll-mobile"
-          className="shrink-0 w-full snap-start h-full"
-        >
-          <ReaderPanel
-            nextArticle={nextArticle}
-            prevArticle={prevArticle}
-            onNavigate={handleArticleSelect}
-            onBack={articleId ? () => {
-              scrollToList();
-              navigate(`/feeds/${feedId}`);
-            } : undefined}
-          />
-        </div>
+        {articleId && feedId && (
+          <MobileReaderLayer onBack={closeReader}>
+            <div data-testid="reader-scroll-mobile" className="h-full">
+              <ReaderPanel
+                nextArticle={nextArticle}
+                prevArticle={prevArticle}
+                onNavigate={handleArticleSelect}
+                onBack={closeReader}
+              />
+            </div>
+          </MobileReaderLayer>
+        )}
       </div>
     );
   }
@@ -277,5 +218,36 @@ export function FeedsRoute() {
         />
       </ResizablePanel>
     </ResizablePanelGroup>
+  );
+}
+
+/**
+ * Full-viewport layer hosting the mobile reader above the article
+ * list. Slides in from the right on mount; an edge-swipe-right drag
+ * follows the finger and dismisses via `onBack` (the same exit the
+ * back pill uses), snapping back if released early.
+ */
+function MobileReaderLayer({
+  onBack,
+  children,
+}: {
+  onBack: () => void;
+  children: ReactNode;
+}) {
+  const layerRef = useRef<HTMLDivElement>(null);
+  const { dragX } = useSwipeBack({ ref: layerRef, enabled: true, onBack });
+
+  return (
+    <div
+      ref={layerRef}
+      data-testid="reader-layer"
+      className="absolute inset-0 z-20 bg-background animate-in slide-in-from-right duration-200"
+      style={{
+        transform: dragX > 0 ? `translateX(${dragX}px)` : undefined,
+        transition: dragX === 0 ? "transform 150ms ease-out" : "none",
+      }}
+    >
+      {children}
+    </div>
   );
 }

--- a/src/pages/feeds-route.tsx
+++ b/src/pages/feeds-route.tsx
@@ -241,7 +241,11 @@ function MobileReaderLayer({
     <div
       ref={layerRef}
       data-testid="reader-layer"
-      className="absolute inset-0 z-20 bg-background animate-in slide-in-from-right duration-200"
+      // touch-pan-y hands horizontal drags to the back-swipe hook on
+      // real hardware (browsers otherwise claim them as scrolls);
+      // <pre> re-enables native panning for wide code blocks, matching
+      // the hook's own pre-guard.
+      className="absolute inset-0 z-20 bg-background animate-in slide-in-from-right duration-200 touch-pan-y [&_pre]:touch-auto"
       style={{
         transform: dragX > 0 ? `translateX(${dragX}px)` : undefined,
         transition: dragX === 0 ? "transform 150ms ease-out" : "none",

--- a/tests/components/articles/article-list-controls.test.tsx
+++ b/tests/components/articles/article-list-controls.test.tsx
@@ -39,6 +39,9 @@ vi.mock("@/core/storage/db.ts", () => ({
   getSmartFilters: vi.fn().mockResolvedValue({ ok: true, value: [] }),
   getArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
   getAllArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  // Selecting a sort mode persists through the preferences row.
+  getPreferences: vi.fn().mockResolvedValue({ ok: true, value: null }),
+  putPreferences: vi.fn().mockResolvedValue({ ok: true, value: true }),
 }));
 
 vi.mock("@/core/sync/sync-service", () => ({

--- a/tests/components/articles/article-list-controls.test.tsx
+++ b/tests/components/articles/article-list-controls.test.tsx
@@ -16,7 +16,6 @@ import {
   ArticleListControls,
   MobileHeaderPills,
 } from "@/components/articles/article-list-controls.tsx";
-import { getFeeds } from "@/core/storage/db.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useSmartFilterStore } from "@/stores/smart-filter-store.ts";
@@ -176,90 +175,63 @@ describe("MobileHeaderPills", () => {
     useArticleStore.setState({ articleSortMode: "newest" });
   });
 
-  it("renders the two pills without a title or sticky positioning", () => {
+  it("renders one consolidated view-options pill — no refresh, no separate cog/sort", () => {
+    // Three same-looking pills of three different scopes (refresh action,
+    // feed settings, list sort) read as inconsistent (user feedback on
+    // PR #237). Refresh is the pull-to-refresh gesture's job on mobile;
+    // sort + contextual settings consolidate into one menu.
     render(
       <MemoryRouter>
         <MobileHeaderPills />
       </MemoryRouter>,
     );
     const wrapper = screen.getByTestId("mobile-header-pills");
-    expect(wrapper).toBeInTheDocument();
-    // Bare wrapper — no sticky / border / title slot.
     expect(wrapper.className).not.toMatch(/sticky/);
-    expect(wrapper.className).not.toMatch(/border-b/);
-    expect(screen.getByTestId("settings-pill")).toBeInTheDocument();
-    expect(screen.getByLabelText(/sort/i)).toBeInTheDocument();
-  });
-
-  it("hides the settings pill on ALL_FEEDS view (sort still renders)", () => {
-    useFeedStore.setState({ selectedFeedId: ALL_FEEDS_ID });
-    render(
-      <MemoryRouter>
-        <MobileHeaderPills />
-      </MemoryRouter>,
-    );
-    expect(screen.queryByTestId("settings-pill")).toBeNull();
-    expect(screen.getByLabelText(/sort/i)).toBeInTheDocument();
-  });
-
-  it("shows a refresh control when feeds exist", () => {
-    render(
-      <MemoryRouter>
-        <MobileHeaderPills />
-      </MemoryRouter>,
-    );
-    expect(screen.getByTestId("mobile-refresh")).toBeInTheDocument();
-  });
-
-  it("hides the refresh control when there are no feeds", () => {
-    useFeedStore.setState({ feeds: [], selectedFeedId: ALL_FEEDS_ID });
-    render(
-      <MemoryRouter>
-        <MobileHeaderPills />
-      </MemoryRouter>,
-    );
+    expect(screen.getByTestId("view-options-pill")).toBeInTheDocument();
     expect(screen.queryByTestId("mobile-refresh")).toBeNull();
+    expect(screen.queryByTestId("settings-pill")).toBeNull();
   });
 
-  it("tapping refresh on a single feed view refreshes only that feed", async () => {
-    const { refreshFeed, refreshAllFeeds } = await import(
-      "@/core/feeds/feed-service.ts"
-    );
-    vi.mocked(getFeeds).mockResolvedValue({
-      ok: true,
-      value: [feed("f-tech", "Tech Crunchies")],
-    });
+  it("menu offers the sort modes; selecting one updates the store", async () => {
     const user = userEvent.setup();
     render(
       <MemoryRouter>
         <MobileHeaderPills />
       </MemoryRouter>,
     );
-    await user.click(screen.getByTestId("mobile-refresh"));
-    expect(refreshFeed).toHaveBeenCalledTimes(1);
-    expect(refreshAllFeeds).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("view-options-pill"));
+    await user.click(await screen.findByText(/oldest first/i));
+
+    expect(useArticleStore.getState().articleSortMode).toBe("oldest");
   });
 
-  it("tapping refresh on the All-items view refreshes every feed", async () => {
+  it("menu offers Feed settings on a feed view and opens the dialog", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <MobileHeaderPills />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByTestId("view-options-pill"));
+    await user.click(await screen.findByText(/feed settings/i));
+
+    expect(useFeedStore.getState().feedSettingsDialogId).toBe("f-tech");
+  });
+
+  it("omits the settings item on aggregated views (nothing to configure)", async () => {
     useFeedStore.setState({ selectedFeedId: ALL_FEEDS_ID });
-    const { refreshAllFeeds } = await import("@/core/feeds/feed-service.ts");
     const user = userEvent.setup();
     render(
       <MemoryRouter>
         <MobileHeaderPills />
       </MemoryRouter>,
     );
-    await user.click(screen.getByTestId("mobile-refresh"));
-    expect(refreshAllFeeds).toHaveBeenCalled();
-  });
 
-  it("disables the refresh control while a refresh is in flight", () => {
-    useFeedStore.setState({ isRefreshingAll: true });
-    render(
-      <MemoryRouter>
-        <MobileHeaderPills />
-      </MemoryRouter>,
-    );
-    expect(screen.getByTestId("mobile-refresh")).toBeDisabled();
+    await user.click(screen.getByTestId("view-options-pill"));
+
+    expect(await screen.findByText(/newest first/i)).toBeInTheDocument();
+    expect(screen.queryByText(/feed settings/i)).toBeNull();
   });
 });

--- a/tests/components/articles/article-list.test.tsx
+++ b/tests/components/articles/article-list.test.tsx
@@ -363,6 +363,27 @@ describe("ArticleList", () => {
     expect(list!.className).toContain("pb-12");
   });
 
+  it("shows a row skeleton during the initial silent load instead of a blank panel", () => {
+    useFeedStore.setState({
+      feeds: [mockFeed("f1", "Feed 1")],
+      selectedFeedId: "f1",
+      isLoading: false,
+      isRefreshingAll: false,
+      error: null,
+    });
+    useArticleStore.setState({
+      articles: [],
+      selectedArticle: null,
+      isLoading: true,
+    });
+
+    render(<ArticleList />);
+
+    // Blank reads as "broken"; a pulsing list reads as "already loading".
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.queryByText(/no articles here yet/i)).toBeNull();
+  });
+
   it("clicking the 'Mark N read' pill marks everything read and offers Undo", async () => {
     const { toast } = await import("sonner");
     const user = userEvent.setup();

--- a/tests/components/articles/swipe-to-read-row.test.tsx
+++ b/tests/components/articles/swipe-to-read-row.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { SwipeToReadRow } from "@/components/articles/swipe-to-read-row.tsx";
+import { ArticleList } from "@/components/articles/article-list.tsx";
+import { useArticleStore } from "@/stores/article-store.ts";
+import { useFeedStore } from "@/stores/feed-store.ts";
+import {
+  installVirtualizerShims,
+  restoreVirtualizerShims,
+} from "../../helpers/virtualizer-shims.ts";
+
+vi.mock("@/core/storage/db.ts", () => ({
+  getArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getAllArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  updateArticle: vi.fn().mockResolvedValue({ ok: true, value: true }),
+  getFeeds: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getFeed: vi.fn(),
+  removeFeed: vi.fn(),
+  getSmartFilters: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  getFolders: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+}));
+
+vi.mock("@/core/feeds/feed-service.ts", () => ({
+  addFeedFlow: vi.fn(),
+  refreshFeed: vi.fn(),
+  refreshAllFeeds: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-media-query.ts", () => ({
+  useMediaQuery: vi.fn().mockReturnValue(false),
+  useIsDesktop: vi.fn().mockReturnValue(false),
+}));
+
+const article = (read = false) => ({
+  id: "a1",
+  feedId: "f1",
+  guid: "a1",
+  title: "Swipeable",
+  link: "https://example.com/a1",
+  content: "<p>c</p>",
+  summary: "s",
+  author: "",
+  publishedAt: Date.now(),
+  read,
+  createdAt: Date.now(),
+});
+
+function seed(read = false) {
+  const a = article(read);
+  useArticleStore.setState({
+    articles: [a],
+    articlesByFeedId: { f1: [a] },
+    selectedArticle: null,
+    isLoading: false,
+  });
+  return a;
+}
+
+function touch(el: Element, type: string, x: number, y: number) {
+  act(() => {
+    el.dispatchEvent(
+      new TouchEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        touches:
+          type === "touchend"
+            ? []
+            : [
+                new Touch({
+                  identifier: 1,
+                  target: el,
+                  clientX: x,
+                  clientY: y,
+                }),
+              ],
+      }),
+    );
+  });
+}
+
+/** Drag from (x0,y0) to (x1,y1) with an intermediate step, then release. */
+function drag(el: Element, x0: number, y0: number, x1: number, y1: number) {
+  touch(el, "touchstart", x0, y0);
+  touch(el, "touchmove", (x0 + x1) / 2, (y0 + y1) / 2);
+  touch(el, "touchmove", x1, y1);
+  touch(el, "touchend", x1, y1);
+}
+
+function renderRow(read = false) {
+  const a = seed(read);
+  render(
+    <SwipeToReadRow article={a} enabled>
+      <div data-testid="row-content">{a.title}</div>
+    </SwipeToReadRow>,
+  );
+  return screen.getByTestId("swipe-to-read-row");
+}
+
+describe("SwipeToReadRow", () => {
+  it("rightward swipe past the threshold marks an unread article read", async () => {
+    const row = renderRow(false);
+
+    drag(row, 100, 100, 200, 104);
+
+    await vi.waitFor(() => {
+      expect(useArticleStore.getState().articles[0].read).toBe(true);
+    });
+  });
+
+  it("rightward swipe on a read article restores unread", async () => {
+    const row = renderRow(true);
+
+    drag(row, 100, 100, 200, 104);
+
+    await vi.waitFor(() => {
+      expect(useArticleStore.getState().articles[0].read).toBe(false);
+    });
+  });
+
+  it("translates the row content while dragging (visible feedback)", () => {
+    const row = renderRow(false);
+
+    touch(row, "touchstart", 100, 100);
+    touch(row, "touchmove", 160, 102);
+
+    const content = screen.getByTestId("row-content").parentElement!;
+    expect(content.getAttribute("style") ?? "").toContain("translateX");
+
+    touch(row, "touchend", 160, 102);
+  });
+
+  it("a short rightward swipe snaps back without committing", () => {
+    const row = renderRow(false);
+
+    drag(row, 100, 100, 130, 102);
+
+    expect(useArticleStore.getState().articles[0].read).toBe(false);
+  });
+
+  it("leftward swipes never commit — the pager owns leftward", () => {
+    const row = renderRow(false);
+
+    drag(row, 200, 100, 80, 104);
+
+    expect(useArticleStore.getState().articles[0].read).toBe(false);
+  });
+
+  it("vertical-dominant drags are left to the scroll container", () => {
+    const row = renderRow(false);
+
+    drag(row, 100, 100, 130, 220);
+
+    expect(useArticleStore.getState().articles[0].read).toBe(false);
+  });
+
+  it("renders children without gesture chrome when disabled (desktop)", () => {
+    const a = seed(false);
+    render(
+      <SwipeToReadRow article={a} enabled={false}>
+        <div data-testid="row-content">{a.title}</div>
+      </SwipeToReadRow>,
+    );
+    expect(screen.queryByTestId("swipe-to-read-row")).toBeNull();
+    expect(screen.getByTestId("row-content")).toBeInTheDocument();
+  });
+});
+
+describe("ArticleList swipe integration", () => {
+  beforeEach(() => {
+    installVirtualizerShims();
+    useFeedStore.setState({
+      feeds: [
+        {
+          id: "f1",
+          url: "https://f1.com/feed",
+          title: "Feed 1",
+          description: "",
+          siteUrl: "https://f1.com",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+      selectedFeedId: "f1",
+      isLoading: false,
+      isRefreshingAll: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    restoreVirtualizerShims();
+  });
+
+  it("wraps article rows in the swipe gesture on mobile", () => {
+    seed(false);
+    render(<ArticleList />);
+    expect(screen.getByTestId("swipe-to-read-row")).toBeInTheDocument();
+  });
+});

--- a/tests/components/articles/swipe-to-read-row.test.tsx
+++ b/tests/components/articles/swipe-to-read-row.test.tsx
@@ -153,6 +153,17 @@ describe("SwipeToReadRow", () => {
     expect(useArticleStore.getState().articles[0].read).toBe(false);
   });
 
+  it("declares touch-action pan-y so real browsers hand horizontal drags to JS", () => {
+    // Without touch-action, mobile browsers claim the drag as a scroll
+    // after their own slop and stop dispatching touchmove — the arming
+    // logic loses the race on real hardware even though synthetic-event
+    // tests pass. pan-y keeps vertical scrolling native and horizontal
+    // gestures ours. Safe now that the snap pager no longer needs
+    // leftward drags on the list.
+    const row = renderRow(false);
+    expect(row.className).toContain("touch-pan-y");
+  });
+
   it("renders children without gesture chrome when disabled (desktop)", () => {
     const a = seed(false);
     render(

--- a/tests/components/layout/feeds-page-layout.test.tsx
+++ b/tests/components/layout/feeds-page-layout.test.tsx
@@ -595,11 +595,26 @@ describe("FeedsPage layout — mobile", () => {
     }
   });
 
-  it("mobile reader snap panel delegates to ReaderPanel (no overflow-y-auto on the wrapper)", () => {
-    // ReaderPanel now owns its own scroll container and nav bar. The outer snap
-    // panel is a geometry wrapper only — it must not double-scroll.
+  it("mobile reader overlay delegates to ReaderPanel (no overflow-y-auto on the wrapper)", () => {
+    // ReaderPanel owns its own scroll container and nav bar. The overlay
+    // wrapper is a geometry layer only — it must not double-scroll. It
+    // mounts only while an article is open (reader-as-overlay model).
+    const article = {
+      id: "a1",
+      feedId: "f1",
+      guid: "a1",
+      title: "Article",
+      link: "https://example.com/a1",
+      content: "<p>c</p>",
+      summary: "",
+      author: "",
+      read: false,
+      publishedAt: Date.now(),
+      createdAt: Date.now(),
+    };
     useFeedStore.setState({ feeds: [defaultFeed], selectedFeedId: "f1" });
-    const { container } = renderPage("/feeds/f1");
+    useArticleStore.setState({ articles: [article], selectedArticle: article });
+    const { container } = renderPage("/feeds/f1/articles/a1");
     const reader = container.querySelector('[data-testid="reader-scroll-mobile"]');
     expect(reader).not.toBeNull();
     expect((reader as HTMLElement).className).not.toContain("overflow-y-auto");

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -217,6 +217,32 @@ describe("MobileNavDrawer", () => {
       }
     });
 
+    it("swiping up on the dock strip opens the drawer (the handle pill advertises it)", async () => {
+      useFeedStore.setState({ feeds: [makeFeed("f1", "Feed 1")] });
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+
+      const touch = (type: string, y: number) =>
+        strip.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches:
+              type === "touchend"
+                ? []
+                : [new Touch({ identifier: 1, target: strip, clientX: 200, clientY: y })],
+          }),
+        );
+
+      touch("touchstart", 800);
+      touch("touchmove", 760);
+      touch("touchend", 760);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("drawer-content")).toBeInTheDocument();
+      });
+    });
+
     it("has a fixed Explore shortcut that navigates without opening the drawer", async () => {
       const user = userEvent.setup();
       useFeedStore.setState({ feeds: [makeFeed("f1", "Feed 1")] });
@@ -244,6 +270,20 @@ describe("MobileNavDrawer", () => {
       expect(screen.getByTestId("probe-path")).toHaveTextContent("/settings");
       expect(screen.queryByTestId("drawer-content")).toBeNull();
     });
+  });
+
+  it("drawer footer carries the full 'Refreshed X ago' status (moved out of the header)", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [makeFeed("f1", "Feed 1")],
+      lastRefreshAllAt: Date.now() - 5 * 60 * 1000,
+    });
+    renderDrawer();
+
+    await user.click(screen.getByRole("button", { name: /open feed list/i }));
+
+    const drawer = await screen.findByTestId("drawer-content");
+    expect(within(drawer).getByText(/refreshed .* ago/i)).toBeInTheDocument();
   });
 
   it("renders 'All items' entry when drawer is open and there are feeds", async () => {

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -154,7 +154,7 @@ describe("MobileNavDrawer", () => {
       expect(onFeedSelect).toHaveBeenCalledWith("all");
     });
 
-    it("orders dock favicons most-recently-viewed first", () => {
+    it("dock keeps sidebar order regardless of recency (no reorder under the thumb)", () => {
       useFeedStore.setState({
         feeds: [makeFeed("f1", "Alpha"), makeFeed("f2", "Bravo"), makeFeed("f3", "Charlie")],
         recentFeedIds: ["f3", "f1"],
@@ -164,14 +164,15 @@ describe("MobileNavDrawer", () => {
       const labels = within(strip)
         .getAllByRole("button")
         .map((b) => b.getAttribute("aria-label"));
-      // After the anchored "All items", recency order wins: f3, f1, then the
-      // never-viewed f2; the fixed Explore/Settings shortcuts and the
-      // open-list chevron trail.
+      // Recency only decides WHICH feeds occupy dock slots; POSITION is
+      // sidebar order. Earlier the dock re-sorted most-recent-first, which
+      // shuffled the buttons on every tap — jarring on a strip you tap
+      // by muscle memory (user feedback on PR #237).
       expect(labels).toEqual([
         "All items",
-        "Charlie",
         "Alpha",
         "Bravo",
+        "Charlie",
         "Explore",
         "Settings",
         "Open feed list",

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -204,6 +204,18 @@ describe("MobileNavDrawer", () => {
       ).toHaveAttribute("aria-pressed", "true");
     });
 
+    it("dock buttons meet the 44px tap-target floor (size-11)", () => {
+      useFeedStore.setState({
+        feeds: [makeFeed("f1", "Feed 1")],
+        recentFeedIds: ["f1"],
+      });
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+      for (const btn of within(strip).getAllByRole("button")) {
+        expect(btn.className).toContain("size-11");
+      }
+    });
+
     it("has a fixed Explore shortcut that navigates without opening the drawer", async () => {
       const user = userEvent.setup();
       useFeedStore.setState({ feeds: [makeFeed("f1", "Feed 1")] });

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -165,12 +165,15 @@ describe("MobileNavDrawer", () => {
         .getAllByRole("button")
         .map((b) => b.getAttribute("aria-label"));
       // After the anchored "All items", recency order wins: f3, f1, then the
-      // never-viewed f2; the open-list chevron trails.
+      // never-viewed f2; the fixed Explore/Settings shortcuts and the
+      // open-list chevron trail.
       expect(labels).toEqual([
         "All items",
         "Charlie",
         "Alpha",
         "Bravo",
+        "Explore",
+        "Settings",
         "Open feed list",
       ]);
     });
@@ -199,6 +202,34 @@ describe("MobileNavDrawer", () => {
       expect(
         within(strip).getByRole("button", { name: "Hacker News" }),
       ).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("has a fixed Explore shortcut that navigates without opening the drawer", async () => {
+      const user = userEvent.setup();
+      useFeedStore.setState({ feeds: [makeFeed("f1", "Feed 1")] });
+      renderDrawer();
+
+      const strip = screen.getByTestId("drawer-handle-strip");
+      await user.click(
+        within(strip).getByRole("button", { name: /explore/i }),
+      );
+
+      expect(screen.getByTestId("probe-path")).toHaveTextContent("/explore");
+      expect(screen.queryByTestId("drawer-content")).toBeNull();
+    });
+
+    it("has a fixed Settings shortcut that navigates without opening the drawer", async () => {
+      const user = userEvent.setup();
+      useFeedStore.setState({ feeds: [makeFeed("f1", "Feed 1")] });
+      renderDrawer();
+
+      const strip = screen.getByTestId("drawer-handle-strip");
+      await user.click(
+        within(strip).getByRole("button", { name: /settings/i }),
+      );
+
+      expect(screen.getByTestId("probe-path")).toHaveTextContent("/settings");
+      expect(screen.queryByTestId("drawer-content")).toBeNull();
     });
   });
 

--- a/tests/components/loading/stage-skeleton.test.tsx
+++ b/tests/components/loading/stage-skeleton.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StageSkeleton } from "@/components/loading/stage-skeleton.tsx";
+
+/**
+ * Fallback for lazy stage routes (Explore/Stats/Settings/Signal). A
+ * blank flash reads as "broken"; a pulsing layout reads as "loading".
+ */
+describe("<StageSkeleton>", () => {
+  it("announces itself as a loading status region", () => {
+    render(<StageSkeleton />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-label", expect.stringMatching(/loading/i));
+  });
+
+  it("renders pulsing placeholder blocks that mirror a stage layout", () => {
+    const { container } = render(<StageSkeleton />);
+    expect(
+      container.querySelectorAll("[data-slot='skeleton']").length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/tests/components/reader/reader-panel.test.tsx
+++ b/tests/components/reader/reader-panel.test.tsx
@@ -96,6 +96,53 @@ describe("ReaderPanel", () => {
     });
   });
 
+  describe("reading measure + text size", () => {
+    it("centers the article column at the existing max measure", () => {
+      useArticleStore.setState({
+        selectedArticle: mockArticle(),
+        articles: [],
+        isLoading: false,
+      });
+      render(<ReaderPanel />);
+      const articleEl = screen
+        .getByRole("heading", { level: 2 })
+        .closest("article");
+      expect(articleEl!.className).toContain("max-w-180");
+      expect(articleEl!.className).toContain("mx-auto");
+    });
+
+    it.each([
+      ["small", "text-sm"],
+      ["large", "text-lg"],
+    ] as const)(
+      "applies the persisted %s reader text size",
+      async (size, expectedClass) => {
+        const { usePreferencesStore } = await import(
+          "@/stores/preferences-store.ts"
+        );
+        const { DEFAULT_PREFERENCES } = await import("@feedzero/core/types");
+        usePreferencesStore.setState({
+          preferences: { ...DEFAULT_PREFERENCES, readerTextSize: size },
+        });
+        useArticleStore.setState({
+          selectedArticle: mockArticle(),
+          articles: [],
+          isLoading: false,
+        });
+
+        render(<ReaderPanel />);
+
+        const articleEl = screen
+          .getByRole("heading", { level: 2 })
+          .closest("article");
+        expect(articleEl!.className).toContain(expectedClass);
+        usePreferencesStore.setState({
+          preferences: { ...DEFAULT_PREFERENCES },
+        });
+      },
+    );
+  });
+
   describe("tap targets (≥44px effective, Apple HIG)", () => {
     beforeEach(() => {
       useArticleStore.setState({

--- a/tests/components/reader/reader-panel.test.tsx
+++ b/tests/components/reader/reader-panel.test.tsx
@@ -96,6 +96,33 @@ describe("ReaderPanel", () => {
     });
   });
 
+  describe("tap targets (≥44px effective, Apple HIG)", () => {
+    beforeEach(() => {
+      useArticleStore.setState({
+        selectedArticle: mockArticle(),
+        articles: [],
+        isLoading: false,
+      });
+    });
+
+    it("star and share keep their compact look but expand the hit area", () => {
+      render(<ReaderPanel />);
+      for (const name of [/star article/i, /share article/i]) {
+        const btn = screen.getByRole("button", { name });
+        // h-7 (28px) + after:-inset-2 (2×8px) = 44px effective.
+        expect(btn.className).toContain("h-7");
+        expect(btn.className).toContain("after:-inset-2");
+      }
+    });
+
+    it("view-mode segments expand vertically only (no cross-segment overlap)", () => {
+      render(<ReaderPanel />);
+      const feedSegment = screen.getByRole("button", { name: "Feed" });
+      expect(feedSegment.className).toContain("after:-inset-y-2");
+      expect(feedSegment.className).not.toContain("after:-inset-2");
+    });
+  });
+
   it("renders article title and content", () => {
     useArticleStore.setState({
       selectedArticle: mockArticle(),

--- a/tests/components/reader/reader-panel.test.tsx
+++ b/tests/components/reader/reader-panel.test.tsx
@@ -57,6 +57,45 @@ describe("ReaderPanel", () => {
     expect(screen.getByText("Select an article to read.")).toBeInTheDocument();
   });
 
+  describe("share button", () => {
+    it("shares the article via the native share sheet when supported", async () => {
+      const user = userEvent.setup();
+      const shareSpy = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "share", {
+        value: shareSpy,
+        configurable: true,
+      });
+      useArticleStore.setState({
+        selectedArticle: mockArticle(),
+        articles: [],
+        isLoading: false,
+      });
+
+      render(<ReaderPanel />);
+      await user.click(
+        screen.getByRole("button", { name: /share article/i }),
+      );
+
+      expect(shareSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ url: mockArticle().link }),
+      );
+      delete (navigator as { share?: unknown }).share;
+    });
+
+    it("sits in the action row beside the star toggle", () => {
+      useArticleStore.setState({
+        selectedArticle: mockArticle(),
+        articles: [],
+        isLoading: false,
+      });
+
+      render(<ReaderPanel />);
+      const row = screen.getByTestId("reader-action-row");
+      const share = screen.getByRole("button", { name: /share article/i });
+      expect(row.contains(share)).toBe(true);
+    });
+  });
+
   it("renders article title and content", () => {
     useArticleStore.setState({
       selectedArticle: mockArticle(),

--- a/tests/components/settings/reading-tab.test.tsx
+++ b/tests/components/settings/reading-tab.test.tsx
@@ -47,6 +47,32 @@ describe("<ReadingTab>", () => {
     useSignalModeStore.setState({ mode: "ml", hidden: false, nightly: false });
   });
 
+  describe("text size", () => {
+    it("renders a three-way text size control defaulting to Medium", () => {
+      renderTab();
+      const medium = screen.getByRole("button", { name: /^medium$/i });
+      expect(medium).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: /^small$/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^large$/i })).toBeInTheDocument();
+    });
+
+    it("selecting Large persists the preference", async () => {
+      const { usePreferencesStore } = await import(
+        "@/stores/preferences-store.ts"
+      );
+      renderTab();
+
+      fireEvent.click(screen.getByRole("button", { name: /^large$/i }));
+
+      expect(
+        usePreferencesStore.getState().preferences.readerTextSize,
+      ).toBe("large");
+      expect(
+        screen.getByRole("button", { name: /^large$/i }),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
   it("renders a Group floods toggle reflecting useAppStore state", () => {
     useAppStore.setState({ groupArticleFloods: true });
     renderTab();

--- a/tests/components/sync/sync-status-badge.test.tsx
+++ b/tests/components/sync/sync-status-badge.test.tsx
@@ -46,6 +46,34 @@ describe("SyncStatusBadge", () => {
     vi.useRealTimers();
   });
 
+  describe("compact mode (mobile header)", () => {
+    it("renders the color dot only — no text label", () => {
+      useSyncStore.setState({ status: "local-only" });
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 5 * 60 * 1000 });
+      render(
+        <MemoryRouter>
+          <SyncStatusBadge compact />
+        </MemoryRouter>,
+      );
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge.textContent).toBe("");
+      expect(screen.queryByText(/refreshed/i)).toBeNull();
+    });
+
+    it("keeps the full status in the accessible label", () => {
+      useSyncStore.setState({ status: "local-only" });
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 5 * 60 * 1000 });
+      render(
+        <MemoryRouter>
+          <SyncStatusBadge compact />
+        </MemoryRouter>,
+      );
+      expect(
+        screen.getByLabelText(/refreshed 5 min ago · local/i),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("idle states", () => {
     it("shows just 'Local' when local-only with no refresh history", () => {
       useSyncStore.setState({ status: "local-only", lastSyncedAt: null });

--- a/tests/components/ui/button-tap-target.test.tsx
+++ b/tests/components/ui/button-tap-target.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Button } from "@/components/ui/button.tsx";
+
+/**
+ * Tier-2 structural: compact icon buttons must carry an expanded hit
+ * area so their effective tap target reaches the 44px Apple HIG floor
+ * while the rendered size stays compact (size-8 = 32px + 2×6px = 44px).
+ */
+describe("Button tap targets", () => {
+  it("icon-sm expands its effective hit area to ≥44px", () => {
+    render(
+      <Button size="icon-sm" aria-label="compact">
+        x
+      </Button>,
+    );
+    const btn = screen.getByRole("button", { name: "compact" });
+    expect(btn.className).toContain("after:-inset-1.5");
+    expect(btn.className).toContain("after:absolute");
+  });
+});

--- a/tests/components/ui/sonner-theme.test.tsx
+++ b/tests/components/ui/sonner-theme.test.tsx
@@ -36,6 +36,29 @@ describe("Toaster theming", () => {
     });
   });
 
+  it("lifts toasts above the mobile dock (60px strip + safe area)", async () => {
+    render(
+      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+        <Toaster />
+      </ThemeProvider>,
+    );
+    act(() => {
+      toast("Offset check");
+    });
+
+    await waitFor(() => {
+      const toaster = document.querySelector(
+        "[data-sonner-toaster]",
+      ) as HTMLElement | null;
+      expect(toaster).not.toBeNull();
+      const style = toaster!.getAttribute("style") ?? "";
+      // bottom-center toasts must clear the persistent dock strip
+      // (60px + env(safe-area-inset-bottom)) instead of covering it.
+      expect(style).toContain("--mobile-offset-bottom");
+      expect(style).toContain("safe-area-inset-bottom");
+    });
+  });
+
   it("uses theme tokens for toast colors, not hardcoded hex values", async () => {
     render(
       <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>

--- a/tests/lib/recent-feeds.test.ts
+++ b/tests/lib/recent-feeds.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   recordRecentFeed,
-  orderFeedsByRecency,
+  stableDockFeeds,
   MOBILE_DOCK_FEED_CAP,
   RECENT_LIST_CAP,
 } from "../../src/lib/recent-feeds.ts";
@@ -38,34 +38,56 @@ describe("recordRecentFeed", () => {
   });
 });
 
-describe("orderFeedsByRecency", () => {
-  it("orders feeds most-recently-viewed first", () => {
-    const feeds = [feed("a"), feed("b"), feed("c")];
-    const ordered = orderFeedsByRecency(feeds, ["c", "a"]);
-    expect(ordered.map((f) => f.id)).toEqual(["c", "a", "b"]);
-  });
-
-  it("appends never-viewed feeds in their incoming order after recent ones", () => {
-    const feeds = [feed("a"), feed("b"), feed("c"), feed("d")];
-    const ordered = orderFeedsByRecency(feeds, ["d"]);
-    expect(ordered.map((f) => f.id)).toEqual(["d", "a", "b", "c"]);
-  });
-
-  it("drops recency ids that no longer correspond to a feed", () => {
-    const feeds = [feed("a"), feed("b")];
-    const ordered = orderFeedsByRecency(feeds, ["gone", "b"]);
-    expect(ordered.map((f) => f.id)).toEqual(["b", "a"]);
-  });
-
-  it("returns feeds in their original order when nothing has been viewed", () => {
-    const feeds = [feed("a"), feed("b")];
-    expect(orderFeedsByRecency(feeds, []).map((f) => f.id)).toEqual(["a", "b"]);
-  });
-});
-
 describe("MOBILE_DOCK_FEED_CAP", () => {
   it("is a small positive cap so the closed dock never overflows the strip", () => {
     expect(MOBILE_DOCK_FEED_CAP).toBeGreaterThan(0);
     expect(MOBILE_DOCK_FEED_CAP).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("stableDockFeeds", () => {
+  const feeds = [feed("a"), feed("b"), feed("c"), feed("d"), feed("e"), feed("f")];
+
+  it("recency decides membership, sidebar order decides position", () => {
+    // e and c are the most recent — both make the dock — but they render
+    // in feeds order (c before e), not recency order.
+    const dock = stableDockFeeds(feeds, ["e", "c"], 4);
+    expect(dock.map((f) => f.id)).toEqual(["a", "b", "c", "e"]);
+  });
+
+  it("tapping a feed already in the dock never reorders the dock", () => {
+    const before = stableDockFeeds(feeds, ["e", "c", "a", "b"], 4);
+    // Viewing "c" promotes it in the recency list…
+    const after = stableDockFeeds(
+      feeds,
+      recordRecentFeed(["e", "c", "a", "b"], "c"),
+      4,
+    );
+    // …but the dock must not move under the user's thumb.
+    expect(after.map((f) => f.id)).toEqual(before.map((f) => f.id));
+  });
+
+  it("viewing a feed outside the dock swaps out the least-recent member only", () => {
+    const before = stableDockFeeds(feeds, ["a", "b", "c", "d"], 4);
+    expect(before.map((f) => f.id)).toEqual(["a", "b", "c", "d"]);
+
+    const after = stableDockFeeds(
+      feeds,
+      recordRecentFeed(["a", "b", "c", "d"], "f"),
+      4,
+    );
+    // f enters (at its sidebar-order slot), d — least recent — leaves;
+    // a, b, c keep their relative positions.
+    expect(after.map((f) => f.id)).toEqual(["a", "b", "c", "f"]);
+  });
+
+  it("fills spare slots with never-viewed feeds in sidebar order", () => {
+    const dock = stableDockFeeds(feeds, ["d"], 3);
+    expect(dock.map((f) => f.id)).toEqual(["a", "b", "d"]);
+  });
+
+  it("ignores recency ids for deleted feeds", () => {
+    const dock = stableDockFeeds(feeds.slice(0, 2), ["ghost", "b"], 2);
+    expect(dock.map((f) => f.id)).toEqual(["a", "b"]);
   });
 });

--- a/tests/lib/share-article.test.ts
+++ b/tests/lib/share-article.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { toast } from "sonner";
+import { shareArticle } from "@/lib/share-article.ts";
+
+vi.mock("sonner", () => ({
+  toast: vi.fn(),
+}));
+
+describe("shareArticle", () => {
+  const shareSpy = vi.fn();
+  const writeTextSpy = vi.fn();
+
+  beforeEach(() => {
+    vi.mocked(toast).mockClear();
+    shareSpy.mockReset().mockResolvedValue(undefined);
+    writeTextSpy.mockReset().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: writeTextSpy },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Remove the share shim so tests that rely on its absence stay isolated.
+    delete (navigator as { share?: unknown }).share;
+  });
+
+  it("uses the native share sheet when available", async () => {
+    Object.defineProperty(navigator, "share", {
+      value: shareSpy,
+      configurable: true,
+    });
+
+    await shareArticle({ title: "Hello", link: "https://example.com/a" });
+
+    expect(shareSpy).toHaveBeenCalledWith({
+      title: "Hello",
+      url: "https://example.com/a",
+    });
+    expect(writeTextSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to clipboard + toast when native share is unavailable", async () => {
+    await shareArticle({ title: "Hello", link: "https://example.com/a" });
+
+    expect(writeTextSpy).toHaveBeenCalledWith("https://example.com/a");
+    expect(toast).toHaveBeenCalledWith("Link copied");
+  });
+
+  it("treats a cancelled share sheet as a non-event", async () => {
+    shareSpy.mockRejectedValue(new DOMException("cancel", "AbortError"));
+    Object.defineProperty(navigator, "share", {
+      value: shareSpy,
+      configurable: true,
+    });
+
+    await expect(
+      shareArticle({ title: "Hello", link: "https://example.com/a" }),
+    ).resolves.toBeUndefined();
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for an article without a link", async () => {
+    await shareArticle({ title: "No link" });
+
+    expect(writeTextSpy).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
+  });
+});

--- a/tests/pages/feeds-page-behavior.test.tsx
+++ b/tests/pages/feeds-page-behavior.test.tsx
@@ -582,57 +582,53 @@ describe("FeedsPage behavior — mobile", () => {
     });
   });
 
-  it("does NOT scroll to reader on initial mobile load with articleId in URL", async () => {
-    // When the URL contains an articleId on initial load (e.g. user resized from
-    // desktop or opened a bookmarked article URL), the snap container must stay
-    // at position 0 (article list). The scroll-to-reader effect must only fire
-    // when the user explicitly selects an article — not on mount.
+  // ── Reader-as-overlay model ─────────────────────────────────────────
+  // The mobile reader is a LAYER over the article list, not a sibling
+  // snap-pager panel. The old snap-x model made the list feel physically
+  // connected to the reader — swiping left on the list dragged the reader
+  // in, which fought row swipe-actions and misread the mental model
+  // (user feedback on PR #237): tap goes IN, swipe goes OUT, and the
+  // list underneath never moves or unmounts.
+
+  it("mobile: reader renders as an overlay only when an article is open; the list stays mounted beneath", () => {
     useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
-    useArticleStore.setState({ articles: [makeArticle("art-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
 
-    // Spy on HTMLElement.prototype.scrollTo to capture scroll-left calls
-    const snapScrollCalls: number[] = [];
-    const origScrollTo = HTMLElement.prototype.scrollTo;
-    HTMLElement.prototype.scrollTo = function (optionsOrX?: ScrollToOptions | number) {
-      const left = typeof optionsOrX === "number"
-        ? optionsOrX
-        : (optionsOrX as ScrollToOptions)?.left ?? 0;
-      if ((this as HTMLElement).classList?.contains("snap-x")) {
-        snapScrollCalls.push(left);
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (origScrollTo as any).call(this, optionsOrX);
-    };
+    const closed = renderPage("/feeds/feed-1");
+    expect(closed.container.querySelector("[data-testid='reader-layer']")).toBeNull();
+    closed.unmount();
 
-    renderPage("/feeds/feed-1/articles/art-1");
-    // Wait for any requestAnimationFrame callbacks to settle
-    await new Promise((r) => setTimeout(r, 50));
-
-    HTMLElement.prototype.scrollTo = origScrollTo;
-
-    // scrollTo with left > 0 should NOT have been called on the snap container
-    expect(snapScrollCalls.filter((l) => l > 0)).toHaveLength(0);
+    const open = renderPage("/feeds/feed-1/articles/art-1");
+    expect(open.container.querySelector("[data-testid='reader-layer']")).not.toBeNull();
+    // The list is still in the DOM underneath — scroll position survives.
+    expect(open.container.querySelector("[role='main']")).not.toBeNull();
   });
 
-  it("navigating to a different feed scrolls the snap container back to the article list", async () => {
-    // If the user is on the reader panel (panel 2) and navigates to a different
-    // feed, the snap container must scroll back to panel 1 (article list).
-    // Without this, the reader shows empty state for the new feed.
-    useFeedStore.setState({ feeds: [makeFeed("feed-1"), makeFeed("feed-2")] });
-    useArticleStore.setState({ articles: [makeArticle("art-1")], selectedArticle: makeArticle("art-1") });
+  it("mobile: the horizontal snap pager is gone — the list cannot swipe into the reader", () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    const { container } = renderPage("/feeds/feed-1");
+    expect(container.querySelector(".snap-x")).toBeNull();
+  });
 
-    const snapScrollToLeft: number[] = [];
-    const origScrollTo = HTMLElement.prototype.scrollTo;
-    HTMLElement.prototype.scrollTo = function (optionsOrX?: ScrollToOptions | number) {
-      const left = typeof optionsOrX === "number"
-        ? optionsOrX
-        : (optionsOrX as ScrollToOptions)?.left ?? 0;
-      if ((this as HTMLElement).classList?.contains("snap-x")) {
-        snapScrollToLeft.push(left);
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (origScrollTo as any).call(this, optionsOrX);
-    };
+  it("mobile: a deeplink with articleId shows the reader overlay immediately", () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
+    const { container } = renderPage("/feeds/feed-1/articles/art-1");
+    expect(container.querySelector("[data-testid='reader-layer']")).not.toBeNull();
+  });
+
+  it("mobile: navigating to a different feed closes the reader overlay", async () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1"), makeFeed("feed-2")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
 
     const user = userEvent.setup();
     const { container } = render(
@@ -646,18 +642,86 @@ describe("FeedsPage behavior — mobile", () => {
         </Routes>
       </MemoryRouter>
     );
-
-    // Simulate snap container being at panel 2
-    const snapEl = container.querySelector(".snap-x") as HTMLElement;
-    if (snapEl) Object.defineProperty(snapEl, "scrollLeft", { value: 400, writable: true });
+    expect(container.querySelector("[data-testid='reader-layer']")).not.toBeNull();
 
     await user.click(screen.getByTestId("nav-to-go-feed-2"));
 
-    HTMLElement.prototype.scrollTo = origScrollTo;
+    await waitFor(() => {
+      expect(container.querySelector("[data-testid='reader-layer']")).toBeNull();
+    });
+  });
+
+  it("mobile: edge-swipe right dismisses the reader back to the list", async () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    // Keep the article present through loadArticles, otherwise the
+    // vanished-article guard navigates back on its own and this test
+    // would pass without the gesture doing anything.
+    vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [makeArticle("art-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
+    const { container } = renderPage("/feeds/feed-1/articles/art-1");
+    const layer = container.querySelector(
+      "[data-testid='reader-layer']",
+    ) as HTMLElement;
+
+    const touch = (type: string, x: number) =>
+      act(() => {
+        layer.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches:
+              type === "touchend"
+                ? []
+                : [new Touch({ identifier: 1, target: layer, clientX: x, clientY: 300 })],
+          }),
+        );
+      });
+
+    touch("touchstart", 8); // within the left edge zone
+    touch("touchmove", 80);
+    touch("touchmove", 180);
+    touch("touchend", 180);
 
     await waitFor(() => {
-      expect(snapScrollToLeft.filter((l) => l === 0)).toHaveLength(1);
+      expect(currentUrl).toBe("/feeds/feed-1");
     });
+  });
+
+  it("mobile: a swipe starting away from the edge does not dismiss the reader", async () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [makeArticle("art-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
+    const { container } = renderPage("/feeds/feed-1/articles/art-1");
+    const layer = container.querySelector(
+      "[data-testid='reader-layer']",
+    ) as HTMLElement;
+
+    const touch = (type: string, x: number) =>
+      act(() => {
+        layer.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches:
+              type === "touchend"
+                ? []
+                : [new Touch({ identifier: 1, target: layer, clientX: x, clientY: 300 })],
+          }),
+        );
+      });
+
+    touch("touchstart", 150); // mid-screen — content owns this drag
+    touch("touchmove", 260);
+    touch("touchend", 260);
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(currentUrl).toBe("/feeds/feed-1/articles/art-1");
   });
 
   it("mobile header does not have a sidebar trigger (replaced by bottom drawer)", () => {

--- a/tests/pages/feeds-page-behavior.test.tsx
+++ b/tests/pages/feeds-page-behavior.test.tsx
@@ -690,7 +690,46 @@ describe("FeedsPage behavior — mobile", () => {
     });
   });
 
-  it("mobile: a swipe starting away from the edge does not dismiss the reader", async () => {
+  it("mobile: a rightward drag anywhere on the reader dismisses it (browsers own the edge)", async () => {
+    // Real mobile browsers run their OWN back gesture in the left edge
+    // zone, so an edge-only dismiss is unreachable on device. Any
+    // rightward-dominant drag on the reader goes back (Reeder model).
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [makeArticle("art-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
+    const { container } = renderPage("/feeds/feed-1/articles/art-1");
+    const layer = container.querySelector(
+      "[data-testid='reader-layer']",
+    ) as HTMLElement;
+
+    const touch = (type: string, x: number, y = 300) =>
+      act(() => {
+        layer.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches:
+              type === "touchend"
+                ? []
+                : [new Touch({ identifier: 1, target: layer, clientX: x, clientY: y })],
+          }),
+        );
+      });
+
+    touch("touchstart", 180); // mid-screen
+    touch("touchmove", 260);
+    touch("touchmove", 340);
+    touch("touchend", 340);
+
+    await waitFor(() => {
+      expect(currentUrl).toBe("/feeds/feed-1");
+    });
+  });
+
+  it("mobile: a vertical-dominant drag does not dismiss the reader", async () => {
     useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
     vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [makeArticle("art-1")] });
     useArticleStore.setState({
@@ -716,12 +755,40 @@ describe("FeedsPage behavior — mobile", () => {
         );
       });
 
-    touch("touchstart", 150); // mid-screen — content owns this drag
-    touch("touchmove", 260);
-    touch("touchend", 260);
+    touch("touchstart", 150);
+    act(() => {
+      layer.dispatchEvent(
+        new TouchEvent("touchmove", {
+          bubbles: true,
+          cancelable: true,
+          touches: [new Touch({ identifier: 1, target: layer, clientX: 190, clientY: 460 })],
+        }),
+      );
+    });
+    touch("touchend", 190);
 
     await new Promise((r) => setTimeout(r, 30));
     expect(currentUrl).toBe("/feeds/feed-1/articles/art-1");
+  });
+
+  it("mobile header: dot-only status indicator, view options pinned to the right corner", () => {
+    // "Refreshed X ago · local" moved into the drawer footer; the header
+    // keeps a compact color dot and puts the single view-options control
+    // in the right corner (user feedback on PR #237).
+    useFeedStore.setState({
+      feeds: [makeFeed("feed-1")],
+      lastRefreshAllAt: Date.now() - 5 * 60 * 1000,
+    });
+    const { container } = renderPage("/feeds/feed-1");
+    const header = container.querySelector("header")!;
+
+    expect(header.textContent).not.toMatch(/refreshed/i);
+    expect(
+      header.querySelector("[data-testid='sync-status-badge']"),
+    ).not.toBeNull();
+    const pills = header.querySelector("[data-testid='mobile-header-pills']");
+    expect(pills).not.toBeNull();
+    expect(header.lastElementChild).toBe(pills);
   });
 
   it("mobile header does not have a sidebar trigger (replaced by bottom drawer)", () => {

--- a/tests/types/preferences.test.ts
+++ b/tests/types/preferences.test.ts
@@ -16,6 +16,7 @@ describe("UserPreferences type + DEFAULT_PREFERENCES", () => {
       articleSortMode: "newest",
       groupArticleFloods: true,
       theme: "system",
+      readerTextSize: "medium",
     });
   });
 


### PR DESCRIPTION
## Summary

Second batch from the approved **10-improvement UX memo** — the remaining six findings, one RGR'd commit each. **Stacked on #236** (`ux/batch-one`); GitHub will retarget to `main` once that merges.

| Commit | Finding | What changed |
|---|---|---|
| `ff5cc47` | #10 | Share button in the reader action row: `navigator.share` (OS share sheet) with clipboard + toast fallback; dismissed sheet is a non-event. Privacy-clean — raw URL only. |
| `afe2a02` | #5 | Fixed **Explore + Settings** icons in the mobile dock strip (Fitts: bottom-edge thumb zone); dock favicon cap 6→4 so nothing clips at 360px. |
| `f819dac` | #6 | Tap targets to the **44px HIG floor**: `icon-sm` Button variant expands app-wide via invisible `::after`; reader star/share/segments expanded (y-only for grouped segments); dock buttons to a real `size-11`. Structural tests lock the classes. |
| `824287f` | #7 | Reader column now **centers at max-w-180** (was left-hugging on wide panels) + new synced `readerTextSize` preference (S/M/L) with a Settings → Reading control. Optional field — rows from older clients parse fine. |
| `1676edc` | #8 | `<StageSkeleton>` fallback for all five lazy routes (they flashed blank) + `<ArticleListSkeleton>` for the initial silent load. |
| `6374ab5` | #3 | **Swipe right on a row toggles read/unread** (mobile). Rightward-only by design: leftward pages to the reader via the snap pager, and rightward has no pager meaning — zero gesture conflict. Non-passive native touchmove (React root listeners are passive), 1.5:1 horizontal-dominance arming, 64px commit, snap-back. Eight arbitration tests. |

## Verification

- `npm test`: **3781 passed** (35 new tests), `npx tsc --noEmit` clean
- **Visually verified in real Chromium**, including the swipe gesture driven by real CDP touch input: mid-drag underlay + translate, commit flips read state and the Mark-N-read pill count; dock shortcuts; centered/large reader; share button
- Local E2E remains environmentally broken on main (see #236 note); CI is the arbiter
- New synced preference documented in `docs/data-schema.md`

## Memo status after this PR
All 10 findings shipped. Appendix leftovers (not included): `showMuted` dead flag decision, stale `docs/features/010` + `docs/code-map.md` refresh, unread-filter chips (candidate #11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ly8nB4xRWgfLYSKWn4qXMb