### PR TITLE
feat: /ship loop — working tree to verified-live, unattended (+ actionlint, release rehearsal)

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ship
+description: Take a change from working tree to verified-live production, unattended, in under ten minutes. Local gate, PR, CI, auto-merge, then prove the exact commit is serving traffic.
+argument-hint: "[commit subject] [--draft to stop before auto-merge]"
+---
+
+# /ship
+
+One command from working tree to verified production. Nothing here weakens
+verification: all seven required checks still gate the merge. What is removed
+is the *waiting*.
+
+## Preconditions (ABORT if any fail)
+
+1. `git status` shows only changes **you** authored this session. Anything
+   else → create a worktree instead (CLAUDE.md multi-agent rules) and ship
+   from there. Never stash-and-switch.
+2. Ship authority is present: `.claude/settings.local.json` must contain the
+   `Bash(gh pr merge:*)` permission rule. Without it every step past the PR
+   stops for the operator, and this skill's promise does not hold.
+3. Not on `main` with uncommitted work belonging to someone else.
+
+## Phase 1 — Local gate (~40s)
+
+Fail here and nothing has left the machine.
+
+```bash
+npx tsc --noEmit
+npx vitest run <paths covering the change>     # full `npm test` if unsure
+```
+
+Both must be clean. A red local gate ends the run; do not push "to see what
+CI says" — CI is 2 minutes of shared resource for an answer you can have in
+40 seconds.
+
+## Phase 2 — Publish
+
+```bash
+git switch -c <type>/<slug>
+git add <paths>            # never `git add -A` in a worktree: a node_modules
+                           # symlink slipped in that way (see repo-hygiene test)
+git commit -m "<conventional subject>"
+git push -u origin <type>/<slug>
+gh pr create --head <type>/<slug> --base main --title "..." --body "..."
+```
+
+Bug fixes need the four sections (What / Why / Fix / Prevention). PR body
+should say what changed and how it was verified.
+
+## Phase 3 — CI + auto-merge (~2 min)
+
+```bash
+gh pr merge <n> --squash --auto --delete-branch
+gh pr checks <n> --watch --interval 30
+```
+
+Auto-merge lands the PR the moment the checks pass. A red check leaves the PR
+open and unmerged — fix and push, and it lands when green. It never merges
+red.
+
+## Phase 4 — Verify live (~2 min)
+
+Merging is not shipping. Prove the exact commit is serving traffic:
+
+```bash
+SHA=$(git rev-parse origin/main)            # after the merge lands
+node scripts/ship/verify-deploy.mjs https://my.feedzero.app "$SHA"
+```
+
+This polls `/api/health` until it reports the merged commit. Waiting a fixed
+interval instead is how a green deploy report ends up accompanying stale
+code.
+
+If it times out: report the failure and link the Vercel deployment. **Do not
+auto-revert** — whether a bad deploy warrants a revert is a judgement about
+user impact, and that call is the operator's.
+
+## Phase 5 — Report
+
+State plainly: what shipped, the PR, the commit now live, and anything that
+failed on the way. If tests were skipped or a check was retried, say so.
+
+## Budget
+
+| Phase | Typical |
+|---|---|
+| Local gate | 40s |
+| CI | 2 min |
+| Deploy + verify | 2 min |
+| **Total** | **~5 min** |
+
+If a run exceeds ten minutes, something is wrong — say so rather than
+quietly waiting.
+
+## Notes
+
+- **Releases do not use this skill.** Use `/release`, which adds the notes
+  entry and version bump and lets `release-tag.yml` tag and publish.
+- **No merge queue.** Auto-merge lands green PRs directly. The `merge_group`
+  wiring in the workflows is dormant and can be enabled in ruleset 16445501
+  if PR volume ever makes the update-branch treadmill hurt again.
+- **Why `commit` and not `version`:** most changes ship without a version
+  bump, so version cannot answer "is my change live?". The commit can.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,23 @@ permissions:
   contents: read
 
 jobs:
+  # Workflows are only exercised by running them, so their defects surface in
+  # production — three did during the 0.13.0 release, one of which (invalid
+  # YAML in e2e.yml) had silently disabled post-merge E2E from the moment it
+  # merged. actionlint parses every workflow and type-checks the expression
+  # contexts, catching that class in seconds.
+  workflow-lint:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: actionlint
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color
+
   typecheck:
     name: Type check
     runs-on: ubuntu-latest
@@ -212,10 +229,11 @@ jobs:
         run: |
           npm run serve >/tmp/fz-serve.log 2>&1 &
           SERVE_PID=$!
