### PR TITLE
release: v0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feedzero",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feedzero",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedzero",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Privacy-first RSS reader",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/tests/fixtures/release-feed.xml
+++ b/tests/fixtures/release-feed.xml
@@ -3,12 +3,48 @@
   <title>FeedZero Release Notes</title>
   <subtitle>What changed in FeedZero.</subtitle>
   <id>feedzero:changelog</id>
-  <updated>2026-05-31T12:00:00Z</updated>
+  <updated>2026-08-02T12:00:00Z</updated>
   <link rel="self" href="https://feedzero.app/releases.xml" />
   <link rel="alternate" type="text/html" href="https://feedzero.app/#releases" />
   <author>
     <name>FeedZero</name>
   </author>
+  <entry>
+    <id>feedzero:release:0.13.0</id>
+    <title>v0.13.0: Mobile reading rebuilt around gestures</title>
+    <link rel="alternate" href="https://feedzero.app/#releases" />
+    <published>2026-08-02T12:00:00Z</published>
+    <updated>2026-08-02T12:00:00Z</updated>
+    <summary>The reader opens as a layer over the article list, rows swipe to mark read, lists pull to refresh, and mark-all-read can be undone. Reader text size is now adjustable, and expired license tokens explain themselves.</summary>
+    <content type="html"><![CDATA[<p>The reader opens as a layer over the article list, rows swipe to mark read, lists pull to refresh, and mark-all-read can be undone. Reader text size is now adjustable, and expired license tokens explain themselves.</p>
+<h3>Added</h3>
+<ul>
+  <li>Added pull-to-refresh to the article list on mobile. Dragging down from the top refreshes the current view, scoped the same way the refresh control is: a single feed refreshes only that feed, a folder only its members, and an aggregated view every feed.</li>
+  <li>Added swipe-to-mark-read on mobile. Swiping an article row to the right toggles it between read and unread, with a coloured underlay showing which action will commit.</li>
+  <li>Added an undo action to mark-all-read. Marking a view read now shows a toast that restores exactly the articles it touched, from both the floating pill and the command palette.</li>
+  <li>Added a keyboard shortcuts overlay on <code>?</code>. The command palette advertised the shortcut previously without implementing it. The overlay and the list in Settings now render from one source, so they cannot drift apart.</li>
+  <li>Added a share button to the reader. It opens the system share sheet where the browser provides one and copies the link otherwise.</li>
+  <li>Added a reader text size preference with small, medium, and large options in Settings, stored in the encrypted vault and synced across devices.</li>
+  <li>Added Explore and Settings shortcuts to the mobile dock strip, and an upward swipe on the strip now opens the feed drawer.</li>
+  <li>Added loading skeletons for the article list and for Explore, Signal, Stats, and Settings, which previously rendered blank while loading.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+  <li>Rebuilt mobile navigation around the reader as a layer over the article list. Tapping an article opens it, and swiping right or using the back control closes it. The article list stays in place underneath, so returning from an article keeps your scroll position. Swiping the list itself no longer drags the reader in, which frees horizontal swipes for row actions.</li>
+  <li>Consolidated the mobile header into a single view-options menu holding sort order and the settings entry for the current feed, folder, or filter. Refresh moved to the pull-to-refresh gesture and the drawer, and the refresh status line moved into the drawer beside it, leaving a colour dot in the header.</li>
+  <li>Made unread counts visible on mobile, where the badges were previously hidden, and added an aggregate unread count to folder rows.</li>
+  <li>Centred the reader column on wide screens, which previously left text against the left edge with empty space beside it.</li>
+  <li>Increased interactive controls to a 44 pixel touch target across the mobile interface without changing how they look.</li>
+  <li>Stopped the mobile dock reordering its feed shortcuts on every tap. Recently viewed feeds still decide which shortcuts appear, but their positions now follow the sidebar order and stay put.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+  <li>Fixed an expired license token reporting raw timestamps on activation. The error now names the expiry date and links to email recovery, and a token rejected for a clock mismatch or a truncated copy says so.</li>
+  <li>Fixed toasts covering the mobile navigation dock.</li>
+  <li>Fixed toasts ignoring the selected theme and always rendering dark.</li>
+</ul>]]></content>
+    <author><name>FeedZero</name></author>
+  </entry>
   <entry>
     <id>feedzero:release:0.12.0</id>
     <title>v0.12.0: Paywall false-positive fix and automatic TLS for LAN self-hosts</title>


### PR DESCRIPTION
Version bump to **0.13.0** plus the vendored release-feed fixture refreshed from the live landing changelog (which already serves `feedzero:release:0.13.0` as its newest entry — the landing-first invariant is satisfied).

This is the first release cut through the PR-based flow from #248. The bump is verified by the same required checks as any other change, including `release-version-sync.test.ts` (asserts `package.json` == the fixture's newest entry).

## What happens on merge

`release-tag.yml` reacts to the merged bump: it derives the version from `package.json` on main, re-checks it against the live landing feed and existing tags, pushes `v0.13.0`, and calls `docker-publish.yml` for the multi-arch image. **Do not tag by hand.**

Dry-run of the decision logic against this branch + the live feed:

```
Tagging v0.13.0.
should_tag=true
version=0.13.0
```

## Contents of 0.13.0

Everything merged since 0.12.0: the security sweep (#242 — 14 advisories to zero, DOMPurify root-caused, react-router 8), UX batches 1 and 2 (#236/#245 — mobile reading rebuilt around gestures), the license expiry fix (#239), the SDLC repairs (#240, #246), and the release-flow redesign (#248).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5