### PR TITLE
fix(e2e): remove a redundant click that flaked post-merge E2E

### DIFF
--- a/tests/e2e/keyboard-navigation.spec.ts
+++ b/tests/e2e/keyboard-navigation.spec.ts
@@ -16,6 +16,10 @@ async function setupFeed(page: import("@playwright/test").Page) {
   await selectFeedInSidebar(page, "Test Feed");
   const firstArticle = articleOption(page, "First Article");
   await expect(firstArticle).toBeVisible({ timeout: 10000 });
+  // Deliberately NOT { force: true }: forcing also skips the pointer-events
+  // check, so on mobile the click can land on the still-closing nav drawer
+  // and silently do nothing, leaving the reader empty. Observed while fixing
+  // the flake below — the cure was worse than the disease.
   await firstArticle.click();
   await expect(
     page.getByRole("heading", { name: "First Article" }),
@@ -100,11 +104,10 @@ test.describe("Keyboard navigation", () => {
   test("o opens original link in new tab", async ({ feedPage: page }) => {
     await setupFeed(page);
 
-    // Select an article first
-    await articleOption(page, "First Article").click();
-    await expect(
-      page.getByRole("heading", { name: "First Article" }),
-    ).toBeVisible({ timeout: 10000 });
+    // setupFeed already selected the first article and waited for its
+    // heading; clicking it again here was redundant and was the source of a
+    // CI flake (the row is already aria-selected, and the re-click waited on
+    // a colour transition that never settled).
 
     // Press o — should open the original link
     const popupPromise = page.waitForEvent("popup");


### PR DESCRIPTION
Post-merge E2E went red on main (shard 5/6): *"o opens original link in new tab"* timed out clicking an article row.

## Cause

`setupFeed` already selects the first article and waits for its heading. The test then clicked **the same row again**. The failure log shows the row was already `aria-selected="true"` — the redundant click was waiting on the row's `transition-colors duration-150`, which Playwright's actionability check reads as "not stable" under CI load. The element was visible and hit-testable the entire time.

## Fix

Drop the redundant click. That's it.

**Deliberately not `{ force: true }`**, even though CLAUDE.md's Playwright gotchas prescribe forcing for exactly this stability trap. I tried it, and it was worse: `force` also skips the pointer-events check, so on mobile the click landed on the still-closing nav drawer and silently did nothing — leaving the reader empty and breaking *"n navigates to explore page"* in the same file. The code comment records this so the next person doesn't reapply it.

## Verification

Full suite three times after the change: **149 passed** each. The previously flaky test ran clean 3/3 in isolation too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCGcMCZ4pj8oM6tJE7XLV5