-          trap "kill $SERVE_PID 2>/dev/null || true" EXIT
+          # Single quotes: $SERVE_PID must expand when the trap fires, not now.
+          trap 'kill $SERVE_PID 2>/dev/null || true' EXIT
           # Wait for the server to bind. Up to ~10s; fail fast if it never
           # answers so the job doesn't sit until timeout.
-          for i in {1..20}; do
+          for _ in {1..20}; do
             if curl -fsS -o /dev/null http://localhost:3100/; then break; fi
             sleep 0.5
           done

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -1,0 +1,128 @@
+name: Release rehearsal
+
+# Exercises the release chain on an ordinary night so its defects surface
+# then, instead of during a release.
+#
+# The 0.13.0 release hit three latent workflow bugs in a row, each of which
+# could only be found by running the thing for real:
+#   * docker-publish.yml resolved its version from `github.event_name`, which
+#     in a REUSABLE workflow reports the CALLER's event and so never equals
+#     `workflow_call` — the passed-in version was ignored.
+#   * the same idiom gated the release image tags, so the first successful
+#     publish pushed only a sha tag.
+#   * release.yml pushed to main, which the ruleset forbids (GH013).
+# The first two are exactly what this rehearsal reproduces. The third is gone
+# by construction: nothing pushes to main any more.
+#
+# The rehearsal must never publish a release image or move a tag. It runs the
+# real code paths in their throwaway modes and asserts they report what they
+# should.
+on:
+  schedule:
+    # 03:00 UTC daily — after Dependabot, before the working day.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: release-rehearsal
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  rehearse:
+    name: Rehearse the release chain
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Tag list must be complete for the tag-decision no-op assertion.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Tag decision is a quiet no-op on an already-released main
+        run: |
+          set -euo pipefail
+          node scripts/release/tag-decision.mjs > /tmp/decision.txt
+          cat /tmp/decision.txt
+          # main's version is already tagged, so the workflow must decline to
+          # tag AND exit 0. A non-zero exit here means the release path would
+          # fail spuriously on the next merge that touches package.json.
+          grep -qx 'should_tag=false' /tmp/decision.txt
+
+      - name: Image version resolves from an explicit input (reusable-call shape)
+        run: |
+          set -euo pipefail
+          PKG="$(node -p "require('./package.json').version")"
+          # This is the call shape release-tag.yml uses. It regressed once by
+          # resolving to the branch name instead of the input.
+          node scripts/resolve-image-version.mjs "$PKG" "main" > /tmp/ver.txt
+          cat /tmp/ver.txt
+          grep -qx "version=${PKG}" /tmp/ver.txt
+          grep -qx 'release=true' /tmp/ver.txt
+
+      - name: Image version resolves from a v-tag ref
+        run: |
+          set -euo pipefail
+          PKG="$(node -p "require('./package.json').version")"
+          node scripts/resolve-image-version.mjs "" "v${PKG}" > /tmp/ver-tag.txt
+          grep -qx "version=${PKG}" /tmp/ver-tag.txt
+          grep -qx 'release=true' /tmp/ver-tag.txt
+
+      - name: A bare branch build stays throwaway
+        run: |
+          set -euo pipefail
+          PKG="$(node -p "require('./package.json').version")"
+          node scripts/resolve-image-version.mjs "" "main" > /tmp/ver-branch.txt
+          # Must NOT claim a release, or a smoke build would overwrite `latest`.
+          grep -qx 'release=false' /tmp/ver-branch.txt
+          grep -qx "version=${PKG}" /tmp/ver-branch.txt
+
+      - name: A drifting tag is rejected
+        run: |
+          set -euo pipefail
+          # The #211/#212 shape: a tag that disagrees with package.json must
+          # fail rather than publish a mislabelled image.
+          if node scripts/resolve-image-version.mjs "" "v0.0.1-drift" \
+            > /tmp/ver-drift.txt 2>&1; then
+            echo "::error::resolver accepted a drifting tag"; exit 1
+          fi
+
+  # A rehearsal that fails silently is worse than none: it reads as coverage
+  # while providing nothing. Same pattern as the e2e-red net.
+  notify-red:
+    name: File tracking issue on rehearsal failure
+    runs-on: ubuntu-latest
+    needs: rehearse
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - name: Open or bump the release-rehearsal-red issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh label create release-rehearsal-red --repo "$GITHUB_REPOSITORY" \
+            --color B60205 --description "The release chain is broken" --force
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label release-rehearsal-red --state open --json number \
+            --jq '.[0].number // empty')
+          body="Release rehearsal failed: $RUN_URL"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            printf -v full_body '%s\n\n%s' "$body" \
+              "The release chain is broken NOW, before anyone tries to cut a release. Fix it before the next release rather than discovering it at minute ten (2026-08-05 shipping design)."
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Release rehearsal red" \
+              --label release-rehearsal-red \
+              --body "$full_body"
+          fi

