### PR TITLE
fix(feed): serve the release feed as atom+xml from its new origin

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -30,10 +30,50 @@
           "value": "geolocation=(), microphone=(), camera=()"
         }
       ]
+    },
+    {
+      "source": "/releases.xml",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/atom+xml; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    },
+    {
+      "source": "/releases.json",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
     }
   ],
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/$1" },
-    { "source": "/((?!api/).*)", "destination": "/index.html" }
+    {
+      "source": "/api/(.*)",
+      "destination": "/api/$1"
+    },
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
Follow-up to #255, caught while verifying the migration.

`my.feedzero.app/releases.xml` returned `application/xml`; the landing origin serves `application/atom+xml; charset=utf-8`. **Content is byte-identical** (verified with `diff` against the live feed) — only the type differed, because landing's Content-Type came from a headers rule in *its* vercel.json which didn't travel with the file. The response also carries `X-Content-Type-Options: nosniff`, so a client can't recover the intended type by sniffing.

Adds explicit header rules for `/releases.xml` (atom+xml) and `/releases.json`, with the same cache and CORS headers landing applied. Correct at this origin regardless of which layer's headers win once landing rewrites to it.

Blocks the landing rewrite PR (`feedzero-landing#ci/feed-from-app`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5