### PR TITLE
fix(ci): gate release image tags on the resolver, not the event name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,11 @@ on:
     tags:
       - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Republish this release version (e.g. 0.13.0). Leave empty for a throwaway sha-tagged smoke build."
+        required: false
+        type: string
   workflow_call:
     inputs:
       version:
@@ -110,15 +115,15 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/feedzero
             ${{ secrets.DOCKERHUB_TOKEN != '' && format('docker.io/{0}/feedzero', github.repository_owner) || '' }}
-          # Tags (driven by the resolved version so tag-push and
-          # workflow_call behave identically):
-          #   * Release (tag push or workflow_call): vX.Y.Z, X.Y, latest
-          #   * Manual dispatch: short SHA only (a throwaway smoke build)
+          # Tags follow the resolver's `release` verdict, NOT the event name
+          # (see scripts/resolve-image-version.mjs):
+          #   * release (explicit version input, or a v-tag ref): vX.Y.Z, X.Y, latest
+          #   * otherwise (bare branch build): short SHA only, a throwaway smoke build
           tags: |
-            type=raw,value=v${{ steps.ver.outputs.version }},enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=raw,value=${{ steps.ver.outputs.minor }},enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' }}
-            type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=v${{ steps.ver.outputs.version }},enable=${{ steps.ver.outputs.release == 'true' }}
+            type=raw,value=${{ steps.ver.outputs.minor }},enable=${{ steps.ver.outputs.release == 'true' }}
+            type=raw,value=latest,enable=${{ steps.ver.outputs.release == 'true' }}
+            type=sha,enable=${{ steps.ver.outputs.release != 'true' }}
 
       - name: Build + push
         uses: docker/build-push-action@v7

--- a/scripts/resolve-image-version.d.mts
+++ b/scripts/resolve-image-version.d.mts
@@ -10,6 +10,8 @@ export interface ImageVersionInputs {
 
 export interface ResolvedImageVersion {
   ok: boolean;
+  /** True when this build carries release tags rather than only a sha tag. */
+  release: boolean;
   version: string;
   /** Major.minor, for the floating image tag. */
   minor: string;

--- a/scripts/resolve-image-version.mjs
+++ b/scripts/resolve-image-version.mjs
@@ -28,29 +28,45 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 /**
+ * `release` says whether this invocation should carry the release tags
+ * (vX.Y.Z / X.Y / latest) or only a throwaway sha tag. It follows the same
+ * precedence as the version — an explicit input or a v-tag means release, a
+ * bare branch build does not.
+ *
  * @param {{ input: string, refName: string, pkgVersion: string }} params
- * @returns {{ ok: boolean, version: string, minor: string, reason: string }}
+ * @returns {{ ok: boolean, release: boolean, version: string, minor: string, reason: string }}
  */
 export function resolveImageVersion({ input, refName, pkgVersion }) {
   let version;
+  let release = true;
   if (input) {
     version = input;
   } else if (refName.startsWith("v")) {
     version = refName.slice(1);
   } else {
     version = pkgVersion;
+    release = false;
   }
 
   const minor = version.split(".").slice(0, 2).join(".");
   if (version !== pkgVersion) {
     return {
       ok: false,
+      release,
       version,
       minor,
       reason: `version mismatch: resolved ${version} but package.json is ${pkgVersion}`,
     };
   }
-  return { ok: true, version, minor, reason: `Publishing ${version}.` };
+  return {
+    ok: true,
+    release,
+    version,
+    minor,
+    reason: release
+      ? `Publishing release ${version} (tags: v${version}, ${minor}, latest).`
+      : `Throwaway build of ${version} (sha tag only).`,
+  };
 }
 
 function runCli() {
@@ -71,6 +87,7 @@ function runCli() {
   console.error(resolved.reason);
   console.log(`version=${resolved.version}`);
   console.log(`minor=${resolved.minor}`);
+  console.log(`release=${resolved.release}`);
 
   if (!resolved.ok) {
     console.error(`::error::${resolved.reason}`);

--- a/tests/scripts/resolve-image-version.test.ts
+++ b/tests/scripts/resolve-image-version.test.ts
@@ -63,6 +63,43 @@ describe("resolveImageVersion", () => {
     ).toBe(false);
   });
 
+  // Whether an invocation publishes release tags (vX.Y.Z / X.Y / latest) or
+  // just a throwaway sha tag must follow the SAME precedence as the version
+  // itself. docker-publish.yml gated that on `github.event_name !=
+  // 'workflow_dispatch'` — the identical event-name trap that broke version
+  // resolution, and one that left no way to republish a release image.
+  describe("release vs throwaway builds", () => {
+    it("treats an explicit input as a release", () => {
+      expect(
+        resolveImageVersion({
+          input: "0.13.0",
+          refName: "main",
+          pkgVersion: "0.13.0",
+        }).release,
+      ).toBe(true);
+    });
+
+    it("treats a v-tag ref as a release", () => {
+      expect(
+        resolveImageVersion({
+          input: "",
+          refName: "v0.13.0",
+          pkgVersion: "0.13.0",
+        }).release,
+      ).toBe(true);
+    });
+
+    it("treats a bare branch build as throwaway (sha tag only)", () => {
+      expect(
+        resolveImageVersion({
+          input: "",
+          refName: "main",
+          pkgVersion: "0.13.0",
+        }).release,
+      ).toBe(false);
+    });
+  });
+
   it("derives the minor tag alongside the full version", () => {
     expect(
       resolveImageVersion({


### PR DESCRIPTION
Follow-up to #250. The 0.13.0 publish now runs and resolves correctly (`Publishing 0.13.0.`), but pushed **only** `ghcr.io/forcingfx/feedzero:sha-ea4400a` — no `v0.13.0`, `0.13`, or `latest`. **The release image is still unpublished.**

## Root cause: the same trap, one step later

#250 removed `github.event_name` from *version resolution*. The **tag selection** immediately below it still used it:

```yaml
type=raw,value=v${{ steps.ver.outputs.version }},enable=${{ github.event_name != 'workflow_dispatch' }}
```

Manual dispatch is defined as a throwaway smoke build, so my dispatch got a sha tag by design. The real problem this exposed: **there was no way to republish a release image at all.** `release-tag.yml` short-circuits on an already-tagged version (`v0.13.0 already tagged — nothing to release`), so its `publish` job is skipped — and dispatch could only ever produce sha tags. The release was wedged.

## Fix

`resolve-image-version.mjs` now also returns **`release`**, on the same precedence as the version:

| invocation | version | release | tags |
|---|---|---|---|
| reusable call (`0.13.0`, `main`) | 0.13.0 | ✅ | `v0.13.0`, `0.13`, `latest` |
| tag push (`""`, `v0.13.0`) | 0.13.0 | ✅ | `v0.13.0`, `0.13`, `latest` |
| dispatch **with** version | 0.13.0 | ✅ | `v0.13.0`, `0.13`, `latest` |
| dispatch **without** version | 0.13.0 | ❌ | `sha-<short>` only |

`docker-publish.yml`'s `workflow_dispatch` gains an optional `version` input, making "republish this release" an explicit, tested path. **The workflow no longer branches on `github.event_name` anywhere** — that idiom has now produced two distinct release-blocking bugs today.

## Verification

3 new unit tests (RED first) pinning the release/throwaway verdict per invocation shape; both dispatch modes simulated against the real tree. `npm test` 3825 passed / 0 failed · `tsc` clean · all workflows parse.

## After merge

I'll dispatch with `version=0.13.0` to publish the release image, then verify the pushed tags and that the running container reports 0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5