--- a/expected-env.json
+++ b/expected-env.json
@@ -1,135 +1,216 @@
 {
   "$comment": "Single source of truth for every environment variable the codebase reads. Compared against grep'd source via `npm run check-env`, and against a pulled deployment env when a path is passed. See docs/operations/env-audit.md for the runbook.",
   "spec": {
-    "LICENSE_SIGNING_KEY": {
-      "required": "production",
-      "description": "HMAC secret for signing/verifying license tokens. Rotate triggers full re-issue.",
-      "consumers": ["api/stripe/webhook.ts", "server.ts", "src/core/license/issuer.ts"]
-    },
-    "STRIPE_SECRET_KEY": {
-      "required": "production",
-      "description": "Stripe API key used by checkout / recover / admin / billing paths.",
-      "consumers": ["api/checkout/create-session.ts", "api/stripe/webhook.ts", "server.ts"]
-    },
-    "STRIPE_WEBHOOK_SECRET": {
-      "required": "production",
-      "description": "Webhook signing secret used to verify Stripe event signatures.",
-      "consumers": ["api/stripe/webhook.ts", "server.ts"]
-    },
-    "STRIPE_ALLOWED_PRICES": {
-      "required": "production",
-      "description": "Comma-separated list of allowed Stripe price IDs. Defence against price-id tampering at checkout creation.",
-      "consumers": ["api/checkout/create-session.ts"]
-    },
-    "UPSTASH_REDIS_REST_URL": {
-      "required": "production",
-      "description": "Upstash REST URL (canonical name). Used by sync / catalog / license / stripe seen-events stores. Accept either this OR KV_REST_API_URL.",
-      "consumers": ["src/core/sync/adapters/upstash-adapter.ts", "src/core/catalog/adapters/upstash-adapter.ts", "src/core/license/storage-upstash.ts", "src/core/stripe/resolve-seen-event-store.ts", "src/core/proxy/resolve-rate-limiter.ts"]
-    },
-    "UPSTASH_REDIS_REST_TOKEN": {
-      "required": "production",
-      "description": "Upstash REST token paired with UPSTASH_REDIS_REST_URL.",
-      "consumers": ["src/core/sync/adapters/upstash-adapter.ts"]
-    },
-    "KV_REST_API_URL": {
-      "required": "optional",
-      "description": "Vercel-Marketplace-injected legacy name for the Upstash REST URL. Auto-detected as a fallback; do not set manually when UPSTASH_REDIS_REST_URL is present.",
-      "consumers": ["src/core/sync/adapters/upstash-adapter.ts"]
-    },
-    "KV_REST_API_TOKEN": {
-      "required": "optional",
-      "description": "Vercel-Marketplace-injected legacy name paired with KV_REST_API_URL.",
-      "consumers": ["src/core/sync/adapters/upstash-adapter.ts"]
-    },
-    "GITHUB_FEEDBACK_TOKEN": {
-      "required": "production",
-      "description": "Fine-grained GitHub PAT with `issues: write` for /api/feedback. Without it the endpoint 503s gracefully.",
-      "consumers": ["src/core/feedback/feedback-handler.ts", "api/feedback.ts"]
-    },
-    "GITHUB_REPO": {
-      "required": "production",
-      "description": "owner/repo target for /api/feedback issue creation (e.g. forcingfx/feedzero).",
-      "consumers": ["src/core/feedback/feedback-handler.ts", "api/feedback.ts"]
-    },
     "ADMIN_API_KEY": {
       "required": "production",
       "description": "Shared secret for admin endpoints (license find / revoke / re-issue).",
-      "consumers": ["server.ts", "api/checkout/create-session.ts"]
-    },
-    "OPERATOR_ALERT_URL": {
-      "required": "optional",
-      "description": "Webhook URL (Slack / Discord / generic) that receives operator alerts on 5xx and sync regressions. Optional but recommended.",
-      "consumers": ["src/utils/log-error.ts", "api/sync.ts", "api/feed.ts", "api/page.ts", "api/icon.ts", "api/checkout/create-session.ts", "api/stripe/webhook.ts"]
-    },
-    "RATE_LIMIT_HASH_SALT": {
-      "required": "production",
-      "description": "Salt for the IP-hashing rate limiter so a stolen Upstash dump cannot be reversed into raw IPs.",
-      "consumers": ["src/core/proxy/rate-limiter.ts", "api/feed.ts", "api/page.ts"]
+      "consumers": [
+        "server.ts",
+        "api/checkout/create-session.ts"
+      ]
     },
     "APP_VERSION": {
       "required": "optional",
       "description": "Reported by /api/health-version. Injected by the build at compile time via scripts/build-api.js; leave unset in the env.",
-      "consumers": ["src/core/health/health-handler.ts"]
-    },
-    "FEED_USER_AGENT": {
-      "required": "optional",
-      "description": "Operator-supplied User-Agent for outbound /api/feed and /api/page requests. Overrides the default browser-like UA used under SELF_HOSTED.",
-      "consumers": ["src/core/proxy/pick-user-agent.ts"]
+      "consumers": [
+        "src/core/health/health-handler.ts"
+      ]
     },
     "BLOB_READ_WRITE_TOKEN": {
       "required": "optional",
       "description": "Legacy Vercel Blob credential. Only set if rolling back to the pre-Upstash sync backend; the Upstash backend supersedes it (ADR 008).",
-      "consumers": ["src/core/sync/adapters/resolve-adapter.ts", "src/core/sync/adapters/vercel-blob-adapter.ts"]
-    },
-    "SYNC_STORAGE": {
-      "required": "optional",
-      "description": "Explicit override for the sync adapter (`upstash` | `vercel-blob` | `filesystem` | `memory`). Auto-detect is preferred; only set when the operator deliberately wants a different backend than the credentials imply.",
-      "consumers": ["src/core/sync/adapters/resolve-adapter.ts"]
+      "consumers": [
+        "src/core/sync/adapters/resolve-adapter.ts",
+        "src/core/sync/adapters/vercel-blob-adapter.ts"
+      ]
     },
     "DATA_DIR": {
       "required": "self-host",
       "description": "Directory for the filesystem sync adapter's vault files. Self-host only.",
-      "consumers": ["src/core/sync/adapters/resolve-adapter.ts"]
+      "consumers": [
+        "src/core/sync/adapters/resolve-adapter.ts"
+      ]
+    },
+    "FEED_USER_AGENT": {
+      "required": "optional",
+      "description": "Operator-supplied User-Agent for outbound /api/feed and /api/page requests. Overrides the default browser-like UA used under SELF_HOSTED.",
+      "consumers": [
+        "src/core/proxy/pick-user-agent.ts"
+      ]
+    },
+    "GITHUB_FEEDBACK_TOKEN": {
+      "required": "production",
+      "description": "Fine-grained GitHub PAT with `issues: write` for /api/feedback. Without it the endpoint 503s gracefully.",
+      "consumers": [
+        "src/core/feedback/feedback-handler.ts",
+        "api/feedback.ts"
+      ]
+    },
+    "GITHUB_REPO": {
+      "required": "production",
+      "description": "owner/repo target for /api/feedback issue creation (e.g. forcingfx/feedzero).",
+      "consumers": [
+        "src/core/feedback/feedback-handler.ts",
+        "api/feedback.ts"
+      ]
+    },
+    "KV_REST_API_TOKEN": {
+      "required": "optional",
+      "description": "Vercel-Marketplace-injected legacy name paired with KV_REST_API_URL.",
+      "consumers": [
+        "src/core/sync/adapters/upstash-adapter.ts"
+      ]
+    },
+    "KV_REST_API_URL": {
+      "required": "optional",
+      "description": "Vercel-Marketplace-injected legacy name for the Upstash REST URL. Auto-detected as a fallback; do not set manually when UPSTASH_REDIS_REST_URL is present.",
+      "consumers": [
+        "src/core/sync/adapters/upstash-adapter.ts"
+      ]
+    },
+    "LICENSE_SIGNING_KEY": {
+      "required": "production",
+      "description": "HMAC secret for signing/verifying license tokens. Rotate triggers full re-issue.",
+      "consumers": [
+        "api/stripe/webhook.ts",
+        "server.ts",
+        "src/core/license/issuer.ts"
+      ]
+    },
+    "OPERATOR_ALERT_URL": {
+      "required": "optional",
+      "description": "Webhook URL (Slack / Discord / generic) that receives operator alerts on 5xx and sync regressions. Optional but recommended.",
+      "consumers": [
+        "src/utils/log-error.ts",
+        "api/sync.ts",
+        "api/feed.ts",
+        "api/page.ts",
+        "api/icon.ts",
+        "api/checkout/create-session.ts",
+        "api/stripe/webhook.ts"
+      ]
     },
     "PORT": {
       "required": "self-host",
       "description": "Listen port for the Hono standalone server (npm run serve). Self-host only.",
-      "consumers": ["server.ts"]
+      "consumers": [
+        "server.ts"
+      ]
+    },
+    "RATE_LIMIT_HASH_SALT": {
+      "required": "production",
+      "description": "Salt for the IP-hashing rate limiter so a stolen Upstash dump cannot be reversed into raw IPs.",
+      "consumers": [
+        "src/core/proxy/rate-limiter.ts",
+        "api/feed.ts",
+        "api/page.ts"
+      ]
     },
     "SELF_HOSTED": {
       "required": "self-host",
       "description": "Runtime flag (`1`) that forces paid-tier UI off and switches the proxy to a browser-like UA (ADR 014). Self-host only.",
-      "consumers": ["src/core/features/self-hosted.ts", "src/core/proxy/pick-user-agent.ts"]
+      "consumers": [
+        "src/core/features/self-hosted.ts",
+        "src/core/proxy/pick-user-agent.ts"
+      ]
     },
-    "VITE_SELF_HOSTED": {
-      "required": "self-host",
-      "description": "Build-time twin of SELF_HOSTED. Set during `npm run build:all` so the SPA bundle hides the Subscribe UI.",
-      "consumers": ["src/core/features/self-hosted.ts"]
+    "STRIPE_ALLOWED_PRICES": {
+      "required": "production",
+      "description": "Comma-separated list of allowed Stripe price IDs. Defence against price-id tampering at checkout creation.",
+      "consumers": [
+        "api/checkout/create-session.ts"
+      ]
     },
-    "VITE_PAID_TIER_VISIBLE": {
+    "STRIPE_SECRET_KEY": {
+      "required": "production",
+      "description": "Stripe API key used by checkout / recover / admin / billing paths.",
+      "consumers": [
+        "api/checkout/create-session.ts",
+        "api/stripe/webhook.ts",
+        "server.ts"
+      ]
+    },
+    "STRIPE_WEBHOOK_SECRET": {
+      "required": "production",
+      "description": "Webhook signing secret used to verify Stripe event signatures.",
+      "consumers": [
+        "api/stripe/webhook.ts",
+        "server.ts"
+      ]
+    },
+    "SYNC_STORAGE": {
       "required": "optional",
-      "description": "Build-time flag that flips the paid-tier UI visibility independently of SELF_HOSTED. Default off; production sets it to surface checkout flows.",
-      "consumers": ["src/core/features/paid-tier-active.ts"]
+      "description": "Explicit override for the sync adapter (`upstash` | `vercel-blob` | `filesystem` | `memory`). Auto-detect is preferred; only set when the operator deliberately wants a different backend than the credentials imply.",
+      "consumers": [
+        "src/core/sync/adapters/resolve-adapter.ts"
+      ]
     },
-    "VITE_PRICE_PERSONAL_MONTHLY": {
+    "UPSTASH_REDIS_REST_TOKEN": {
       "required": "production",
-      "description": "Stripe price id for the Personal monthly plan, baked into the SPA bundle for the Checkout call.",
-      "consumers": ["src/app.tsx"]
+      "description": "Upstash REST token paired with UPSTASH_REDIS_REST_URL.",
+      "consumers": [
+        "src/core/sync/adapters/upstash-adapter.ts"
+      ]
     },
-    "VITE_PRICE_PERSONAL_YEARLY": {
+    "UPSTASH_REDIS_REST_URL": {
       "required": "production",
-      "description": "Stripe price id for the Personal yearly plan.",
-      "consumers": ["src/app.tsx"]
+      "description": "Upstash REST URL (canonical name). Used by sync / catalog / license / stripe seen-events stores. Accept either this OR KV_REST_API_URL.",
+      "consumers": [
+        "src/core/sync/adapters/upstash-adapter.ts",
+        "src/core/catalog/adapters/upstash-adapter.ts",
+        "src/core/license/storage-upstash.ts",
+        "src/core/stripe/resolve-seen-event-store.ts",
+        "src/core/proxy/resolve-rate-limiter.ts"
+      ]
+    },
+    "VERCEL_GIT_COMMIT_SHA": {
+      "required": "optional",
+      "description": "Short SHA reported by /api/health so a deploy can be identified exactly. Injected by Vercel at build time; never set by hand. Absent on self-hosted images, where health reports commit \"unknown\".",
+      "consumers": [
+        "src/core/health/health-handler.ts"
+      ]
     },
     "VITE_APP_VERSION": {
       "required": "optional",
       "description": "Version string surfaced in the About dialog. Injected at build time; leave unset in the env.",
-      "consumers": ["src/components/settings/tabs/about-tab.tsx"]
+      "consumers": [
+        "src/components/settings/tabs/about-tab.tsx"
+      ]
     },
     "VITE_EXTENSION_ENABLED": {
       "required": "optional",
       "description": "Build-time flag that shows the browser-extension affordance in the SPA.",
-      "consumers": ["src/core/extension/extension-enabled.ts"]
+      "consumers": [
+        "src/core/extension/extension-enabled.ts"
+      ]
+    },
+    "VITE_PAID_TIER_VISIBLE": {
+      "required": "optional",
+      "description": "Build-time flag that flips the paid-tier UI visibility independently of SELF_HOSTED. Default off; production sets it to surface checkout flows.",
+      "consumers": [
+        "src/core/features/paid-tier-active.ts"
+      ]
+    },
+    "VITE_PRICE_PERSONAL_MONTHLY": {
+      "required": "production",
+      "description": "Stripe price id for the Personal monthly plan, baked into the SPA bundle for the Checkout call.",
+      "consumers": [
+        "src/app.tsx"
+      ]
+    },
+    "VITE_PRICE_PERSONAL_YEARLY": {
+      "required": "production",
+      "description": "Stripe price id for the Personal yearly plan.",
+      "consumers": [
+        "src/app.tsx"
+      ]
+    },
+    "VITE_SELF_HOSTED": {
+      "required": "self-host",
+      "description": "Build-time twin of SELF_HOSTED. Set during `npm run build:all` so the SPA bundle hides the Subscribe UI.",
+      "consumers": [
+        "src/core/features/self-hosted.ts"
+      ]
     }
   }
 }

--- a/scripts/ship/verify-deploy.d.mts
+++ b/scripts/ship/verify-deploy.d.mts
@@ -1,0 +1,19 @@
+/** Type surface for scripts/ship/verify-deploy.mjs. */
+
+export interface HealthSnapshot {
+  ok: boolean;
+  /** Short SHA the deployment reports, or "unknown". */
+  commit: string;
+}
+
+export interface DeployVerdict {
+  live: boolean;
+  reason: string;
+}
+
+export function isDeployLive(params: {
+  /** null when health could not be fetched. */
+  health: HealthSnapshot | null;
+  /** Full SHA of the commit that must be live. */
+  targetCommit: string;
+}): DeployVerdict;

--- a/scripts/ship/verify-deploy.mjs
+++ b/scripts/ship/verify-deploy.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Proves that a specific commit is live in production.
+ *
+ * `/ship` uses this as its last gate. Waiting a fixed interval and declaring
+ * success is how a green deploy report ends up accompanying stale code; this
+ * asks production which commit it is actually serving (via /api/health's
+ * `commit` field) and only passes when that is the commit we merged.
+ *
+ * CLI: node scripts/ship/verify-deploy.mjs <baseUrl> <targetCommit> [timeoutSeconds]
+ * Exit 0 once live, 1 on timeout. Narration on stderr; `live=`/`commit=` on
+ * stdout so a workflow can redirect it into $GITHUB_OUTPUT.
+ *
+ * No process.env reads: scripts/ is scanned by `npm run check-env` against
+ * expected-env.json, which is the deployment contract, not a place for
+ * runner variables.
+ */
+
+const POLL_INTERVAL_MS = 5000;
+const DEFAULT_TIMEOUT_SECONDS = 300;
+
+/**
+ * @param {{ health: { ok: boolean, commit: string } | null, targetCommit: string }} params
+ * @returns {{ live: boolean, reason: string }}
+ */
+export function isDeployLive({ health, targetCommit }) {
+  if (!health) {
+    return { live: false, reason: "health unreachable — no response yet" };
+  }
+  if (!health.ok) {
+    return {
+      live: false,
+      reason: `health reports not ok (maintenance or degraded), commit ${health.commit}`,
+    };
+  }
+  if (!health.commit || health.commit === "unknown") {
+    return {
+      live: false,
+      reason: "deployment cannot identify its commit (reports 'unknown')",
+    };
+  }
+  // The served value is a short SHA; require it to PREFIX the full target so
+  // a different commit sharing characters cannot pass.
+  if (!targetCommit.startsWith(health.commit)) {
+    return {
+      live: false,
+      reason: `serving ${health.commit}, waiting for ${targetCommit.slice(0, 7)}`,
+    };
+  }
+  return { live: true, reason: `${health.commit} is live` };
+}
+
+async function fetchHealth(baseUrl) {
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/$/, "")}/api/health`, {
+      headers: { "Cache-Control": "no-cache" },
+    });
+    // 503 is a maintenance response with a valid body; parse it either way.
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function runCli() {
+  const [baseUrl, targetCommit, timeoutArg] = process.argv.slice(2);
+  if (!baseUrl || !targetCommit) {
+    console.error(
+      "usage: verify-deploy.mjs <baseUrl> <targetCommit> [timeoutSeconds]",
+    );
+    process.exit(2);
+  }
+  const timeoutMs =
+    Number(timeoutArg ?? DEFAULT_TIMEOUT_SECONDS) * 1000 || Infinity;
+  const startedAt = Date.now();
+
+  let verdict = { live: false, reason: "not started" };
+  while (Date.now() - startedAt < timeoutMs) {
+    verdict = isDeployLive({
+      health: await fetchHealth(baseUrl),
+      targetCommit,
+    });
+    const elapsed = Math.round((Date.now() - startedAt) / 1000);
+    console.error(`[${elapsed}s] ${verdict.reason}`);
+    if (verdict.live) {
+      console.log(`live=true`);
+      console.log(`commit=${targetCommit.slice(0, 7)}`);
+      return;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  console.log(`live=false`);
+  console.log(`commit=${targetCommit.slice(0, 7)}`);
+  console.error(`::error::deploy not live within timeout: ${verdict.reason}`);
+  process.exit(1);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href
+) {
+  await runCli();
+}

--- a/src/core/health/health-handler.ts
+++ b/src/core/health/health-handler.ts
@@ -16,6 +16,8 @@ export const SUPPORTED_METHODS: readonly string[] = ["GET"];
 interface HealthBody {
   ok: boolean;
   version: string;
+  /** Short SHA of the deployed commit, or "unknown". */
+  commit: string;
   time: string;
   maintenance?: boolean;
 }
@@ -52,6 +54,22 @@ function readViteAppVersion(): string | undefined {
 }
 
 /**
+ * Short SHA of the deployed commit.
+ *
+ * This is what makes deploy verification exact: most changes ship without a
+ * version bump, so `version` cannot answer "is MY change live?" — the commit
+ * can. `/ship` polls this until it matches the SHA it merged.
+ *
+ * Vercel injects `VERCEL_GIT_COMMIT_SHA` at build time. Self-hosted images
+ * have no such variable, so this degrades to "unknown" rather than failing:
+ * health is the one endpoint that must answer even when it knows least.
+ */
+function resolveCommit(): string {
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA;
+  return sha ? sha.slice(0, 7) : "unknown";
+}
+
+/**
  * Builds a JSON Response with `Cache-Control: no-store`.
  *
  * Health responses must never be cached — uptime monitors and operators need
@@ -72,9 +90,13 @@ function jsonHealthResponse(body: HealthBody, status: number): Response {
  * Operators want this even in a maintenance response so they can confirm
  * which build they are looking at.
  */
-function currentBuildIdentity(): Pick<HealthBody, "version" | "time"> {
+function currentBuildIdentity(): Pick<
+  HealthBody,
+  "version" | "commit" | "time"
+> {
   return {
     version: resolveVersion(),
+    commit: resolveCommit(),
     time: new Date().toISOString(),
   };
 }

--- a/tests/core/health/health-handler.test.ts
+++ b/tests/core/health/health-handler.test.ts
@@ -59,3 +59,55 @@ describe("handleHealthRequest", () => {
     expect(res.status).toBe(200);
   });
 });
+
+/**
+ * Deploy verification needs to answer "is MY change live?" exactly, not
+ * approximately. Version alone cannot: most changes ship without a version
+ * bump. The commit can, so /ship polls health until it reports the SHA it
+ * just merged (scripts/ship/verify-deploy.mjs).
+ */
+describe("handleHealthRequest — deployed commit", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MAINTENANCE_MODE;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("reports the short SHA of the deployed commit", async () => {
+    process.env.VERCEL_GIT_COMMIT_SHA = "abc1234def5678901234";
+
+    const body = await (
+      await handleHealthRequest(new Request("http://localhost/api/health"))
+    ).json();
+
+    expect(body.commit).toBe("abc1234");
+  });
+
+  it("reports 'unknown' when no commit is injected, still 200", async () => {
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+
+    // Self-hosted images have no Vercel git metadata; health must stay a 200
+    // there rather than degrading the one endpoint that reports liveness.
+    const res = await handleHealthRequest(
+      new Request("http://localhost/api/health"),
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).commit).toBe("unknown");
+  });
+
+  it("still reports the commit in a maintenance response", async () => {
+    process.env.VERCEL_GIT_COMMIT_SHA = "fedcba9876543210";
+    process.env.MAINTENANCE_MODE = "1";
+
+    const res = await handleHealthRequest(
+      new Request("http://localhost/api/health"),
+    );
+
+    expect(res.status).toBe(503);
+    expect((await res.json()).commit).toBe("fedcba9");
+  });
+});

--- a/tests/scripts/ship/verify-deploy.test.ts
+++ b/tests/scripts/ship/verify-deploy.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { isDeployLive } from "../../../scripts/ship/verify-deploy.mjs";
+
+/**
+ * "Is my change live?" must be answered exactly, not by waiting a while.
+ * Time-based verification is how a green deploy report can accompany stale
+ * code; comparing the commit production actually serves cannot.
+ */
+describe("isDeployLive", () => {
+  it("is live when health serves the target commit and reports ok", () => {
+    const verdict = isDeployLive({
+      health: { ok: true, commit: "abc1234" },
+      targetCommit: "abc1234def567890",
+    });
+    expect(verdict.live).toBe(true);
+  });
+
+  it("is not live while an older commit is still served", () => {
+    const verdict = isDeployLive({
+      health: { ok: true, commit: "0000000" },
+      targetCommit: "abc1234def567890",
+    });
+    expect(verdict.live).toBe(false);
+    expect(verdict.reason).toContain("0000000");
+  });
+
+  it("is not live when health reports not ok (maintenance or degraded)", () => {
+    const verdict = isDeployLive({
+      health: { ok: false, commit: "abc1234" },
+      targetCommit: "abc1234def567890",
+    });
+    expect(verdict.live).toBe(false);
+    expect(verdict.reason).toMatch(/not ok|maintenance/i);
+  });
+
+  it("is not live when the deployment cannot identify its commit", () => {
+    // "unknown" must never satisfy a prefix check against a real SHA.
+    const verdict = isDeployLive({
+      health: { ok: true, commit: "unknown" },
+      targetCommit: "abc1234def567890",
+    });
+    expect(verdict.live).toBe(false);
+  });
+
+  it("is not live when health could not be fetched at all", () => {
+    const verdict = isDeployLive({ health: null, targetCommit: "abc1234" });
+    expect(verdict.live).toBe(false);
+    expect(verdict.reason).toMatch(/unreachable|no response/i);
+  });
+
+  it("requires the served commit to prefix the target, not merely overlap", () => {
+    // A short SHA that is not a prefix (e.g. a different commit that shares
+    // characters) must not pass.
+    const verdict = isDeployLive({
+      health: { ok: true, commit: "bc1234d" },
+      targetCommit: "abc1234def567890",
+    });
+    expect(verdict.live).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements **Parts 1 and 3** of the [shipping design](docs/superpowers/specs/2026-08-05-end-to-end-shipping-design.md) (#253).

## Part 1 — the ship loop

- **Health reports the deployed commit.** Version can't answer "is *my* change live?" — most changes ship without a bump. The commit can. Degrades to `"unknown"` on self-hosted images rather than failing the one endpoint that must always answer.
- **`scripts/ship/verify-deploy.mjs`** polls `/api/health` until production serves the merged SHA. Waiting a fixed interval is how a green deploy report ends up accompanying stale code.
- **`/ship` skill**: local gate → PR → CI → auto-merge → verify live → report. ~5 min, unattended.

This removes *waiting*, not *verification* — all 7 required checks still gate every merge.

## Part 3 — CI for CI

- **`Workflow lint` (actionlint)** on every PR. **Verified against the real bug**: I reintroduced the exact 2026-08-02 `e2e.yml` dedent and actionlint reported `could not parse as YAML: could not find expected ':'` — the defect that silently disabled post-merge E2E from the moment it merged.
- **`release-rehearsal.yml`** runs nightly in throwaway mode and asserts the tag decision no-ops on an already-released main, the resolver honours an explicit input (*the reusable-call shape that regressed twice today*), a bare branch build stays throwaway, and a drifting tag is rejected. Failures file a tracking issue.

Also fixes two shellcheck findings actionlint surfaced in `ci.yml`: a double-quoted `trap` that expanded `$SERVE_PID` at definition time instead of on signal (so cleanup could kill the wrong thing), and an unused loop variable.

## Verification

- 9 new unit tests, RED first · `npm test` 3834 passed / 0 failed
- `tsc` clean · `check-env` clean (27/27, `VERCEL_GIT_COMMIT_SHA` documented) · **actionlint clean across all 9 workflows**
- Rehearsal assertions simulated against the real tree: `should_tag=false`, `release=true` for input and v-tag shapes, `release=false` for a bare branch, drift rejected

## Not in this PR

Part 2 (collapsing the release into one repo) lands separately — it touches the live feed and needs its own verification gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5