### PR TITLE
fix(self-host): point Docker at DATA_DIR so sync can write its vaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /app
 ENV NODE_ENV=production \
     SELF_HOSTED=1 \
     SYNC_STORAGE=filesystem \
-    SYNC_FILESYSTEM_DIR=/data/vaults \
+    DATA_DIR=/data \
     PORT=3000
 
 # Production deps only. `tsx` is needed at runtime because `serve`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,16 @@ services:
     environment:
       SELF_HOSTED: "1"
       SYNC_STORAGE: filesystem
-      SYNC_FILESYSTEM_DIR: /data/vaults
+      # Inside the container the vault directory is always /data — the
+      # Dockerfile creates it and gives it to the `node` user. This is the
+      # variable resolveAdapter reads; it previously set SYNC_FILESYSTEM_DIR,
+      # which nothing consumes, so sync fell back to a relative ./data under
+      # /app and failed with EACCES (#224).
+      DATA_DIR: /data
       PORT: "3000"
     volumes:
+      # NOTE: this ${DATA_DIR} is the HOST path (from your .env), unrelated
+      # to the container-side DATA_DIR above. Host dir -> container /data.
       - ${DATA_DIR:-./data}:/data
     expose:
       - "3000"

--- a/tests/scripts/docker-build-contract.test.ts
+++ b/tests/scripts/docker-build-contract.test.ts
@@ -77,3 +77,44 @@ describe("docker build / prod install contract (#212)", () => {
     expect(lan, "Caddyfile.lan must use internal TLS").toContain("tls internal");
   });
 });
+
+/**
+ * Regression contract for issue #224: enabling sync in the Docker image
+ * failed with `EACCES: permission denied, mkdir 'data/vaults'`.
+ *
+ * The vault directory is chosen by `resolveAdapter`, which reads `DATA_DIR`
+ * and falls back to the RELATIVE "./data". Both the Dockerfile and
+ * docker-compose.yml instead set `SYNC_FILESYSTEM_DIR`, which nothing in the
+ * codebase reads. So the container resolved "./data" against WORKDIR /app and
+ * tried to mkdir /app/data/vaults as the unprivileged `node` user — which
+ * cannot write there. The /data volume it was supposed to use sat empty.
+ *
+ * These assert the deployment artefacts configure the variable the code
+ * actually reads, and that it points at the prepared, writable volume.
+ */
+describe("self-host sync storage contract (#224)", () => {
+  const dockerfile = readFileSync(path.join(REPO, "Dockerfile"), "utf8");
+  const compose = readFileSync(path.join(REPO, "docker-compose.yml"), "utf8");
+
+  it("Dockerfile sets DATA_DIR — the variable resolveAdapter reads", () => {
+    expect(dockerfile).toMatch(/DATA_DIR=\/data\b/);
+  });
+
+  it("Dockerfile prepares that directory and gives it to the runtime user", () => {
+    expect(dockerfile).toMatch(/mkdir -p \/data/);
+    expect(dockerfile).toMatch(/chown -R node:node \/data/);
+    expect(dockerfile).toMatch(/^USER node$/m);
+  });
+
+  it("docker-compose sets DATA_DIR for the container", () => {
+    expect(compose).toMatch(/DATA_DIR:\s*\/data\b/);
+  });
+
+  it("neither artefact SETS SYNC_FILESYSTEM_DIR, which nothing reads", () => {
+    // A variable no code consumes reads as configuration while doing nothing,
+    // which is what hid this bug. Match assignment (`NAME=` / `NAME:`) rather
+    // than any mention, so the comments explaining the history don't trip it.
+    expect(dockerfile).not.toMatch(/SYNC_FILESYSTEM_DIR\s*=/);
+    expect(compose).not.toMatch(/^\s*SYNC_FILESYSTEM_DIR\s*:/m);
+  });
+});


### PR DESCRIPTION
Fixes the sync half of #224.

## The bug

Enabling sync in the Docker image failed with the reporter's error:

```
Sync push failed (500): {"ok":false,"error":"Failed to write vault:
EACCES: permission denied, mkdir 'data/vaults'"}
```

## Root cause

The vault directory comes from `resolveAdapter`, which reads **`DATA_DIR`** and falls back to the **relative** `"./data"`.

Both the Dockerfile and `docker-compose.yml` instead set **`SYNC_FILESYSTEM_DIR`** — a name **nothing in the codebase reads**. So the container resolved `./data` against `WORKDIR /app` and tried to `mkdir /app/data/vaults` as the unprivileged `node` user, which can't write there. Meanwhile the `/data` volume prepared for exactly this sat empty.

The dead variable is what made this hard to see: it reads as configuration while doing nothing, so the volume wiring looked correct.

## Fix

`DATA_DIR=/data` in both artefacts. The Dockerfile already creates `/data` and chowns it to `node`, so nothing else was needed. `docker-compose` keeps its host-side `${DATA_DIR:-./data}` mount, now commented — the same name means the **host** path there and the **container** path in `environment:`, which is worth stating before someone "fixes" it.

## Verified against real containers, not just the files

| image | `PUT /api/sync` |
|---|---|
| pre-fix | **500** — `EACCES: permission denied, mkdir 'data/vaults'` (reporter's exact error) |
| fixed | **200**, `GET` returns the vault, and the JSON lands in the mounted host volume |

`npm test` 3869 passed / 0 failed · `tsc` clean · `check-env` clean.

## Prevention

`tests/scripts/docker-build-contract.test.ts` now asserts the deployment artefacts configure the variable the code actually reads, that the directory is created and owned by the runtime user, and that the dead name isn't reintroduced.

## Still open on #224

The reporter also mentioned articles being falsely flagged as paywalled. Content-heuristic paywall detection was removed entirely in ADR 028 (`6ae8747`), which shipped in 0.13.0 — after their report. I'm leaving #224 open for them to confirm that half against the current image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5