### PR TITLE
fix(api): restore api/health.ts as a wrapper so handler changes deploy again

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -30,10 +30,50 @@
           "value": "geolocation=(), microphone=(), camera=()"
         }
       ]
+    },
+    {
+      "source": "/releases.xml",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/atom+xml; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    },
+    {
+      "source": "/releases.json",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
     }
   ],
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/$1" },
-    { "source": "/((?!api/).*)", "destination": "/index.html" }
+    {
+      "source": "/api/(.*)",
+      "destination": "/api/$1"
+    },
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
**Production `/api/health` reports `version: "0.9.0"` while the app is 0.13.0.** The `commit` field added in #254 for deploy verification never appeared after merge. Rebuilding produced a byte-identical file — the endpoint is frozen.

## Root cause

`scripts/build-api.js` takes `api/*.ts` as its esbuild **entry points** and overwrites them in place (ADR 007: Vercel compiles each api file alone and won't resolve cross-directory imports). That's correct as a *build step* and wrong as a *committed state*.

Once a bundle was committed, the wrapper's `import ... from "../src/..."` was gone. Every later build then bundled the **already-bundled** file:

- source changes could no longer reach the endpoint, and
- an earlier `define` had baked `process.env.APP_VERSION` in as the literal `"0.9.0"` — which no later build could replace.

Evidence: rebuilding `api/health.ts` from current `main` produced **zero diff**, while the source had changed in #254.

## Fix

`api/health.ts` is a thin wrapper again. A fresh `npm run build:all` now emits `return "0.13.0"` and `resolveCommit()` into the bundle, proving source changes flow through.

## Prevention

`tests/scripts/api-wrappers.test.ts` asserts committed api files import from `src/` and carry no bundler artefacts. It reads via `git show` rather than the working tree, because `tests/build/api-bundle.test.ts` bundles `api/` in place mid-run — and its `git checkout -- api/` cleanup **silently discards uncommitted edits to `api/`**, a footgun that bit me twice while writing this.

## Scope — deliberately not fixed here

The other **eleven endpoints are also frozen** and listed in `KNOWN_FROZEN`. Several build adapters from env or pass option objects, so each needs its wrapper reconstructed from bundled output and verified on a preview deploy. That's per-endpoint work with real blast radius on live payment, sync and proxy routes — not a bulk edit, and not something to do unattended. Removing an entry from that list is the definition of done for that endpoint.

## Verification

- `npm test` 3843 passed / 0 failed · `tsc` clean · guard test RED before the wrapper, GREEN after
- **Before merging** I'll curl this PR's Vercel preview `/api/health` and confirm it returns `version: "0.13.0"` and a real `commit` — proving wrappers survive Vercel's build. If the preview is wrong, this must not merge.

Also includes the earlier `vercel.json` feed content-type rules (atom+xml for `/releases.xml`, json for `/releases.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5