### PR TITLE
fix(e2e): repair the post-merge suite — 18 failures to zero

### DIFF
--- a/tests/e2e/content-viewing.spec.ts
+++ b/tests/e2e/content-viewing.spec.ts
@@ -94,8 +94,11 @@ test.describe("Content viewing", () => {
   test("article title is a link to the original URL", async ({ feedPage: page }) => {
     await setupFeed(page);
 
-    // The article title is rendered as an <a> linking to the original article.
-    const titleLink = page.getByRole("link", { name: /First Article/ });
+    // Scope to the reader: on mobile the list stays mounted behind the
+    // reader overlay, so an unscoped /First Article/ link matches twice.
+    const titleLink = page
+      .getByTestId("reader-scroll-container")
+      .getByRole("link", { name: /First Article/ });
     await expect(titleLink).toBeVisible({ timeout: 10000 });
     await expect(titleLink).toHaveAttribute("href", "https://example.com/first");
     await expect(titleLink).toHaveAttribute("target", "_blank");

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect, addFeedViaUI, selectFeedInSidebar } from "./fixtures";
+import {
+  test,
+  expect,
+  addFeedViaUI,
+  openArticle,
+  selectFeedInSidebar,
+} from "./fixtures";
 import {
   mockFeedEndpointError,
   mockFeedEndpointHtml,
@@ -47,6 +53,10 @@ test.describe("Error states", () => {
     await expect(articleOption(page, "First Article")).toBeVisible({
       timeout: 10000,
     });
+
+    // Desktop auto-selects the first article; mobile does not, so the reader
+    // (and the Full text toggle in it) only exists after opening one.
+    await openArticle(page, "First Article");
 
     // The auto-extract triggers in background for short content articles.
     // Since the mock returns 500, extraction fails and disables the Full text toggle.

--- a/tests/e2e/favicon.spec.ts
+++ b/tests/e2e/favicon.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "./fixtures";
+import { test, expect, openSidebar } from "./fixtures";
 import { mockFeedEndpoint, SAMPLE_RSS } from "./feed-fixtures";
 
 // 1x1 red PNG (68 bytes) — a real decodable image for the browser
@@ -42,6 +42,10 @@ test.describe("Favicon rendering", () => {
 
     await addFeedViaExplore(page, "https://example.com/feed");
 
+    // Mobile keeps the feed list in a closed drawer; open it before
+    // asserting on sidebar contents.
+    await openSidebar(page);
+
     // Wait for the feed to appear in the sidebar
     await expect(
       page.locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" }),
@@ -83,6 +87,9 @@ test.describe("Favicon rendering", () => {
 
     await addFeedViaExplore(page, "https://example.com/feed");
 
+    // Mobile keeps the feed list in a closed drawer.
+    await openSidebar(page);
+
     await expect(
       page.locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" }),
     ).toBeVisible({ timeout: 10000 });
@@ -112,6 +119,9 @@ test.describe("Favicon rendering", () => {
     });
 
     await addFeedViaExplore(page, "https://example.com/feed");
+
+    // Mobile keeps the feed list in a closed drawer.
+    await openSidebar(page);
 
     await expect(
       page.locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" }),

--- a/tests/e2e/feed-management.spec.ts
+++ b/tests/e2e/feed-management.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect, addFeedViaUI, selectFeedInSidebar } from "./fixtures";
+import {
+  test,
+  expect,
+  addFeedViaUI,
+  openSidebar,
+  openViewSettings,
+  selectFeedInSidebar,
+} from "./fixtures";
 import {
   SAMPLE_RSS,
   mockFeedEndpoint,
@@ -39,8 +46,9 @@ test.describe("Feed management", () => {
     // Ensure the feed is selected so the context-aware settings pill renders.
     await selectFeedInSidebar(page, "Test Feed");
 
-    // Open per-feed settings via the floating cog above the article list.
-    await page.getByTestId("settings-pill").click();
+    // Desktop shows a dedicated cog; mobile folds the same entry into the
+    // "View options" menu. openViewSettings handles both.
+    await openViewSettings(page);
     await page.getByTestId("feed-settings-delete").click();
 
     // Confirmation dialog should appear with the feed title in the body.
@@ -66,14 +74,21 @@ test.describe("Feed management", () => {
 
     await selectFeedInSidebar(page, "Test Feed");
 
-    await page.getByTestId("settings-pill").click();
+    await openViewSettings(page);
     await page.getByTestId("feed-settings-delete").click();
     await page.getByTestId("feed-settings-delete-cancel").click();
 
-    // Close the settings dialog so the sidebar is uncovered.
-    await page.keyboard.press("Escape");
+    // Close the settings dialog so the sidebar is uncovered. Escape used to
+    // be enough; after cancelling the nested AlertDialog the focus target
+    // changes and the outer dialog stayed open, so click its Done button.
+    await page.getByRole("button", { name: "Done" }).click();
+    // Radix keeps the overlay mounted through its close animation; clicking
+    // the drawer trigger underneath before it unmounts silently does nothing.
+    await expect(page.getByRole("dialog")).toBeHidden({ timeout: 5000 });
 
-    // Feed should still be there
+    // Feed should still be there. On mobile the list lives in a drawer that
+    // the dialog left closed.
+    await openSidebar(page);
     await expect(
       page.locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" }),
     ).toBeVisible();

--- a/tests/e2e/feed-refresh.spec.ts
+++ b/tests/e2e/feed-refresh.spec.ts
@@ -62,15 +62,35 @@ test.describe("Feed refresh", () => {
     });
   });
 
-  test("refresh shows spinner", async ({ feedPage: page }) => {
+  test("refresh shows spinner", async ({ feedPage: page }, testInfo) => {
+    // The Refresh button is a desktop affordance. Mobile replaced the old
+    // row of pills with pull-to-refresh (see ViewOptionsPill), so there is
+    // no button to click or disable there.
+    test.skip(
+      testInfo.project.name === "mobile",
+      "Mobile refreshes by pull-to-refresh, not a Refresh button",
+    );
+
     await mockFeedEndpoint(page, SAMPLE_RSS);
     await addFeedViaUI(page, "https://example.com/feed");
 
-    // Add a delay to the feed response so we can observe the spinner
+    // The Refresh button only renders once the store has a feed
+    // (`feeds.length > 0` in app-sidebar). addFeedViaUI can return on the
+    // success toast before that lands, so wait for the button itself rather
+    // than assuming it is there — under parallel load it was not.
+    const refreshButton = page.getByRole("button", { name: "Refresh" });
+    await refreshButton.waitFor({ state: "visible", timeout: 15000 });
+
+    // Delay the feed response so the spinner is observable. The delay must
+    // comfortably exceed the assertion timeouts below: at 1s it raced them
+    // whenever parallel workers loaded the machine, which is what made this
+    // spec flaky. Holding the response open indefinitely instead is NOT an
+    // option — the app's boot refresh hits this same route, so an unreleased
+    // request stalls the UI before the Refresh button ever renders.
     await page.unroute("**/api/feed*");
     await page.route("**/api/feed*", async (route) => {
-      await new Promise((r) => setTimeout(r, 1000));
-      route.fulfill({
+      await new Promise((r) => setTimeout(r, 4000));
+      await route.fulfill({
         status: 200,
         contentType: "text/xml",
         body: SAMPLE_RSS,
@@ -83,13 +103,19 @@ test.describe("Feed refresh", () => {
     // Refresh button should be disabled during refresh
     await expect(
       page.getByRole("button", { name: "Refresh" }),
-    ).toBeDisabled({ timeout: 2000 });
+    ).toBeDisabled({ timeout: 3000 });
 
     // The icon inside the button should have animate-spin
     const svg = page
       .getByRole("button", { name: "Refresh" })
       .locator("svg");
-    await expect(svg).toHaveClass(/animate-spin/, { timeout: 2000 });
+    await expect(svg).toHaveClass(/animate-spin/, { timeout: 3000 });
+
+    // Let the in-flight refresh settle so the route handler doesn't outlive
+    // the test and leak into teardown.
+    await expect(
+      page.getByRole("button", { name: "Refresh" }),
+    ).toBeEnabled({ timeout: 15000 });
   });
 
   test("duplicate articles not added on refresh", async ({

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base, type Page } from "@playwright/test";
+import { test as base, expect as pwExpect, type Page } from "@playwright/test";
 
 export { expect } from "@playwright/test";
 
@@ -140,6 +140,98 @@ export async function selectFeedInSidebar(page: Page, feedName: string) {
   // Force click — sidebar buttons have CSS transitions that Playwright
   // considers "not stable", causing actionability timeouts
   await feedButton.click({ force: true });
+}
+
+/**
+ * Make the feed list reachable, whatever the viewport.
+ *
+ * On desktop the sidebar is always mounted; on mobile it is a vaul drawer
+ * that starts closed. Specs that assert on sidebar contents (favicons, the
+ * release-notes subscription) were querying `[data-sidebar="menu-button"]`
+ * directly and timing out on mobile against a drawer nobody had opened.
+ */
+export async function openSidebar(page: Page) {
+  const anyFeedButton = page.locator('[data-sidebar="menu-button"]').first();
+  if (await anyFeedButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+    return;
+  }
+
+  const drawerTrigger = page.getByRole("button", { name: /open feed list/i });
+  if (await drawerTrigger.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await drawerTrigger.click();
+    // vaul slides the drawer up; clicking mid-animation resolves buttons
+    // while they are still off-viewport.
+    await page
+      .locator('[data-testid="drawer-content"][data-state="open"]')
+      .waitFor({ state: "visible", timeout: 10000 })
+      .catch(() => {});
+    await page.waitForTimeout(350);
+    return;
+  }
+
+  const legacyTrigger = page.locator('[data-sidebar="trigger"]');
+  if (await legacyTrigger.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await legacyTrigger.click();
+  }
+}
+
+/**
+ * Open an article in the reader.
+ *
+ * Desktop auto-selects the first article, so specs could assert on reader
+ * chrome immediately. Mobile deliberately does not — the article list is a
+ * destination, not a transient state (see FeedsRoute) — so the reader and
+ * everything in it only exists after a tap.
+ */
+export async function openArticle(page: Page, title: string | RegExp) {
+  const option = page.locator('[role="option"]', { hasText: title });
+  await option.first().waitFor({ state: "visible", timeout: 10000 });
+  await option.first().click();
+}
+
+/**
+ * Open the contextual feed/folder/filter settings dialog.
+ *
+ * Desktop shows a dedicated cog (`settings-pill`) above the article list.
+ * Mobile consolidated the old row of three same-looking pills into one
+ * "View options" menu, with the settings entry inside it, so a spec that
+ * clicks `settings-pill` finds nothing there.
+ */
+export async function openViewSettings(page: Page) {
+  const settingsPill = page.getByTestId("settings-pill");
+  if (await settingsPill.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await settingsPill.click();
+    return;
+  }
+
+  await page.getByTestId("view-options-pill").click();
+  // The last item in the menu is the contextual settings entry ("Feed
+  // settings…", "Folder settings…"), rendered only when a target exists.
+  await page.getByRole("menuitem", { name: /settings…$/ }).click();
+}
+
+/**
+ * Wait until no refresh is in flight, on either viewport.
+ *
+ * `refreshAll()` no-ops while another refresh is running (feed-store guard),
+ * so a spec that triggers a refresh too early has it silently swallowed. The
+ * disabled state of the refresh control is the observable signal — desktop
+ * has a "Refresh" button in the sidebar, mobile has `drawer-refresh-all`
+ * inside the nav drawer.
+ */
+export async function waitForRefreshIdle(page: Page) {
+  const desktopRefresh = page.getByRole("button", {
+    name: "Refresh",
+    exact: true,
+  });
+  if (await desktopRefresh.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await pwExpect(desktopRefresh).toBeEnabled({ timeout: 15000 });
+    return;
+  }
+
+  await openSidebar(page);
+  const drawerRefresh = page.getByTestId("drawer-refresh-all");
+  await pwExpect(drawerRefresh).toBeEnabled({ timeout: 15000 });
 }
 
 /**

--- a/tests/e2e/import-recovery.spec.ts
+++ b/tests/e2e/import-recovery.spec.ts
@@ -11,7 +11,10 @@
  * to retry fetching the feed(s) later via the refresh button or the
  * 'r' key."
  */
-import { test, expect } from "./fixtures";
+import { test, expect,
+  openSidebar,
+  waitForRefreshIdle,
+} from "./fixtures";
 import { SAMPLE_RSS, readTargetUrlFromBody } from "./feed-fixtures";
 
 const URL_LIST = `https://ok.example.com/feed
@@ -102,9 +105,15 @@ test.describe("Import recovery — placeholder for rate-limited URLs", () => {
     await page.goto("/feeds");
 
     // Placeholder sidebar label is the URL host because metadata hasn't
-    // been fetched yet. The OK feed shows its parsed <title>.
-    await expect(page.getByText("Test Feed")).toBeVisible();
-    await expect(page.getByText("rate-limited.example.com")).toBeVisible();
+    // been fetched yet. The OK feed shows its parsed <title>. Scope to the
+    // sidebar: "Test Feed" also appears in the breadcrumb and the mobile
+    // dock, so an unscoped getByText matches several nodes.
+    await openSidebar(page);
+    const sidebarFeeds = page.locator('[data-sidebar="menu-button"]');
+    await expect(sidebarFeeds.filter({ hasText: "Test Feed" })).toBeVisible();
+    await expect(
+      sidebarFeeds.filter({ hasText: "rate-limited.example.com" }),
+    ).toBeVisible();
 
     // The placeholder carries the red failed-feed indicator.
     const failedIndicator = page.getByTestId("failed-feed-indicator");
@@ -119,9 +128,7 @@ test.describe("Import recovery — placeholder for rate-limited URLs", () => {
     // feed would never get re-fetched in the recovered phase. Wait for the
     // in-flight refresh to finish (the sidebar Refresh button re-enables)
     // before flipping the phase, so the keypress drives a real refresh.
-    await expect(
-      page.getByRole("button", { name: "Refresh", exact: true }),
-    ).toBeEnabled({ timeout: 15000 });
+    await waitForRefreshIdle(page);
 
     // The boot refresh's 429 registered a host-pause for ~1s (see the
     // Retry-After header on the mock). Wait it out before pressing "r"

--- a/tests/e2e/layout-scroll.spec.ts
+++ b/tests/e2e/layout-scroll.spec.ts
@@ -65,7 +65,16 @@ test.describe("Layout and scroll", () => {
     expect(afterScroll).toBe(0);
   });
 
-  test("article list scrolls independently", async ({ feedPage: page }) => {
+  test("article list scrolls independently", async ({ feedPage: page }, testInfo) => {
+    // Desktop-only by construction: the two-pane layout (list beside reader,
+    // each its own scroll container, separated by drag handles) does not
+    // exist on mobile. There the reader is an overlay opened by tapping an
+    // article, so there is no second pane to scroll or handle to drag.
+    test.skip(
+      testInfo.project.name === "mobile",
+      "Two-pane scroll/resize is a desktop layout; mobile uses an overlay reader",
+    );
+
     await setupFeed(page);
 
     // Article-list panel's scroll container is the direct div child of the
@@ -84,7 +93,16 @@ test.describe("Layout and scroll", () => {
     expect(readerAfter).toBe(readerBefore);
   });
 
-  test("reader scrolls independently", async ({ feedPage: page }) => {
+  test("reader scrolls independently", async ({ feedPage: page }, testInfo) => {
+    // Desktop-only by construction: the two-pane layout (list beside reader,
+    // each its own scroll container, separated by drag handles) does not
+    // exist on mobile. There the reader is an overlay opened by tapping an
+    // article, so there is no second pane to scroll or handle to drag.
+    test.skip(
+      testInfo.project.name === "mobile",
+      "Two-pane scroll/resize is a desktop layout; mobile uses an overlay reader",
+    );
+
     await setupFeed(page);
 
     // Inject tall content into the reader so it has somewhere to scroll to.
@@ -110,7 +128,16 @@ test.describe("Layout and scroll", () => {
     expect(listAfter).toBe(listBefore);
   });
 
-  test("outer handle resizes sidebar vs stage", async ({ feedPage: page }) => {
+  test("outer handle resizes sidebar vs stage", async ({ feedPage: page }, testInfo) => {
+    // Desktop-only by construction: the two-pane layout (list beside reader,
+    // each its own scroll container, separated by drag handles) does not
+    // exist on mobile. There the reader is an overlay opened by tapping an
+    // article, so there is no second pane to scroll or handle to drag.
+    test.skip(
+      testInfo.project.name === "mobile",
+      "Two-pane scroll/resize is a desktop layout; mobile uses an overlay reader",
+    );
+
     // Two-tier model: the outer ResizablePanelGroup has [sidebar, stage] —
     // the only place sidebar width changes. Drag the *first* (outer) handle
     // and assert the sidebar panel's width changed. .first() is required
@@ -149,7 +176,16 @@ test.describe("Layout and scroll", () => {
 
   test("inner handle resizes article-list vs reader, leaves sidebar alone", async ({
     feedPage: page,
-  }) => {
+  }, testInfo) => {
+    // Desktop-only by construction: the two-pane layout (list beside reader,
+    // each its own scroll container, separated by drag handles) does not
+    // exist on mobile. There the reader is an overlay opened by tapping an
+    // article, so there is no second pane to scroll or handle to drag.
+    test.skip(
+      testInfo.project.name === "mobile",
+      "Two-pane scroll/resize is a desktop layout; mobile uses an overlay reader",
+    );
+
     // The inner ResizablePanelGroup persists the article-list/reader split
     // independently of the sidebar. Dragging its handle must NOT change the
     // sidebar's width — that's the structural promise of the two-tier model.

--- a/tests/e2e/release-feed.spec.ts
+++ b/tests/e2e/release-feed.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { readFileSync } from "fs";
-import { skipOnboarding } from "./fixtures";
+import { openSidebar, skipOnboarding } from "./fixtures";
 
 /**
  * E2E test for the first-launch auto-subscribe flow.
@@ -50,11 +50,10 @@ test.describe("Release notes auto-subscribe", () => {
       page.locator("text=FeedZero Release Notes"),
     ).toBeVisible({ timeout: 15000 });
 
-    // On mobile the sidebar is offcanvas — open it to verify the feed button.
-    const trigger = page.locator('[data-sidebar="trigger"]');
-    if (await trigger.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await trigger.click();
-    }
+    // On mobile the feed list is a vaul drawer. This used to click the
+    // legacy [data-sidebar="trigger"], which no longer exists, so the
+    // assertion below ran against a closed drawer.
+    await openSidebar(page);
 
     const releaseFeedButton = page.locator('[data-sidebar="menu-button"]', {
       hasText: "FeedZero Release Notes",

--- a/tests/e2e/sidebar-width-stability.spec.ts
+++ b/tests/e2e/sidebar-width-stability.spec.ts
@@ -31,7 +31,11 @@ async function sidebarWidth(page: import("@playwright/test").Page) {
 test.describe("Sidebar width stability across routes (ADR 013)", () => {
   test.skip(({ viewport }) => (viewport?.width ?? 1280) < 1024, "Desktop only");
 
-  test("sidebar width survives Feed → Explore → Feed navigation", async ({ page }) => {
+  // `feedPage`, not the bare `page`: the raw fixture leaves onboarding up,
+  // so Explore never rendered and addFeedViaUI timed out on its search input.
+  test("sidebar width survives Feed → Explore → Feed navigation", async ({
+    feedPage: page,
+  }) => {
     await mockFeedEndpoint(page, SAMPLE_RSS);
     await addFeedViaUI(page, "https://example.com/feed");
     await selectFeedInSidebar(page, "Test Feed");

--- a/tests/e2e/sync.spec.ts
+++ b/tests/e2e/sync.spec.ts
@@ -12,26 +12,17 @@ import type { Page } from "@playwright/test";
  * self-host-gated path, so anchoring on Danger zone keeps this helper
  * robust across both modes.
  *
- * On mobile, the sidebar Settings button is inside the bottom drawer which
- * we open first.
+ * Desktop puts Settings in the sidebar menu; mobile puts it in the
+ * always-visible dock as an icon button carrying only an aria-label. The
+ * previous "open the drawer and look for a menu-button" path found nothing
+ * there, which is what kept the mobile sync specs red.
  */
 async function goToSyncSection(page: Page) {
-  const settingsBtn = page.locator('[data-sidebar="menu-button"]', {
-    hasText: "Settings",
-  });
-  if (!(await settingsBtn.isVisible())) {
-    // Mobile: settings is inside the bottom drawer.
-    const drawerHandle = page.getByRole("button", { name: /open feed list/i });
-    if (await drawerHandle.isVisible()) {
-      await drawerHandle.click();
-    } else {
-      const sidebarTrigger = page
-        .getByRole("main")
-        .getByRole("button", { name: /toggle sidebar/i });
-      await sidebarTrigger.click();
-    }
-    await settingsBtn.waitFor({ state: "visible", timeout: 5000 });
-  }
+  const settingsBtn = page
+    .locator('[data-sidebar="menu-button"]', { hasText: "Settings" })
+    .or(page.getByRole("button", { name: "Settings", exact: true }))
+    .first();
+  await settingsBtn.waitFor({ state: "visible", timeout: 10000 });
 
   await settingsBtn.click();
   await page.waitForURL(/\/settings/, { timeout: 5000 });
@@ -59,16 +50,14 @@ test.describe("Sync", () => {
   test("clicking the sidebar Settings button navigates to /settings", async ({
     feedPage: page,
   }) => {
-    const settingsBtn = page.locator('[data-sidebar="menu-button"]', {
-      hasText: "Settings",
-    });
-    if (!(await settingsBtn.isVisible())) {
-      const drawerHandle = page.getByRole("button", { name: /open feed list/i });
-      if (await drawerHandle.isVisible()) {
-        await drawerHandle.click();
-      }
-      await settingsBtn.waitFor({ state: "visible", timeout: 5000 });
-    }
+    // Desktop puts Settings in the sidebar menu; mobile puts it in the
+    // always-visible dock as an icon button (aria-label only), so the old
+    // "open the drawer and look for a menu-button" path found nothing.
+    const settingsBtn = page
+      .locator('[data-sidebar="menu-button"]', { hasText: "Settings" })
+      .or(page.getByRole("button", { name: "Settings", exact: true }))
+      .first();
+    await settingsBtn.waitFor({ state: "visible", timeout: 10000 });
     await settingsBtn.click();
     await page.waitForURL(/\/settings/, { timeout: 5000 });
   });
@@ -89,10 +78,16 @@ test.describe("Sync", () => {
     ).toBeVisible({ timeout: 5000 });
     await confirm.getByRole("button", { name: /delete everything/i }).click();
 
-    // resetApp() doesn't navigate — it just clears the DB and re-onboards
-    // silently. The deterministic post-reset signal is the dialog closing,
-    // and the previously-added Test Feed no longer appearing in the sidebar.
-    await expect(confirm).toBeHidden({ timeout: 15000 });
+    // resetApp() clears the DB and drops the user back into onboarding. The
+    // deterministic post-reset signal is that welcome dialog appearing, plus
+    // the previously-added Test Feed being gone.
+    //
+    // This used to assert `getByRole("dialog")` became hidden, which cannot
+    // hold: the confirm dialog closes but the onboarding dialog opens in its
+    // place, so the generic role query keeps matching.
+    await expect(
+      page.getByRole("dialog", { name: /welcome to feedzero/i }),
+    ).toBeVisible({ timeout: 15000 });
     await expect(
       page.locator('[data-sidebar="menu-button"]', { hasText: "Test Feed" }),
     ).toHaveCount(0, { timeout: 5000 });


### PR DESCRIPTION
Closes #247 (E2E red on main).

CI reported **14 mobile failures**. Running the suite locally surfaced **4 more that CI never showed** — shard 3/6 was cancelled by fail-fast before it could report, so `sync.spec.ts` and `sidebar-width-stability.spec.ts` were failing invisibly.

## These were stale tests, not app bugs

UX batch 2 rearchitected mobile: the reader became an overlay opened by tapping, the feed list moved into a vaul drawer, three pills consolidated into one "View options" menu, refresh became the pull-to-refresh gesture, settings moved to the dock. The specs still encoded the pre-batch-2, desktop-shaped layout.

I verified the app against its source in each case rather than assuming the test was wrong — e.g. `FeedsRoute` deliberately skips auto-select on mobile ("the article list is a first-class destination"), which is exactly why `reader-scroll-container` never appeared.

## Fixes

Shared helpers in `fixtures.ts` — `openSidebar`, `openArticle`, `openViewSettings`, `waitForRefreshIdle` — so specs stop hand-rolling viewport-specific paths, which is what drifted in the first place. Then per spec:

| Spec | Cause |
|---|---|
| `layout-scroll` ×4 | Two-pane scroll/resize is desktop-only; mobile has no second pane or drag handle → marked desktop-only |
| `favicon` ×3, `release-feed`, `import-recovery` | Asserted on sidebar contents without opening the drawer. `release-feed` clicked the legacy `[data-sidebar="trigger"]`, which no longer exists |
| `feed-management` ×2 | Settings moved into the View options menu; also needed to wait for the dialog to unmount before touching the page beneath |
| `error-states` | Full-text toggle lives in the reader, which needs a tap on mobile |
| `content-viewing`, `import-recovery` | Strict-mode violations: the list stays mounted behind the reader overlay, so unscoped text matched several nodes |
| `sync` ×3 | Settings is a dock icon button (aria-label only) on mobile. **The reset assertion could never hold**: it waited for `getByRole("dialog")` to hide, but resetting opens the onboarding dialog in its place — now asserts that welcome dialog, the real post-reset signal |
| `sidebar-width-stability` | Used the bare `page` fixture, so onboarding was never skipped and Explore never rendered |
| `feed-refresh` | Refresh only renders once `feeds.length > 0`; also a 1s mocked delay raced 2s assertions under parallel load |

## Verification

**149 E2E passed / 0 failed** across desktop + mobile, over repeated full runs · 3865 unit tests · `tsc` clean.

One honest caveat: `import-recovery` flaked once in five full local runs (it depends on a rate-limit `Retry-After` window and a fixed wait). It passed 3/3 in isolation and in every subsequent run. CI's 6-way sharding means less contention than a local full run, but if it resurfaces it wants a condition-based wait rather than a sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5