### PR TITLE
chore(release): v0.13.0 — version bump + release feed fixture

### DIFF
--- a/docs/features/010-mobile-navigation.md
+++ b/docs/features/010-mobile-navigation.md
@@ -1,34 +1,50 @@
 # Feature 010: Mobile Navigation
 
 ## Status
-Implemented
+Implemented (reader-as-overlay model, 2026-08)
 
 ## Summary
 
-On mobile devices (< 1024px viewport), FeedZero uses a single-panel navigation pattern with a Back button to navigate between views. The navigation follows a drill-down hierarchy: Feed List → Article List → Article Reader. The Back button respects user intent and does not auto-redirect to articles when the user explicitly navigates back.
+On mobile (< 1024px viewport) the article list fills the viewport and the reader is an **overlay layer** on top of it. Navigation is asymmetric by design: **tap goes in, swipe goes out**. Tapping an article mounts the reader layer (slides in from the right); an edge-swipe right (starting within ~28px of the left edge) follows the finger and dismisses it, as does the back pill. The list never horizontal-swipes into the reader and never unmounts while reading, so its scroll position survives the round trip. The URL stays the source of truth: the reader layer exists iff the route carries an `articleId`.
+
+This replaced two earlier models: the original drill-down-with-back-buttons, and a horizontal snap-x pager (list and reader as side-by-side panels). The pager made the two surfaces feel physically connected — a leftward swipe on the list dragged the reader in — which fought the swipe-right-to-mark-read row gesture and lost list scroll position (PR #237 feedback).
 
 ## Behaviour
 
 ```gherkin
 Feature: Mobile navigation
 
-  Rule: Back button navigates up the hierarchy
+  Rule: Tap goes in, swipe goes out
 
-  Scenario: Back from article shows article list
+  Scenario: Tap opens the reader overlay
+    Given the user is viewing an article list on mobile
+    When the user taps an article row
+    Then the reader layer slides in over the list
+    And the URL gains the articleId segment
+
+  Scenario: Edge-swipe dismisses the reader
+    Given the reader layer is open
+    When the user drags rightward starting at the left screen edge
+    Then the layer follows the finger
+    And releasing past a third of the screen width returns to the list
+    And the article list is unchanged (scroll position intact)
+
+  Scenario: Mid-screen swipes belong to the content
+    Given the reader layer is open
+    When the user drags starting away from the left edge
+    Then the reader does not dismiss
+
+  Scenario: The list cannot swipe into the reader
+    Given the user is viewing an article list on mobile
+    When the user swipes leftward on the list
+    Then no reader appears (rows own rightward swipe-to-mark-read;
+      nothing owns leftward)
+
+  Scenario: Back pill returns to the list without auto-redirect
     Given the user is viewing an article on mobile
-    When the user taps the Back button
+    When the user taps the back pill
     Then the article list is displayed
     And the user is not auto-redirected to an article
-
-  Scenario: Back from article list shows feed sidebar prompt
-    Given the user is viewing an article list on mobile
-    When the user taps the Back button
-    Then the user is navigated to /feeds
-    And a prompt to open the sidebar is shown
-
-  Scenario: Back button is hidden at root
-    Given the user is at the /feeds root on mobile
-    Then the Back button is not displayed
 
   Rule: Auto-select is suppressed after Back navigation
 
@@ -53,14 +69,14 @@ Feature: Mobile navigation
     Then the user stays on that URL (the reader shows its own empty state)
     And no automatic back-navigation occurs
 
-  Rule: Mobile layout is single-panel
+  Rule: The reader is a layer, not a sibling panel
 
-  Scenario: Mobile shows one content panel at a time
+  Scenario: Mobile shows the reader above the mounted list
     Given the user is on a mobile device (< 1024px)
     When viewing /feeds/:feedId/articles/:articleId
-    Then only the reader panel is visible
-    And the article list is not visible
-    And the sidebar is collapsed to offcanvas
+    Then the reader layer covers the viewport
+    And the article list stays mounted beneath it
+    And a deeplink to this URL shows the reader immediately
 
   Scenario: Desktop shows multi-panel layout
     Given the user is on a desktop device (>= 1024px)
@@ -73,8 +89,15 @@ Feature: Mobile navigation
   Scenario: Closed drawer surfaces recent feeds instead of the current feed name
     Given the user is on mobile with the bottom drawer closed
     Then the strip shows an anchored "All items" button
-    And the favicons of the most-recently-viewed feeds, newest first
+    And the favicons of the most-recently-viewed feeds in stable sidebar order
+    And fixed Explore and Settings shortcuts beside the chevron
     And it does not repeat the current feed name (the header already shows it)
+
+  Scenario: Dock slots never reorder under the thumb
+    Given the dock shows a set of feed favicons
+    When the user taps one of them
+    Then the dock's buttons keep their positions
+    And only viewing a feed from outside the dock swaps a slot
 
   Scenario: Tapping a dock favicon switches feed without opening the drawer
     Given the closed drawer dock shows a feed's favicon
@@ -90,22 +113,29 @@ Feature: Mobile navigation
 
 ## Architecture
 
-### Flow
+### Flow (closing the reader)
 
-1. User taps Back button in mobile header
-2. `handleBack()` sets `skipAutoSelectRef.current = true`
-3. Navigation occurs via `navigate()` to parent route
+1. User edge-swipes right on the reader layer (or taps the back pill)
+2. `closeReader()` sets `skipAutoSelectRef.current = true` and navigates
+   to the parent route (`/feeds/:feedId`)
+3. The reader layer unmounts (its existence is derived from `articleId`)
 4. Auto-select effect checks `skipAutoSelectRef` and skips if true
-5. Ref is reset only when user explicitly navigates to an article
+5. Ref is reset only when the user explicitly navigates to an article
+
+Gesture ownership map (mobile):
+- **List rows**: rightward drag → toggle read; vertical → scroll; leftward → nothing.
+- **Reader layer**: edge-zone rightward drag → dismiss; elsewhere → content scroll.
+- **Article list top**: downward overscroll → pull-to-refresh.
 
 ### Files
 
 | File | Role |
 |------|------|
-| `src/pages/feeds-route.tsx` | Mobile/desktop layout switching, scroll-snap nav, auto-select suppression, and the empty-stage→list fallback (present→absent transition guard) |
+| `src/pages/feeds-route.tsx` | Mobile branch renders `<main>` (list) + conditional `<MobileReaderLayer>`; auto-select suppression; empty-stage→list fallback (present→absent transition guard) |
+| `src/hooks/use-swipe-back.ts` | Edge-zone arming, finger-following `dragX`, commit past ⅓ width; non-passive touchmove for `preventDefault` |
 | `src/hooks/use-media-query.ts` | `useIsDesktop()` hook for responsive breakpoint detection |
-| `src/components/layout/mobile-nav-drawer.tsx` | Bottom drawer. Closed state = quick-switch favicon dock; open state = full feed list + Refresh/Settings footer |
-| `src/lib/recent-feeds.ts` | Pure `orderFeedsByRecency()` / `recordRecentFeed()` helpers + `MOBILE_DOCK_FEED_CAP` |
+| `src/components/layout/mobile-nav-drawer.tsx` | Bottom drawer. Closed state = quick-switch favicon dock + Explore/Settings shortcuts; open state = full feed list + Refresh/Settings footer |
+| `src/lib/recent-feeds.ts` | Pure `stableDockFeeds()` / `recordRecentFeed()` helpers + `MOBILE_DOCK_FEED_CAP` |
 | `src/stores/feed-store.ts` | Tracks `recentFeedIds` (device-local, persisted) — recorded in `selectFeed`, pruned in `removeFeed` |
 
 ### Tests
@@ -139,7 +169,7 @@ Test guards (Tier 2 structural): `tests/index-html-viewport.test.ts` (PWA meta t
 
 - **Ref-based skip flag** — Using a ref (`skipAutoSelectRef`) instead of state avoids re-renders while still persisting across the async article load cycle. The ref is reset only when `articleId` appears in the URL, ensuring the skip persists through multiple effect runs.
 
-- **Stack-based navigation** — Mobile navigation follows the standard iOS/Android pattern: Article → Article List → Feed List. This matches user mental models for drill-down interfaces.
+- **Reader as a layer, not a peer** — The snap-pager model made the list and reader feel like two connected panels; users read that as "swiping the list drags the reader in," which collided with row swipe-actions. A layer matches the iOS mental model (detail slides over master), frees every list gesture, and keeps the list mounted so scroll position is preserved for free. Entry is tap-only; exit is edge-swipe or back pill — asymmetric on purpose.
 
 - **Auto-select only on feed switch** — Auto-selecting the first article when switching feeds improves UX by showing content immediately. But auto-select is suppressed after Back navigation because the user explicitly wanted to see the article list (to pick a different article).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedzero",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Privacy-first RSS reader",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src/components/articles/article-list-controls.tsx
+++ b/src/components/articles/article-list-controls.tsx
@@ -140,7 +140,7 @@ export function MobileHeaderPills() {
   return (
     <div
       data-testid="mobile-header-pills"
-      className="flex items-center gap-2"
+      className="ml-auto flex items-center gap-2"
     >
       <ViewOptionsPill />
     </div>

--- a/src/components/articles/swipe-to-read-row.tsx
+++ b/src/components/articles/swipe-to-read-row.tsx
@@ -128,7 +128,13 @@ export function SwipeToReadRow({
     <div
       ref={rootRef}
       data-testid="swipe-to-read-row"
-      className="relative overflow-hidden"
+      // touch-pan-y: without it, real mobile browsers claim the drag as
+      // a native scroll after their own slop and stop dispatching
+      // touchmove — the arming logic loses the race on hardware even
+      // though synthetic-event tests pass. pan-y keeps vertical
+      // scrolling native and hands horizontal drags to JS. Safe now
+      // that no ancestor needs horizontal touch gestures on the list.
+      className="relative overflow-hidden touch-pan-y"
     >
       <div
         aria-hidden

--- a/src/components/layout/mobile-nav-drawer.tsx
+++ b/src/components/layout/mobile-nav-drawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 import { ChevronUp, Compass, Layers, RefreshCw, Settings } from "lucide-react";
 import { Drawer } from "vaul";
@@ -11,6 +11,7 @@ import { SidebarBody } from "@/components/layout/sidebar-body.tsx";
 import { NewFolderInput } from "@/components/sidebar/new-folder-input.tsx";
 import { AutoOrganizePill } from "@/components/folders/auto-organize-pill.tsx";
 import { goToSettings } from "@/lib/go-to-settings.ts";
+import { SyncStatusBadge } from "@/components/sync/sync-status-badge.tsx";
 
 interface MobileNavDrawerProps {
   onFeedSelect: (feedId: string) => void;
@@ -19,6 +20,26 @@ interface MobileNavDrawerProps {
 export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
+  // The strip's handle pill advertises "drag me up" — honor it: an
+  // upward-dominant drag on the strip opens the drawer (tapping the
+  // chevron still works). Tracked per-gesture so a horizontal scrub
+  // across the favicons doesn't trigger it.
+  const stripTouchRef = useRef<{ x: number; y: number } | null>(null);
+  function handleStripTouchStart(e: React.TouchEvent) {
+    const t = e.touches[0];
+    stripTouchRef.current = t ? { x: t.clientX, y: t.clientY } : null;
+  }
+  function handleStripTouchMove(e: React.TouchEvent) {
+    const start = stripTouchRef.current;
+    const t = e.touches[0];
+    if (!start || !t) return;
+    const dx = t.clientX - start.x;
+    const dy = t.clientY - start.y;
+    if (dy < -20 && Math.abs(dy) > Math.abs(dx)) {
+      stripTouchRef.current = null;
+      setOpen(true);
+    }
+  }
   const selectedFeedId = useFeedStore((s) => s.selectedFeedId);
   const feeds = useFeedStore((s) => s.feeds);
   const refreshAll = useFeedStore((s) => s.refreshAll);
@@ -62,6 +83,8 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
     <Drawer.Root open={open} onOpenChange={setOpen}>
       <div
         data-testid="drawer-handle-strip"
+        onTouchStart={handleStripTouchStart}
+        onTouchMove={handleStripTouchMove}
         // iOS safe-area clearance:
         //   pb-[env(safe-area-inset-bottom)] + matching h-[calc()] keeps the
         //   60px dock content area above the home indicator.
@@ -209,6 +232,12 @@ export function MobileNavDrawer({ onFeedSelect }: MobileNavDrawerProps) {
                 <Settings className="size-4 shrink-0 text-muted-foreground" />
                 Settings
               </button>
+              {/* Full refresh/sync status line — the mobile header only
+                  shows the color dot, the words live here next to the
+                  refresh control they describe. */}
+              <div className="px-2 pb-1">
+                <SyncStatusBadge onClick={() => setOpen(false)} />
+              </div>
             </div>
           </SidebarProvider>
         </Drawer.Content>

--- a/src/components/sync/sync-status-badge.tsx
+++ b/src/components/sync/sync-status-badge.tsx
@@ -51,7 +51,18 @@ const TICK_INTERVAL_MS = 30 * 1000;
 
 type DisplayState = "local-only" | "syncing" | "synced" | "error";
 
-export function SyncStatusBadge() {
+interface SyncStatusBadgeProps {
+  /**
+   * Dot-only rendering for the mobile header: the color carries the
+   * state, the full text stays in the accessible label, and the
+   * verbose "Refreshed X ago · mode" line lives in the drawer footer.
+   */
+  compact?: boolean;
+  /** Optional click hook (e.g. close the drawer before navigating). */
+  onClick?: () => void;
+}
+
+export function SyncStatusBadge({ compact = false, onClick }: SyncStatusBadgeProps = {}) {
   const status = useSyncStore((s) => s.status);
   const lastRefreshAllAt = useFeedStore((s) => s.lastRefreshAllAt);
   const isRefreshingAll = useFeedStore((s) => s.isRefreshingAll);
@@ -116,9 +127,11 @@ export function SyncStatusBadge() {
       data-testid="sync-status-badge"
       data-state={displayState}
       aria-label={`Cloud sync: ${label}`}
+      onClick={onClick}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
+        "inline-flex items-center gap-1.5 rounded-full text-xs font-medium",
         "hover:text-foreground transition-colors",
+        compact ? "p-2" : "px-2.5 py-1",
         tone,
       )}
     >
@@ -127,10 +140,14 @@ export function SyncStatusBadge() {
       ) : (
         <span
           aria-hidden
-          className={cn("size-1.5 rounded-full", dotColor)}
+          className={cn(
+            "rounded-full",
+            compact ? "size-2" : "size-1.5",
+            dotColor,
+          )}
         />
       )}
-      <span className="leading-none">{label}</span>
+      {!compact && <span className="leading-none">{label}</span>}
     </Link>
   );
 }

--- a/src/hooks/use-swipe-back.ts
+++ b/src/hooks/use-swipe-back.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+/** Width of the left-edge zone (px) where a back-swipe may begin. */
+const EDGE_ZONE = 28;
+/** Movement (px) before we decide whether the gesture is ours. */
+const ARM_SLOP = 10;
+/** Fallback commit distance when the element width is unknown. */
+const COMMIT_MIN = 96;
+
+interface Options {
+  ref: RefObject<HTMLElement | null>;
+  enabled: boolean;
+  onBack: () => void;
+}
+
+/**
+ * iOS-style edge-swipe-back for an overlay layer: a rightward drag that
+ * STARTS in the left edge zone follows the finger (`dragX`) and commits
+ * `onBack` when released past a third of the layer width. Drags starting
+ * anywhere else belong to the layer's content (vertical scroll,
+ * horizontally scrollable code blocks) and are never intercepted.
+ *
+ * touchmove is registered non-passive so an armed drag can
+ * preventDefault() browser panning — React's root touch listeners are
+ * passive, so this cannot be done with synthetic handlers.
+ */
+export function useSwipeBack({ ref, enabled, onBack }: Options): {
+  dragX: number;
+} {
+  const [dragX, setDragX] = useState(0);
+  const dragXRef = useRef(0);
+  const gestureRef = useRef<{
+    startX: number;
+    startY: number;
+    armed: boolean;
+    aborted: boolean;
+  } | null>(null);
+  const onBackRef = useRef(onBack);
+  onBackRef.current = onBack;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!enabled || !el) return;
+
+    function setDrag(value: number) {
+      dragXRef.current = value;
+      setDragX(value);
+    }
+
+    function handleStart(e: TouchEvent) {
+      const t = e.touches[0];
+      if (!t || t.clientX > EDGE_ZONE) {
+        gestureRef.current = null;
+        return;
+      }
+      gestureRef.current = {
+        startX: t.clientX,
+        startY: t.clientY,
+        armed: false,
+        aborted: false,
+      };
+    }
+
+    function handleMove(e: TouchEvent) {
+      const g = gestureRef.current;
+      const t = e.touches[0];
+      if (!g || g.aborted || !t) return;
+      const dx = t.clientX - g.startX;
+      const dy = t.clientY - g.startY;
+
+      if (!g.armed) {
+        if (Math.abs(dx) < ARM_SLOP && Math.abs(dy) < ARM_SLOP) return;
+        if (dx > 0 && dx > Math.abs(dy)) {
+          g.armed = true;
+        } else {
+          g.aborted = true;
+          return;
+        }
+      }
+
+      if (e.cancelable) e.preventDefault();
+      setDrag(Math.max(0, dx));
+    }
+
+    function handleEnd() {
+      const g = gestureRef.current;
+      gestureRef.current = null;
+      const width = el?.clientWidth ?? 0;
+      const threshold = width > 0 ? Math.min(COMMIT_MIN, width / 3) : COMMIT_MIN;
+      const commit = Boolean(g?.armed) && dragXRef.current >= threshold;
+      setDrag(0);
+      if (commit) onBackRef.current();
+    }
+
+    el.addEventListener("touchstart", handleStart, { passive: true });
+    el.addEventListener("touchmove", handleMove, { passive: false });
+    el.addEventListener("touchend", handleEnd);
+    el.addEventListener("touchcancel", handleEnd);
+    return () => {
+      el.removeEventListener("touchstart", handleStart);
+      el.removeEventListener("touchmove", handleMove);
+      el.removeEventListener("touchend", handleEnd);
+      el.removeEventListener("touchcancel", handleEnd);
+    };
+  }, [ref, enabled]);
+
+  return { dragX };
+}

--- a/src/hooks/use-swipe-back.ts
+++ b/src/hooks/use-swipe-back.ts
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 
-/** Width of the left-edge zone (px) where a back-swipe may begin. */
-const EDGE_ZONE = 28;
 /** Movement (px) before we decide whether the gesture is ours. */
 const ARM_SLOP = 10;
 /** Fallback commit distance when the element width is unknown. */
@@ -14,11 +12,15 @@ interface Options {
 }
 
 /**
- * iOS-style edge-swipe-back for an overlay layer: a rightward drag that
- * STARTS in the left edge zone follows the finger (`dragX`) and commits
- * `onBack` when released past a third of the layer width. Drags starting
- * anywhere else belong to the layer's content (vertical scroll,
- * horizontally scrollable code blocks) and are never intercepted.
+ * Swipe-back for an overlay layer: a rightward-dominant drag ANYWHERE
+ * on the layer follows the finger (`dragX`) and commits `onBack` when
+ * released past a third of the layer width.
+ *
+ * Deliberately not edge-gated: real mobile browsers run their own
+ * back-navigation gesture in the left edge zone, so an edge-only
+ * dismiss is unreachable on device. Vertical-dominant drags stay with
+ * the content scroller, and drags starting inside a `<pre>` are left
+ * alone so horizontally scrollable code blocks keep their native pan.
  *
  * touchmove is registered non-passive so an armed drag can
  * preventDefault() browser panning — React's root touch listeners are
@@ -49,7 +51,10 @@ export function useSwipeBack({ ref, enabled, onBack }: Options): {
 
     function handleStart(e: TouchEvent) {
       const t = e.touches[0];
-      if (!t || t.clientX > EDGE_ZONE) {
+      // Code blocks scroll horizontally; their pans are not back-swipes.
+      const inHorizontalScroller =
+        e.target instanceof Element && e.target.closest("pre") !== null;
+      if (!t || inHorizontalScroller) {
         gestureRef.current = null;
         return;
       }

--- a/src/pages/app-layout.tsx
+++ b/src/pages/app-layout.tsx
@@ -107,10 +107,13 @@ export function AppLayout() {
   if (!isDesktop) {
     return (
       <div className="flex flex-col h-dvh overflow-hidden bg-background">
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-3 z-10 bg-background">
+        <header className="flex h-12 shrink-0 items-center gap-1 border-b px-3 z-10 bg-background">
           <HeaderBreadcrumbs fallback={feedId ? "Articles" : "Feeds"} />
+          {/* Dot-only status: the verbose "Refreshed X ago · mode" line
+              lives in the drawer footer now; the single view-options
+              control anchors the right corner. */}
+          <SyncStatusBadge compact />
           <MobileHeaderPills />
-          <SyncStatusBadge />
         </header>
         <Outlet />
         <MobileNavDrawer onFeedSelect={handleFeedSelect} />

--- a/src/pages/feeds-route.tsx
+++ b/src/pages/feeds-route.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useCallback, lazy, Suspense } from "react";
+import { useEffect, useRef, lazy, Suspense, type ReactNode } from "react";
 import { useParams, useNavigate } from "react-router";
+import { useSwipeBack } from "@/hooks/use-swipe-back.ts";
 import { useFeedStore } from "@/stores/feed-store.ts";
 import { useArticleStore } from "@/stores/article-store.ts";
 import { useIsDesktop } from "@/hooks/use-media-query.ts";
@@ -24,10 +25,16 @@ const ExploreCatalog = lazy(() =>
  * The feeds surface: article list + reader pane.
  *
  * Desktop: inner ResizablePanelGroup [article-list | reader].
- * Mobile: horizontal scroll-snap container [list | reader].
+ * Mobile: the list fills the viewport; the reader is an OVERLAY LAYER
+ * on top of it whenever the URL carries an articleId. Tap goes in,
+ * edge-swipe-right (or the back pill) goes out — the list never
+ * horizontal-swipes into the reader and never unmounts, so its scroll
+ * position survives reading. (Replaces the earlier snap-x pager,
+ * which made the two panels feel physically connected and fought the
+ * row swipe-actions — user feedback on PR #237.)
  *
- * Drives article selection from URL params, auto-selects the first
- * article on desktop, and handles the mobile back-swipe gesture.
+ * Drives article selection from URL params and auto-selects the first
+ * article on desktop.
  *
  * When the user has no feeds, redirects to /explore — the empty state
  * for "feeds" is the catalog itself.
@@ -60,25 +67,6 @@ export function FeedsRoute() {
   // loads when the effect re-fires for the same param.
   const loadedFeedRef = useRef<string | null>(null);
 
-  // Scroll-snap container ref (mobile only)
-  const snapContainerRef = useRef<HTMLDivElement>(null);
-  const programmaticScrollRef = useRef(false);
-
-  const scrollToReader = useCallback(() => {
-    const el = snapContainerRef.current;
-    if (!el) return;
-    programmaticScrollRef.current = true;
-    el.scrollTo({ left: el.clientWidth, behavior: "smooth" });
-  }, []);
-
-  const scrollToList = useCallback(() => {
-    const el = snapContainerRef.current;
-    if (!el) return;
-    programmaticScrollRef.current = true;
-    skipAutoSelectRef.current = true;
-    el.scrollTo({ left: 0, behavior: "smooth" });
-  }, []);
-
   // Feed switch: select feed and start loading when feedId changes
   useEffect(() => {
     if (!feedId || feedId === loadedFeedRef.current) return;
@@ -86,10 +74,6 @@ export function FeedsRoute() {
     lastSyncedArticleIdRef.current = undefined;
     selectFeed(feedId);
     selectArticle(null);
-    // On mobile, if the reader panel is visible (container scrolled right),
-    // snap back to the article list so the user lands on panel 1 for the
-    // new feed.
-    if (snapContainerRef.current?.scrollLeft) scrollToList();
     loadArticles(feedId).then(() => {
       // Only auto-select the first article on desktop, where the 3-panel
       // layout would otherwise show an empty reader pane. On mobile the
@@ -103,7 +87,7 @@ export function FeedsRoute() {
         });
       }
     });
-  }, [feedId, selectFeed, selectArticle, loadArticles, articleId, navigate, isDesktop, scrollToList]);
+  }, [feedId, selectFeed, selectArticle, loadArticles, articleId, navigate, isDesktop]);
 
   // Article sync + auto-select. Waits until loading completes, then either
   // syncs articleId from URL or auto-selects the first article on desktop.
@@ -148,49 +132,8 @@ export function FeedsRoute() {
     if (!viewedArticlePresentRef.current) return;
     viewedArticlePresentRef.current = false;
     skipAutoSelectRef.current = true;
-    scrollToList();
     navigate(`/feeds/${feedId}`, { replace: true });
-  }, [isDesktop, feedId, articleId, articles, isLoadingArticles, navigate, scrollToList]);
-
-  // Scroll to the reader panel when the user explicitly navigates to an article.
-  // snapScrollMountedRef skips the initial render so loading the app with an
-  // articleId already in the URL lands on the article list, not the reader.
-  // Depending only on articleId means a desktop→mobile viewport transition
-  // never fires this scroll.
-  const snapScrollMountedRef = useRef(false);
-  useEffect(() => {
-    if (!snapScrollMountedRef.current) {
-      snapScrollMountedRef.current = true;
-      return;
-    }
-    if (!isDesktop && articleId && feedId) {
-      requestAnimationFrame(() => scrollToReader());
-    }
-    // isDesktop intentionally excluded: viewport changes should not trigger scroll.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [articleId]);
-
-  // Detect user-initiated swipe-back via scrollend. When the user swipes
-  // from the reader panel back to the list, drop the articleId from the URL
-  // so the back navigation is reflected in history.
-  useEffect(() => {
-    const el = snapContainerRef.current;
-    if (!el || isDesktop) return;
-
-    function handleScrollEnd() {
-      if (programmaticScrollRef.current) {
-        programmaticScrollRef.current = false;
-        return;
-      }
-      if (el!.scrollLeft < el!.clientWidth / 2 && articleId && feedId) {
-        skipAutoSelectRef.current = true;
-        navigate(`/feeds/${feedId}`, { replace: true });
-      }
-    }
-
-    el.addEventListener("scrollend", handleScrollEnd);
-    return () => el.removeEventListener("scrollend", handleScrollEnd);
-  }, [isDesktop, articleId, feedId, navigate]);
+  }, [isDesktop, feedId, articleId, articles, isLoadingArticles, navigate]);
 
   function handleArticleSelect(article: { id: string }) {
     if (!feedId) return;
@@ -219,32 +162,30 @@ export function FeedsRoute() {
   }
 
   if (!isDesktop) {
+    const closeReader = () => {
+      skipAutoSelectRef.current = true;
+      navigate(`/feeds/${feedId}`);
+    };
     return (
-      <div
-        ref={snapContainerRef}
-        className="flex flex-1 min-h-0 overflow-x-auto snap-x snap-mandatory"
-        style={{ scrollbarWidth: "none", WebkitOverflowScrolling: "touch" }}
-      >
-        {/* Panel 1: Article list — owns its own scroll for virtualization */}
-        <main role="main" className="shrink-0 w-full snap-start">
+      <div className="relative flex-1 min-h-0 overflow-hidden">
+        {/* The list fills the viewport and stays mounted while reading,
+            so its scroll position survives the round trip. */}
+        <main role="main" className="h-full">
           <ArticleList onArticleSelect={handleArticleSelect} />
         </main>
 
-        {/* Panel 2: Reader — ReaderPanel owns its own scroll and nav bar */}
-        <div
-          data-testid="reader-scroll-mobile"
-          className="shrink-0 w-full snap-start h-full"
-        >
-          <ReaderPanel
-            nextArticle={nextArticle}
-            prevArticle={prevArticle}
-            onNavigate={handleArticleSelect}
-            onBack={articleId ? () => {
-              scrollToList();
-              navigate(`/feeds/${feedId}`);
-            } : undefined}
-          />
-        </div>
+        {articleId && feedId && (
+          <MobileReaderLayer onBack={closeReader}>
+            <div data-testid="reader-scroll-mobile" className="h-full">
+              <ReaderPanel
+                nextArticle={nextArticle}
+                prevArticle={prevArticle}
+                onNavigate={handleArticleSelect}
+                onBack={closeReader}
+              />
+            </div>
+          </MobileReaderLayer>
+        )}
       </div>
     );
   }
@@ -277,5 +218,36 @@ export function FeedsRoute() {
         />
       </ResizablePanel>
     </ResizablePanelGroup>
+  );
+}
+
+/**
+ * Full-viewport layer hosting the mobile reader above the article
+ * list. Slides in from the right on mount; an edge-swipe-right drag
+ * follows the finger and dismisses via `onBack` (the same exit the
+ * back pill uses), snapping back if released early.
+ */
+function MobileReaderLayer({
+  onBack,
+  children,
+}: {
+  onBack: () => void;
+  children: ReactNode;
+}) {
+  const layerRef = useRef<HTMLDivElement>(null);
+  const { dragX } = useSwipeBack({ ref: layerRef, enabled: true, onBack });
+
+  return (
+    <div
+      ref={layerRef}
+      data-testid="reader-layer"
+      className="absolute inset-0 z-20 bg-background animate-in slide-in-from-right duration-200"
+      style={{
+        transform: dragX > 0 ? `translateX(${dragX}px)` : undefined,
+        transition: dragX === 0 ? "transform 150ms ease-out" : "none",
+      }}
+    >
+      {children}
+    </div>
   );
 }

--- a/src/pages/feeds-route.tsx
+++ b/src/pages/feeds-route.tsx
@@ -241,7 +241,11 @@ function MobileReaderLayer({
     <div
       ref={layerRef}
       data-testid="reader-layer"
-      className="absolute inset-0 z-20 bg-background animate-in slide-in-from-right duration-200"
+      // touch-pan-y hands horizontal drags to the back-swipe hook on
+      // real hardware (browsers otherwise claim them as scrolls);
+      // <pre> re-enables native panning for wide code blocks, matching
+      // the hook's own pre-guard.
+      className="absolute inset-0 z-20 bg-background animate-in slide-in-from-right duration-200 touch-pan-y [&_pre]:touch-auto"
       style={{
         transform: dragX > 0 ? `translateX(${dragX}px)` : undefined,
         transition: dragX === 0 ? "transform 150ms ease-out" : "none",

--- a/tests/components/articles/article-list-controls.test.tsx
+++ b/tests/components/articles/article-list-controls.test.tsx
@@ -39,6 +39,9 @@ vi.mock("@/core/storage/db.ts", () => ({
   getSmartFilters: vi.fn().mockResolvedValue({ ok: true, value: [] }),
   getArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
   getAllArticles: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+  // Selecting a sort mode persists through the preferences row.
+  getPreferences: vi.fn().mockResolvedValue({ ok: true, value: null }),
+  putPreferences: vi.fn().mockResolvedValue({ ok: true, value: true }),
 }));
 
 vi.mock("@/core/sync/sync-service", () => ({

--- a/tests/components/articles/swipe-to-read-row.test.tsx
+++ b/tests/components/articles/swipe-to-read-row.test.tsx
@@ -153,6 +153,17 @@ describe("SwipeToReadRow", () => {
     expect(useArticleStore.getState().articles[0].read).toBe(false);
   });
 
+  it("declares touch-action pan-y so real browsers hand horizontal drags to JS", () => {
+    // Without touch-action, mobile browsers claim the drag as a scroll
+    // after their own slop and stop dispatching touchmove — the arming
+    // logic loses the race on real hardware even though synthetic-event
+    // tests pass. pan-y keeps vertical scrolling native and horizontal
+    // gestures ours. Safe now that the snap pager no longer needs
+    // leftward drags on the list.
+    const row = renderRow(false);
+    expect(row.className).toContain("touch-pan-y");
+  });
+
   it("renders children without gesture chrome when disabled (desktop)", () => {
     const a = seed(false);
     render(

--- a/tests/components/layout/feeds-page-layout.test.tsx
+++ b/tests/components/layout/feeds-page-layout.test.tsx
@@ -595,11 +595,26 @@ describe("FeedsPage layout — mobile", () => {
     }
   });
 
-  it("mobile reader snap panel delegates to ReaderPanel (no overflow-y-auto on the wrapper)", () => {
-    // ReaderPanel now owns its own scroll container and nav bar. The outer snap
-    // panel is a geometry wrapper only — it must not double-scroll.
+  it("mobile reader overlay delegates to ReaderPanel (no overflow-y-auto on the wrapper)", () => {
+    // ReaderPanel owns its own scroll container and nav bar. The overlay
+    // wrapper is a geometry layer only — it must not double-scroll. It
+    // mounts only while an article is open (reader-as-overlay model).
+    const article = {
+      id: "a1",
+      feedId: "f1",
+      guid: "a1",
+      title: "Article",
+      link: "https://example.com/a1",
+      content: "<p>c</p>",
+      summary: "",
+      author: "",
+      read: false,
+      publishedAt: Date.now(),
+      createdAt: Date.now(),
+    };
     useFeedStore.setState({ feeds: [defaultFeed], selectedFeedId: "f1" });
-    const { container } = renderPage("/feeds/f1");
+    useArticleStore.setState({ articles: [article], selectedArticle: article });
+    const { container } = renderPage("/feeds/f1/articles/a1");
     const reader = container.querySelector('[data-testid="reader-scroll-mobile"]');
     expect(reader).not.toBeNull();
     expect((reader as HTMLElement).className).not.toContain("overflow-y-auto");

--- a/tests/components/layout/mobile-nav-drawer.test.tsx
+++ b/tests/components/layout/mobile-nav-drawer.test.tsx
@@ -217,6 +217,32 @@ describe("MobileNavDrawer", () => {
       }
     });
 
+    it("swiping up on the dock strip opens the drawer (the handle pill advertises it)", async () => {
+      useFeedStore.setState({ feeds: [makeFeed("f1", "Feed 1")] });
+      renderDrawer();
+      const strip = screen.getByTestId("drawer-handle-strip");
+
+      const touch = (type: string, y: number) =>
+        strip.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches:
+              type === "touchend"
+                ? []
+                : [new Touch({ identifier: 1, target: strip, clientX: 200, clientY: y })],
+          }),
+        );
+
+      touch("touchstart", 800);
+      touch("touchmove", 760);
+      touch("touchend", 760);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("drawer-content")).toBeInTheDocument();
+      });
+    });
+
     it("has a fixed Explore shortcut that navigates without opening the drawer", async () => {
       const user = userEvent.setup();
       useFeedStore.setState({ feeds: [makeFeed("f1", "Feed 1")] });
@@ -244,6 +270,20 @@ describe("MobileNavDrawer", () => {
       expect(screen.getByTestId("probe-path")).toHaveTextContent("/settings");
       expect(screen.queryByTestId("drawer-content")).toBeNull();
     });
+  });
+
+  it("drawer footer carries the full 'Refreshed X ago' status (moved out of the header)", async () => {
+    const user = userEvent.setup();
+    useFeedStore.setState({
+      feeds: [makeFeed("f1", "Feed 1")],
+      lastRefreshAllAt: Date.now() - 5 * 60 * 1000,
+    });
+    renderDrawer();
+
+    await user.click(screen.getByRole("button", { name: /open feed list/i }));
+
+    const drawer = await screen.findByTestId("drawer-content");
+    expect(within(drawer).getByText(/refreshed .* ago/i)).toBeInTheDocument();
   });
 
   it("renders 'All items' entry when drawer is open and there are feeds", async () => {

--- a/tests/components/sync/sync-status-badge.test.tsx
+++ b/tests/components/sync/sync-status-badge.test.tsx
@@ -46,6 +46,34 @@ describe("SyncStatusBadge", () => {
     vi.useRealTimers();
   });
 
+  describe("compact mode (mobile header)", () => {
+    it("renders the color dot only — no text label", () => {
+      useSyncStore.setState({ status: "local-only" });
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 5 * 60 * 1000 });
+      render(
+        <MemoryRouter>
+          <SyncStatusBadge compact />
+        </MemoryRouter>,
+      );
+      const badge = screen.getByTestId("sync-status-badge");
+      expect(badge.textContent).toBe("");
+      expect(screen.queryByText(/refreshed/i)).toBeNull();
+    });
+
+    it("keeps the full status in the accessible label", () => {
+      useSyncStore.setState({ status: "local-only" });
+      useFeedStore.setState({ lastRefreshAllAt: Date.now() - 5 * 60 * 1000 });
+      render(
+        <MemoryRouter>
+          <SyncStatusBadge compact />
+        </MemoryRouter>,
+      );
+      expect(
+        screen.getByLabelText(/refreshed 5 min ago · local/i),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("idle states", () => {
     it("shows just 'Local' when local-only with no refresh history", () => {
       useSyncStore.setState({ status: "local-only", lastSyncedAt: null });

--- a/tests/fixtures/release-feed.xml
+++ b/tests/fixtures/release-feed.xml
@@ -3,12 +3,48 @@
   <title>FeedZero Release Notes</title>
   <subtitle>What changed in FeedZero.</subtitle>
   <id>feedzero:changelog</id>
-  <updated>2026-05-31T12:00:00Z</updated>
+  <updated>2026-08-02T12:00:00Z</updated>
   <link rel="self" href="https://feedzero.app/releases.xml" />
   <link rel="alternate" type="text/html" href="https://feedzero.app/#releases" />
   <author>
     <name>FeedZero</name>
   </author>
+  <entry>
+    <id>feedzero:release:0.13.0</id>
+    <title>v0.13.0: Mobile reading rebuilt around gestures</title>
+    <link rel="alternate" href="https://feedzero.app/#releases" />
+    <published>2026-08-02T12:00:00Z</published>
+    <updated>2026-08-02T12:00:00Z</updated>
+    <summary>The reader opens as a layer over the article list, rows swipe to mark read, lists pull to refresh, and mark-all-read can be undone. Reader text size is now adjustable, and expired license tokens explain themselves.</summary>
+    <content type="html"><![CDATA[<p>The reader opens as a layer over the article list, rows swipe to mark read, lists pull to refresh, and mark-all-read can be undone. Reader text size is now adjustable, and expired license tokens explain themselves.</p>
+<h3>Added</h3>
+<ul>
+  <li>Added pull-to-refresh to the article list on mobile. Dragging down from the top refreshes the current view, scoped the same way the refresh control is: a single feed refreshes only that feed, a folder only its members, and an aggregated view every feed.</li>
+  <li>Added swipe-to-mark-read on mobile. Swiping an article row to the right toggles it between read and unread, with a coloured underlay showing which action will commit.</li>
+  <li>Added an undo action to mark-all-read. Marking a view read now shows a toast that restores exactly the articles it touched, from both the floating pill and the command palette.</li>
+  <li>Added a keyboard shortcuts overlay on <code>?</code>. The command palette advertised the shortcut previously without implementing it. The overlay and the list in Settings now render from one source, so they cannot drift apart.</li>
+  <li>Added a share button to the reader. It opens the system share sheet where the browser provides one and copies the link otherwise.</li>
+  <li>Added a reader text size preference with small, medium, and large options in Settings, stored in the encrypted vault and synced across devices.</li>
+  <li>Added Explore and Settings shortcuts to the mobile dock strip, and an upward swipe on the strip now opens the feed drawer.</li>
+  <li>Added loading skeletons for the article list and for Explore, Signal, Stats, and Settings, which previously rendered blank while loading.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+  <li>Rebuilt mobile navigation around the reader as a layer over the article list. Tapping an article opens it, and swiping right or using the back control closes it. The article list stays in place underneath, so returning from an article keeps your scroll position. Swiping the list itself no longer drags the reader in, which frees horizontal swipes for row actions.</li>
+  <li>Consolidated the mobile header into a single view-options menu holding sort order and the settings entry for the current feed, folder, or filter. Refresh moved to the pull-to-refresh gesture and the drawer, and the refresh status line moved into the drawer beside it, leaving a colour dot in the header.</li>
+  <li>Made unread counts visible on mobile, where the badges were previously hidden, and added an aggregate unread count to folder rows.</li>
+  <li>Centred the reader column on wide screens, which previously left text against the left edge with empty space beside it.</li>
+  <li>Increased interactive controls to a 44 pixel touch target across the mobile interface without changing how they look.</li>
+  <li>Stopped the mobile dock reordering its feed shortcuts on every tap. Recently viewed feeds still decide which shortcuts appear, but their positions now follow the sidebar order and stay put.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+  <li>Fixed an expired license token reporting raw timestamps on activation. The error now names the expiry date and links to email recovery, and a token rejected for a clock mismatch or a truncated copy says so.</li>
+  <li>Fixed toasts covering the mobile navigation dock.</li>
+  <li>Fixed toasts ignoring the selected theme and always rendering dark.</li>
+</ul>]]></content>
+    <author><name>FeedZero</name></author>
+  </entry>
   <entry>
     <id>feedzero:release:0.12.0</id>
     <title>v0.12.0: Paywall false-positive fix and automatic TLS for LAN self-hosts</title>

--- a/tests/pages/feeds-page-behavior.test.tsx
+++ b/tests/pages/feeds-page-behavior.test.tsx
@@ -582,57 +582,53 @@ describe("FeedsPage behavior — mobile", () => {
     });
   });
 
-  it("does NOT scroll to reader on initial mobile load with articleId in URL", async () => {
-    // When the URL contains an articleId on initial load (e.g. user resized from
-    // desktop or opened a bookmarked article URL), the snap container must stay
-    // at position 0 (article list). The scroll-to-reader effect must only fire
-    // when the user explicitly selects an article — not on mount.
+  // ── Reader-as-overlay model ─────────────────────────────────────────
+  // The mobile reader is a LAYER over the article list, not a sibling
+  // snap-pager panel. The old snap-x model made the list feel physically
+  // connected to the reader — swiping left on the list dragged the reader
+  // in, which fought row swipe-actions and misread the mental model
+  // (user feedback on PR #237): tap goes IN, swipe goes OUT, and the
+  // list underneath never moves or unmounts.
+
+  it("mobile: reader renders as an overlay only when an article is open; the list stays mounted beneath", () => {
     useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
-    useArticleStore.setState({ articles: [makeArticle("art-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
 
-    // Spy on HTMLElement.prototype.scrollTo to capture scroll-left calls
-    const snapScrollCalls: number[] = [];
-    const origScrollTo = HTMLElement.prototype.scrollTo;
-    HTMLElement.prototype.scrollTo = function (optionsOrX?: ScrollToOptions | number) {
-      const left = typeof optionsOrX === "number"
-        ? optionsOrX
-        : (optionsOrX as ScrollToOptions)?.left ?? 0;
-      if ((this as HTMLElement).classList?.contains("snap-x")) {
-        snapScrollCalls.push(left);
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (origScrollTo as any).call(this, optionsOrX);
-    };
+    const closed = renderPage("/feeds/feed-1");
+    expect(closed.container.querySelector("[data-testid='reader-layer']")).toBeNull();
+    closed.unmount();
 
-    renderPage("/feeds/feed-1/articles/art-1");
-    // Wait for any requestAnimationFrame callbacks to settle
-    await new Promise((r) => setTimeout(r, 50));
-
-    HTMLElement.prototype.scrollTo = origScrollTo;
-
-    // scrollTo with left > 0 should NOT have been called on the snap container
-    expect(snapScrollCalls.filter((l) => l > 0)).toHaveLength(0);
+    const open = renderPage("/feeds/feed-1/articles/art-1");
+    expect(open.container.querySelector("[data-testid='reader-layer']")).not.toBeNull();
+    // The list is still in the DOM underneath — scroll position survives.
+    expect(open.container.querySelector("[role='main']")).not.toBeNull();
   });
 
-  it("navigating to a different feed scrolls the snap container back to the article list", async () => {
-    // If the user is on the reader panel (panel 2) and navigates to a different
-    // feed, the snap container must scroll back to panel 1 (article list).
-    // Without this, the reader shows empty state for the new feed.
-    useFeedStore.setState({ feeds: [makeFeed("feed-1"), makeFeed("feed-2")] });
-    useArticleStore.setState({ articles: [makeArticle("art-1")], selectedArticle: makeArticle("art-1") });
+  it("mobile: the horizontal snap pager is gone — the list cannot swipe into the reader", () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    const { container } = renderPage("/feeds/feed-1");
+    expect(container.querySelector(".snap-x")).toBeNull();
+  });
 
-    const snapScrollToLeft: number[] = [];
-    const origScrollTo = HTMLElement.prototype.scrollTo;
-    HTMLElement.prototype.scrollTo = function (optionsOrX?: ScrollToOptions | number) {
-      const left = typeof optionsOrX === "number"
-        ? optionsOrX
-        : (optionsOrX as ScrollToOptions)?.left ?? 0;
-      if ((this as HTMLElement).classList?.contains("snap-x")) {
-        snapScrollToLeft.push(left);
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (origScrollTo as any).call(this, optionsOrX);
-    };
+  it("mobile: a deeplink with articleId shows the reader overlay immediately", () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
+    const { container } = renderPage("/feeds/feed-1/articles/art-1");
+    expect(container.querySelector("[data-testid='reader-layer']")).not.toBeNull();
+  });
+
+  it("mobile: navigating to a different feed closes the reader overlay", async () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1"), makeFeed("feed-2")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
 
     const user = userEvent.setup();
     const { container } = render(
@@ -646,18 +642,86 @@ describe("FeedsPage behavior — mobile", () => {
         </Routes>
       </MemoryRouter>
     );
-
-    // Simulate snap container being at panel 2
-    const snapEl = container.querySelector(".snap-x") as HTMLElement;
-    if (snapEl) Object.defineProperty(snapEl, "scrollLeft", { value: 400, writable: true });
+    expect(container.querySelector("[data-testid='reader-layer']")).not.toBeNull();
 
     await user.click(screen.getByTestId("nav-to-go-feed-2"));
 
-    HTMLElement.prototype.scrollTo = origScrollTo;
+    await waitFor(() => {
+      expect(container.querySelector("[data-testid='reader-layer']")).toBeNull();
+    });
+  });
+
+  it("mobile: edge-swipe right dismisses the reader back to the list", async () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    // Keep the article present through loadArticles, otherwise the
+    // vanished-article guard navigates back on its own and this test
+    // would pass without the gesture doing anything.
+    vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [makeArticle("art-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
+    const { container } = renderPage("/feeds/feed-1/articles/art-1");
+    const layer = container.querySelector(
+      "[data-testid='reader-layer']",
+    ) as HTMLElement;
+
+    const touch = (type: string, x: number) =>
+      act(() => {
+        layer.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches:
+              type === "touchend"
+                ? []
+                : [new Touch({ identifier: 1, target: layer, clientX: x, clientY: 300 })],
+          }),
+        );
+      });
+
+    touch("touchstart", 8); // within the left edge zone
+    touch("touchmove", 80);
+    touch("touchmove", 180);
+    touch("touchend", 180);
 
     await waitFor(() => {
-      expect(snapScrollToLeft.filter((l) => l === 0)).toHaveLength(1);
+      expect(currentUrl).toBe("/feeds/feed-1");
     });
+  });
+
+  it("mobile: a swipe starting away from the edge does not dismiss the reader", async () => {
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [makeArticle("art-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
+    const { container } = renderPage("/feeds/feed-1/articles/art-1");
+    const layer = container.querySelector(
+      "[data-testid='reader-layer']",
+    ) as HTMLElement;
+
+    const touch = (type: string, x: number) =>
+      act(() => {
+        layer.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches:
+              type === "touchend"
+                ? []
+                : [new Touch({ identifier: 1, target: layer, clientX: x, clientY: 300 })],
+          }),
+        );
+      });
+
+    touch("touchstart", 150); // mid-screen — content owns this drag
+    touch("touchmove", 260);
+    touch("touchend", 260);
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(currentUrl).toBe("/feeds/feed-1/articles/art-1");
   });
 
   it("mobile header does not have a sidebar trigger (replaced by bottom drawer)", () => {

--- a/tests/pages/feeds-page-behavior.test.tsx
+++ b/tests/pages/feeds-page-behavior.test.tsx
@@ -690,7 +690,46 @@ describe("FeedsPage behavior — mobile", () => {
     });
   });
 
-  it("mobile: a swipe starting away from the edge does not dismiss the reader", async () => {
+  it("mobile: a rightward drag anywhere on the reader dismisses it (browsers own the edge)", async () => {
+    // Real mobile browsers run their OWN back gesture in the left edge
+    // zone, so an edge-only dismiss is unreachable on device. Any
+    // rightward-dominant drag on the reader goes back (Reeder model).
+    useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
+    vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [makeArticle("art-1")] });
+    useArticleStore.setState({
+      articles: [makeArticle("art-1")],
+      selectedArticle: makeArticle("art-1"),
+    });
+    const { container } = renderPage("/feeds/feed-1/articles/art-1");
+    const layer = container.querySelector(
+      "[data-testid='reader-layer']",
+    ) as HTMLElement;
+
+    const touch = (type: string, x: number, y = 300) =>
+      act(() => {
+        layer.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches:
+              type === "touchend"
+                ? []
+                : [new Touch({ identifier: 1, target: layer, clientX: x, clientY: y })],
+          }),
+        );
+      });
+
+    touch("touchstart", 180); // mid-screen
+    touch("touchmove", 260);
+    touch("touchmove", 340);
+    touch("touchend", 340);
+
+    await waitFor(() => {
+      expect(currentUrl).toBe("/feeds/feed-1");
+    });
+  });
+
+  it("mobile: a vertical-dominant drag does not dismiss the reader", async () => {
     useFeedStore.setState({ feeds: [makeFeed("feed-1")] });
     vi.mocked(db.getArticles).mockResolvedValue({ ok: true, value: [makeArticle("art-1")] });
     useArticleStore.setState({
@@ -716,12 +755,40 @@ describe("FeedsPage behavior — mobile", () => {
         );
       });
 
-    touch("touchstart", 150); // mid-screen — content owns this drag
-    touch("touchmove", 260);
-    touch("touchend", 260);
+    touch("touchstart", 150);
+    act(() => {
+      layer.dispatchEvent(
+        new TouchEvent("touchmove", {
+          bubbles: true,
+          cancelable: true,
+          touches: [new Touch({ identifier: 1, target: layer, clientX: 190, clientY: 460 })],
+        }),
+      );
+    });
+    touch("touchend", 190);
 
     await new Promise((r) => setTimeout(r, 30));
     expect(currentUrl).toBe("/feeds/feed-1/articles/art-1");
+  });
+
+  it("mobile header: dot-only status indicator, view options pinned to the right corner", () => {
+    // "Refreshed X ago · local" moved into the drawer footer; the header
+    // keeps a compact color dot and puts the single view-options control
+    // in the right corner (user feedback on PR #237).
+    useFeedStore.setState({
+      feeds: [makeFeed("feed-1")],
+      lastRefreshAllAt: Date.now() - 5 * 60 * 1000,
+    });
+    const { container } = renderPage("/feeds/feed-1");
+    const header = container.querySelector("header")!;
+
+    expect(header.textContent).not.toMatch(/refreshed/i);
+    expect(
+      header.querySelector("[data-testid='sync-status-badge']"),
+    ).not.toBeNull();
+    const pills = header.querySelector("[data-testid='mobile-header-pills']");
+    expect(pills).not.toBeNull();
+    expect(header.lastElementChild).toBe(pills);
   });
 
   it("mobile header does not have a sidebar trigger (replaced by bottom drawer)", () => {


### PR DESCRIPTION
App half of the **0.13.0** release. Stacked on `ux/batch-two` (#237) because the release notes describe that work.

## Contents
- `package.json` → 0.13.0
- `tests/fixtures/release-feed.xml` → regenerated feed from landing PR forcingfx/feedzero-landing#25

## Merge order

```
#235  dependabot (clears the npm-audit red on every other PR)
#236  ux/batch-one
#237  ux/batch-two          ← this PR retargets to main once #237 lands
landing#25                   ← BEFORE the app, so releases.xml exists
THIS PR                      ← then tag v0.13.0
#239  license expiry UX      ┐ independent of the release; merge any time
#240  SDLC quality gates     ┘
```

Tagging `v0.13.0` after merge triggers `.github/workflows/docker-publish.yml`, which pushes to ghcr.io and mirrors to Docker Hub. **Tag after the bump is on main**, not before — v0.11.0 was tagged ahead of its bump and the published image reported 0.9.0.

## Note on the release skill
`.claude/skills/new-release` documents the commit message `release: bump version to <VERSION>`, but this repo's commit-msg hook rejects `release:` (allowed types: feat, fix, chore, refactor, docs, test, ci, build, perf, style, revert). Used `chore(release):`. Worth correcting in the skill — the landing repo accepts `release:`, which is probably where the wording came from.

## Verification
`npm test` 3791 passed; the parser contract test parses the new fixture; the version-sync guard agrees bump ↔ notes.