### PR TITLE
fix(api): restore api/health.ts as a wrapper so handler changes deploy again

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -59,6 +59,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Deployment-artifact contract: the deployed /api/health must report the
+      # commit that was actually deployed. This catches the frozen-bundle
+      # class directly — api/*.ts are esbuild entry points that get overwritten
+      # in place, so committing built output silently detaches an endpoint from
+      # src/ and it stops receiving changes forever. Production served
+      # version "0.9.0" from a 0.13.0 app that way, undetected, until 2026-08-05.
+      - name: Deployed health reports the deployed commit
+        env:
+          SMOKE_BASE_URL: ${{ github.event.deployment_status.target_url }}
+          VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
+        run: |
+          node scripts/ship/verify-deploy.mjs \
+            "$SMOKE_BASE_URL" \
+            "${{ github.event.deployment.sha }}" \
+            120 \
+            "$VERCEL_PROTECTION_BYPASS"
+
       - name: Run cross-device sync smoke against the preview deploy
         env:
           SMOKE_TESTS: '1'

--- a/api/health.ts
+++ b/api/health.ts
@@ -1,47 +1,16 @@
-// @ts-nocheck
-// api/health.ts
-function isFlagEnabled(name, env = process.env) {
-  return env[name] === "1";
-}
-function resolveVersion() {
-  const viteVersion = readViteAppVersion();
-  if (viteVersion) return viteVersion;
-  return "0.9.0";
-}
-function readViteAppVersion() {
-  try {
-    const env = import.meta.env;
-    return env?.VITE_APP_VERSION;
-  } catch {
-    return void 0;
-  }
-}
-function jsonHealthResponse(body, status) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store"
-    }
-  });
-}
-function handleHealthRequest(_request) {
-  const body = {
-    ok: true,
-    version: resolveVersion(),
-    time: (/* @__PURE__ */ new Date()).toISOString()
-  };
-  if (isFlagEnabled("MAINTENANCE_MODE")) {
-    return jsonHealthResponse(
-      { ...body, ok: false, maintenance: true },
-      503
-    );
-  }
-  return jsonHealthResponse(body, 200);
-}
-function GET(req) {
+// Thin Vercel wrapper. ADR 007: scripts/build-api.js replaces this file with
+// a self-contained esbuild bundle AT BUILD TIME, because Vercel compiles each
+// api file individually and will not resolve cross-directory imports.
+//
+// This file must stay a wrapper IN GIT. Committing the built output freezes
+// the endpoint: the import below disappears, the next build bundles the
+// already-bundled file, and every later change to the shared handler silently
+// stops deploying. That is how production served version "0.9.0" from a 0.13.0
+// app — an earlier build inlined `process.env.APP_VERSION` as a literal, after
+// which no later build could replace it. Guarded by
+// tests/scripts/api-wrappers.test.ts.
+import { handleHealthRequest } from "../src/core/health/health-handler";
+
+export function GET(req: Request): Response {
   return handleHealthRequest(req);
 }
-export {
-  GET
-};

--- a/scripts/ship/verify-deploy.mjs
+++ b/scripts/ship/verify-deploy.mjs
@@ -50,10 +50,15 @@ export function isDeployLive({ health, targetCommit }) {
   return { live: true, reason: `${health.commit} is live` };
 }
 
-async function fetchHealth(baseUrl) {
+async function fetchHealth(baseUrl, bypassToken) {
   try {
+    const headers = { "Cache-Control": "no-cache" };
+    // Vercel Preview Deployment Protection 302s every request at the edge
+    // before app code runs; the automation bypass token exempts CI.
+    if (bypassToken) headers["x-vercel-protection-bypass"] = bypassToken;
+
     const res = await fetch(`${baseUrl.replace(/\/$/, "")}/api/health`, {
-      headers: { "Cache-Control": "no-cache" },
+      headers,
     });
     // 503 is a maintenance response with a valid body; parse it either way.
     return await res.json();
@@ -65,10 +70,11 @@ async function fetchHealth(baseUrl) {
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function runCli() {
-  const [baseUrl, targetCommit, timeoutArg] = process.argv.slice(2);
+  const [baseUrl, targetCommit, timeoutArg, bypassToken] =
+    process.argv.slice(2);
   if (!baseUrl || !targetCommit) {
     console.error(
-      "usage: verify-deploy.mjs <baseUrl> <targetCommit> [timeoutSeconds]",
+      "usage: verify-deploy.mjs <baseUrl> <targetCommit> [timeoutSeconds] [vercelBypassToken]",
     );
     process.exit(2);
   }
@@ -79,7 +85,7 @@ async function runCli() {
   let verdict = { live: false, reason: "not started" };
   while (Date.now() - startedAt < timeoutMs) {
     verdict = isDeployLive({
-      health: await fetchHealth(baseUrl),
+      health: await fetchHealth(baseUrl, bypassToken),
       targetCommit,
     });
     const elapsed = Math.round((Date.now() - startedAt) / 1000);

--- a/tests/scripts/api-wrappers.test.ts
+++ b/tests/scripts/api-wrappers.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const REPO = path.resolve(__dirname, "../..");
+
+const git = (...args: string[]) =>
+  execFileSync("git", args, { cwd: REPO, encoding: "utf8" });
+
+/**
+ * Read COMMITTED content, not the working tree.
+ *
+ * tests/build/api-bundle.test.ts deliberately bundles api/ in place and
+ * restores it afterwards, so the working tree holds build output for part of
+ * any run. The invariant here is about what is committed, and reading from
+ * git also makes this test immune to that interleaving.
+ */
+const committed = (relPath: string) => git("show", `HEAD:${relPath}`);
+
+const apiFiles = () =>
+  git("ls-files", "api")
+    .split("\n")
+    .filter((f) => f.endsWith(".ts"));
+
+/**
+ * `api/*.ts` in git must be THIN WRAPPERS that import from `src/`.
+ *
+ * scripts/build-api.js takes api/*.ts as its esbuild entry points and
+ * overwrites them in place with self-contained bundles (ADR 007 — Vercel
+ * compiles each api file individually and will not resolve cross-directory
+ * imports). That is correct as a BUILD step and wrong as a COMMITTED state:
+ * once a bundle is committed, the wrapper's `import ... from "../src/..."` is
+ * gone, so the next build bundles the already-bundled file and every later
+ * change to the shared handler silently fails to deploy.
+ *
+ * That is not hypothetical. Every api file was a committed bundle, and
+ * production served `/api/health` with `version: "0.9.0"` while the app was
+ * at 0.13.0 — an earlier build had inlined `process.env.APP_VERSION` as the
+ * literal "0.9.0", after which no later build could ever replace it.
+ *
+ * If this test fails: do NOT commit the built output. Restore the wrapper,
+ * and let the build produce bundles into the deployment only.
+ */
+/**
+ * Endpoints still frozen as committed bundles, tracked for restoration.
+ *
+ * Restoring one means reconstructing its wrapper from bundled output —
+ * several build adapters from env or pass option objects — and verifying the
+ * rebuilt endpoint on a preview deployment before merge. That is per-endpoint
+ * work with real blast radius, so it is deliberately not done in bulk.
+ *
+ * Removing an entry from this list is the definition of done for that
+ * endpoint. Do not add to it.
+ */
+const KNOWN_FROZEN = new Set([
+  "api/briefing.ts",
+  "api/catalog.ts",
+  "api/checkout/create-session.ts",
+  "api/feed.ts",
+  "api/feedback.ts",
+  "api/icon.ts",
+  "api/license/[action].ts",
+  "api/page.ts",
+  "api/stats-sync.ts",
+  "api/stripe/webhook.ts",
+  "api/sync.ts",
+]);
+
+describe("api wrappers stay wrappers (ADR 007)", () => {
+  const files = apiFiles().filter((f) => !KNOWN_FROZEN.has(f));
+
+  it("finds the api entry points", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)(
+    "%s imports its handler from src/ instead of inlining it",
+    (file) => {
+      const source = committed(file);
+
+      expect(
+        /from\s+["']\.\.?\/(\.\.\/)*src\//.test(source),
+        "no import from src/ — this looks like committed build output",
+      ).toBe(true);
+    },
+  );
+
+  it.each(files)("%s carries no bundler artefacts", (file) => {
+    const source = committed(file);
+
+    // esbuild stamps @ts-nocheck and pure-annotation comments into output.
+    expect(source).not.toContain("@ts-nocheck");
+    expect(source).not.toContain("/* @__PURE__ */");
+  });
+});


### PR DESCRIPTION
**Production `/api/health` reports `version: "0.9.0"` while the app is 0.13.0**, and the `commit` field added in #254 never appeared after merge. Rebuilding produces a byte-identical file — the endpoint is frozen.

## Root cause

`scripts/build-api.js` takes `api/*.ts` as its esbuild **entry points** and overwrites them in place (ADR 007: Vercel compiles each api file alone and won't resolve cross-directory imports). Correct as a *build step*; wrong as a *committed state*.

Once a bundle was committed, the wrapper's `import ... from "../src/..."` was gone. Every later build then bundled the **already-bundled** file, so:

- source changes could no longer reach the endpoint, and
- an earlier `define` had baked `process.env.APP_VERSION` in as the literal `"0.9.0"`, which no later build could replace.

Evidence: rebuilding `api/health.ts` from current `main` produced **zero diff**, though the source changed in #254.

## Fix

`api/health.ts` is a thin wrapper again. A fresh `npm run build:all` emits `return "0.13.0"` and `resolveCommit()` into the bundle, proving source changes flow through.

## Prevention

`tests/scripts/api-wrappers.test.ts` asserts committed api files import from `src/` and carry no bundler artefacts. It reads via `git show` rather than the working tree, because `tests/build/api-bundle.test.ts` bundles `api/` in place mid-run — and its `git checkout -- api/` cleanup **silently discards uncommitted edits to `api/`**, which cost me two attempts here.

## Scope — deliberately partial

The other **eleven endpoints are also frozen**, listed in `KNOWN_FROZEN`. Several build adapters from env or pass option objects, so each needs its wrapper reconstructed from bundled output and verified on a preview deploy. That's per-endpoint work on live payment, sync and proxy routes — not a bulk edit, and not something to do unattended. Removing an entry from that list is the definition of done for that endpoint.

## Verification

- `npm test` 3843 passed / 0 failed · `tsc` clean · guard RED before the wrapper, GREEN after
- **Gate before merge:** curl this PR's Vercel preview `/api/health` and require `version: "0.13.0"` plus a real `commit`. That proves wrappers survive Vercel's build. If the preview is wrong, this must not merge — it would break the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5