### PR TITLE
fix(ci): resolve the image version correctly in reusable-workflow calls

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,18 +63,13 @@ jobs:
       # package.json. Closes the drift class behind issues #211/#212.
       - name: Resolve + verify release version
         id: ver
+        # Resolution order (input -> v-tag -> package.json) and the
+        # equality guard live in the script, which is unit-tested; see its
+        # header for why `github.event_name` cannot be used to detect a
+        # reusable-workflow call. stdout carries key=value pairs.
         run: |
-          if [ "${{ github.event_name }}" = "workflow_call" ]; then
-            VER="${{ inputs.version }}"
-          else
-            VER="${GITHUB_REF_NAME#v}"
-          fi
-          PKG="$(node -p "require('./package.json').version")"
-          if [ "${{ github.event_name }}" != "workflow_dispatch" ] && [ "$VER" != "$PKG" ]; then
-            echo "::error::version mismatch: ref/input=$VER package.json=$PKG"; exit 1
-          fi
-          echo "version=$VER" >> "$GITHUB_OUTPUT"
-          echo "minor=${VER%.*}" >> "$GITHUB_OUTPUT"
+          node scripts/resolve-image-version.mjs \
+            "${{ inputs.version }}" "$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU (arm64 emulation for cross-arch builds)
         uses: docker/setup-qemu-action@v4

--- a/scripts/resolve-image-version.d.mts
+++ b/scripts/resolve-image-version.d.mts
@@ -1,0 +1,21 @@
+/** Type surface for scripts/resolve-image-version.mjs. */
+
+export interface ImageVersionInputs {
+  /** Explicit version from a reusable-workflow call; empty when absent. */
+  input: string;
+  /** GITHUB_REF_NAME — a `v`-prefixed tag or a branch name. */
+  refName: string;
+  pkgVersion: string;
+}
+
+export interface ResolvedImageVersion {
+  ok: boolean;
+  version: string;
+  /** Major.minor, for the floating image tag. */
+  minor: string;
+  reason: string;
+}
+
+export function resolveImageVersion(
+  params: ImageVersionInputs,
+): ResolvedImageVersion;

--- a/scripts/resolve-image-version.mjs
+++ b/scripts/resolve-image-version.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Resolves the version a Docker image should be published under, and proves
+ * it agrees with package.json.
+ *
+ * Extracted from bash-inside-YAML in docker-publish.yml, which chose its
+ * source of truth with `if github.event_name == 'workflow_call'`. In a
+ * REUSABLE workflow that condition never holds: `github.event_name` reports
+ * the event that triggered the CALLING run (for release-tag.yml, `push`).
+ * The passed-in version was therefore ignored in favour of the branch name,
+ * and the 0.13.0 publish died on `version mismatch: ref/input=main
+ * package.json=0.13.0`. Under `workflow_dispatch` the same wrong branch
+ * lands in `version` while the mismatch check is skipped — that path would
+ * have published an image tagged `main`.
+ *
+ * Resolution order, independent of event names:
+ *   1. explicit input (reusable-workflow call)
+ *   2. `v`-prefixed tag ref
+ *   3. package.json (branch ref — manual dispatch)
+ * The result must always equal package.json; that equality is the #211/#212
+ * drift guard, and it now holds on every path.
+ *
+ * CLI: prints `version=` / `minor=` on stdout for $GITHUB_OUTPUT, narration
+ * on stderr, exit 1 on mismatch.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+/**
+ * @param {{ input: string, refName: string, pkgVersion: string }} params
+ * @returns {{ ok: boolean, version: string, minor: string, reason: string }}
+ */
+export function resolveImageVersion({ input, refName, pkgVersion }) {
+  let version;
+  if (input) {
+    version = input;
+  } else if (refName.startsWith("v")) {
+    version = refName.slice(1);
+  } else {
+    version = pkgVersion;
+  }
+
+  const minor = version.split(".").slice(0, 2).join(".");
+  if (version !== pkgVersion) {
+    return {
+      ok: false,
+      version,
+      minor,
+      reason: `version mismatch: resolved ${version} but package.json is ${pkgVersion}`,
+    };
+  }
+  return { ok: true, version, minor, reason: `Publishing ${version}.` };
+}
+
+function runCli() {
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const pkgVersion = JSON.parse(
+    readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+  ).version;
+
+  const resolved = resolveImageVersion({
+    input: process.argv[2] ?? "",
+    refName: process.argv[3] ?? "",
+    pkgVersion,
+  });
+
+  console.error(resolved.reason);
+  console.log(`version=${resolved.version}`);
+  console.log(`minor=${resolved.minor}`);
+
+  if (!resolved.ok) {
+    console.error(`::error::${resolved.reason}`);
+    process.exit(1);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href
+) {
+  runCli();
+}

--- a/tests/scripts/resolve-image-version.test.ts
+++ b/tests/scripts/resolve-image-version.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { resolveImageVersion } from "../../scripts/resolve-image-version.mjs";
+
+/**
+ * The 0.13.0 publish failed with `version mismatch: ref/input=main
+ * package.json=0.13.0`. docker-publish.yml chose its source of truth with
+ * `if github.event_name == 'workflow_call'` — but in a REUSABLE workflow,
+ * `github.event_name` is the event that triggered the CALLING run (here
+ * `push`), never `workflow_call`. So the passed-in version was ignored and
+ * the branch name was used instead.
+ */
+describe("resolveImageVersion", () => {
+  it("prefers an explicit input (reusable-workflow call)", () => {
+    expect(
+      resolveImageVersion({
+        input: "0.13.0",
+        refName: "main",
+        pkgVersion: "0.13.0",
+      }).version,
+    ).toBe("0.13.0");
+  });
+
+  it("strips the leading v from a tag ref when there is no input", () => {
+    expect(
+      resolveImageVersion({
+        input: "",
+        refName: "v0.13.0",
+        pkgVersion: "0.13.0",
+      }).version,
+    ).toBe("0.13.0");
+  });
+
+  it("falls back to package.json for a branch ref (manual dispatch)", () => {
+    // Previously this produced version="main" and, because the mismatch
+    // check exempted workflow_dispatch, would have published an image
+    // tagged `main`.
+    const resolved = resolveImageVersion({
+      input: "",
+      refName: "main",
+      pkgVersion: "0.13.0",
+    });
+    expect(resolved.version).toBe("0.13.0");
+    expect(resolved.ok).toBe(true);
+  });
+
+  it("rejects a tag that disagrees with package.json (#211/#212 drift)", () => {
+    const resolved = resolveImageVersion({
+      input: "",
+      refName: "v0.11.0",
+      pkgVersion: "0.9.0",
+    });
+    expect(resolved.ok).toBe(false);
+    expect(resolved.reason).toMatch(/0\.11\.0.*0\.9\.0|0\.9\.0.*0\.11\.0/);
+  });
+
+  it("rejects an input that disagrees with package.json", () => {
+    expect(
+      resolveImageVersion({
+        input: "0.14.0",
+        refName: "main",
+        pkgVersion: "0.13.0",
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("derives the minor tag alongside the full version", () => {
+    expect(
+      resolveImageVersion({
+        input: "0.13.0",
+        refName: "main",
+        pkgVersion: "0.13.0",
+      }).minor,
+    ).toBe("0.13");
+  });
+});


### PR DESCRIPTION
**v0.13.0 is tagged** (`v0.13.0` → `0172c05`, identical to main, `package.json` at the tag reads 0.13.0 — the release-tag automation worked). The **image publish** failed:

```
##[error]version mismatch: ref/input=main package.json=0.13.0
```

## Root cause: `github.event_name` in a reusable workflow

`docker-publish.yml` picked its source of truth like this:

```bash
if [ "${{ github.event_name }}" = "workflow_call" ]; then VER="${{ inputs.version }}"
else VER="${GITHUB_REF_NAME#v}"; fi
```

In a **reusable** workflow, `github.event_name` is the event that triggered the *calling* run — for `release-tag.yml` that is `push`, never `workflow_call`. So the `version: 0.13.0` input was ignored and the branch name `main` was used instead.

**This was latent from the start**, and the old `release.yml` would have hit a worse version of it: under `workflow_dispatch` the same wrong value lands in `VER`, but the mismatch check explicitly exempted `workflow_dispatch` — so it would have silently published an image tagged **`main`**.

## Fix

`scripts/resolve-image-version.mjs` resolves by **precedence, not event name**:

1. explicit input (reusable call) → 2. `v`-prefixed tag ref → 3. `package.json` (branch ref / manual dispatch)

and requires the result to equal `package.json` on **every** path — the dispatch escape hatch is gone. Because the branch-ref case now derives from `package.json`, a manual dispatch publishes the correct version instead of garbage.

Moving this out of bash-inside-YAML also makes it locally runnable — the same reason today's `e2e.yml` YAML break (fixed in #246) was invisible until it silently disabled post-merge E2E.

## Verification

6 unit tests, RED first, covering all four invocation shapes and both drift cases — including the exact #211/#212 pair (tag `v0.11.0` vs `package.json` 0.9.0). Simulated against the real tree:

| invocation | resolved |
|---|---|
| reusable call (`0.13.0`, `main`) | `0.13.0` ✅ |
| tag push (`""`, `v0.13.0`) | `0.13.0` ✅ |
| manual dispatch (`""`, `main`) | `0.13.0` ✅ (was `main`) |
| bad tag (`""`, `v0.11.0`) | rejected, exit 1 ✅ |

`npm test` 3822 passed / 0 failed · `tsc` clean · `check-env` clean · all workflows parse.

## After merge

I'll dispatch `docker-publish.yml` to publish the 0.13.0 image — the tag already exists, so nothing else about the release needs redoing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5