### PR TITLE
fix(billing): strip nulls from the echoed schedule phase so the migration actually runs

### DIFF
--- a/docs/decisions/029-single-annual-plan-at-9-usd.md
+++ b/docs/decisions/029-single-annual-plan-at-9-usd.md
@@ -185,8 +185,11 @@ The shape of it:
 
 Decision item 7 is implemented as one Subscription Schedule per subscription:
 phase 0 re-states the current billing period untouched, phase 1 is the annual
-price with `proration_behavior: "none"` and no duration, so it renews
-indefinitely. Nobody is charged, credited or prorated at the switchover.
+price with `proration_behavior: "none"` and no duration. Stripe gives that
+phase one billing period and then ends the schedule; `end_behavior: "release"`
+hands the subscription back still on the annual price, so the steady state is
+$9/year with no schedule attached. Nobody is charged, credited or prorated at
+the switchover.
 
 The one Stripe behaviour that will bite a hand-edited migration: **an update
 replaces a phase rather than merging into it**, so any attribute omitted from
@@ -205,8 +208,10 @@ that reason.
   renewal, and the trial explicitly *not* receiving grace.
 - `tests/core/stripe/plan-migration.test.ts` pins the migration's eligibility
   rules and the schedule payload — including that the current phase is echoed
-  back intact, that the switchover prorates nothing, and that the annual phase
-  is open-ended.
+  back intact — including nulls nested inside `discounts` and `items`, which a
+  verbatim echo trips over — and that the switchover prorates nothing. The flow
+  was rehearsed end-to-end against a real Stripe test-mode subscription
+  carrying a coupon and metadata before being run on the live book.
 - Stripe test mode: `4242 4242 4242 4242` through `?subscribe=personal-yearly`,
   then `?subscribe=personal-monthly` to confirm the legacy key resolves rather
   than failing closed.

--- a/docs/operations/annual-plan-migration.md
+++ b/docs/operations/annual-plan-migration.md
@@ -17,7 +17,7 @@ mechanism is one Stripe Subscription Schedule per subscription:
 | Phase | Price | When |
 | --- | --- | --- |
 | 0 | whatever they pay now | until the current period ends (unchanged) |
-| 1 | `$9/yr` | from then on, open-ended |
+| 1 | `$9/yr` | one year, then the schedule releases and the sub keeps renewing at $9/yr |
 
 Nobody is charged at the switchover. The first `$9` invoice is the one that
 would have been their next `$5` invoice.
@@ -229,7 +229,10 @@ In the Dashboard, on a migrated subscription:
 - A schedule is attached, with **two** phases.
 - Phase 1 ends at the subscription's existing `current_period_end` — *not*
   sooner. If it moved, the switchover will bill early.
-- Phase 2 is the `$9` annual price, with no end date.
+- Phase 2 is the `$9` annual price. It carries an end date one year out — that
+  is expected. With `end_behavior: release` the schedule then hands the
+  subscription back *still on the annual price*, and it renews normally with no
+  schedule attached.
 - **Upcoming invoice is unchanged in amount and date.** This is the check that
   matters: if it moved, proration leaked in.
 - Any coupon, tax rate or metadata the customer had is still on phase 1.

--- a/src/core/stripe/plan-migration.ts
+++ b/src/core/stripe/plan-migration.ts
@@ -28,10 +28,12 @@
  *     without its discounts loses them, permanently and silently. That is why
  *     `buildAnnualScheduleUpdate` echoes the current phase wholesale rather
  *     than naming the fields it cares about.
- *   - **A final phase with no duration runs indefinitely.** That is the shape
- *     for "this is the price from now on" — as opposed to `iterations`, which
- *     would end the annual phase after one year and hand the subscription
- *     back at whatever price the schedule defaulted to.
+ *   - **A final phase with no duration lasts one billing period, then the
+ *     schedule ends.** With `end_behavior: "release"` the subscription is
+ *     handed back *still on the annual price* and keeps renewing normally, so
+ *     the customer's steady state is $9/year with no schedule attached. This
+ *     was verified against a real subscription: phase 1 came back as one year
+ *     with an end date, not as an unbounded phase.
  */
 
 /** Minimal subset of a Stripe Subscription this migration reads. */
@@ -44,11 +46,26 @@ export interface SubscriptionSummary {
   items: { data: { price: { id: string } }[] };
 }
 
-/** A phase as Stripe returns it, plus the pass-through fields we must echo. */
+/**
+ * A phase as Stripe returns it.
+ *
+ * Deliberately open on both levels: a real phase carries far more than the
+ * three fields this module reads (`currency`, `automatic_tax`, `discounts`,
+ * `invoice_settings`, …) and each item carries more than price and quantity
+ * (`plan`, `tax_rates`, `billing_thresholds`, `metadata`). The index
+ * signatures exist so those survive the echo rather than being typed away —
+ * losing them is exactly the data loss this module is built to avoid.
+ */
 export interface SchedulePhase {
   start_date: number;
   end_date: number;
-  items: { price: string; quantity?: number }[];
+  items: SchedulePhaseItem[];
+  [passThrough: string]: unknown;
+}
+
+export interface SchedulePhaseItem {
+  price: string;
+  quantity?: number;
   [passThrough: string]: unknown;
 }
 
@@ -139,8 +156,44 @@ export interface AnnualPhase {
 }
 
 /**
- * Build the second request: re-state the current phase verbatim, then append
- * an open-ended annual phase after it.
+ * Recursively strip `null` and `undefined` from an echoed phase.
+ *
+ * Two separate Stripe behaviours make this necessary, and both were found by
+ * running the migration against a real subscription rather than a fixture:
+ *
+ *   - The SDK serializes a null field to an empty string, and Stripe reads an
+ *     empty string as "unset this parameter", then refuses it for fields that
+ *     cannot be unset — `You passed an empty string for
+ *     'phases[0][collection_method]'`.
+ *   - Stripe returns each discount as `{coupon, discount, promotion_code}`
+ *     with the two unused slots null. Echoed verbatim that reads as all three
+ *     being supplied — `You may only specify one of these parameters: coupon,
+ *     discount, promotion_code`.
+ *
+ * The second is why this recurses instead of filtering the phase's own keys:
+ * the offending nulls are inside an array of objects.
+ *
+ * Only null and undefined are dropped. `0`, `""` and `{}` are values a
+ * customer may genuinely hold, and dropping those would be the very data loss
+ * the echo exists to prevent.
+ */
+function stripNullish<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripNullish(entry)) as unknown as T;
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, v]) => v !== null && v !== undefined)
+        .map(([k, v]) => [k, stripNullish(v)]),
+    ) as unknown as T;
+  }
+  return value;
+}
+
+/**
+ * Build the second request: re-state the current phase, minus its null fields,
+ * then append the annual phase after it.
  *
  * Throws rather than returning a `Result` because every input comes from the
  * response Stripe just gave us one line earlier. A schedule created with
@@ -163,7 +216,7 @@ export function buildAnnualScheduleUpdate(
 
   return {
     phases: [
-      { ...current },
+      stripNullish(current),
       {
         items: [{ price: annualPriceId, quantity }],
         proration_behavior: "none",

--- a/tests/core/stripe/plan-migration.test.ts
+++ b/tests/core/stripe/plan-migration.test.ts
@@ -149,7 +149,11 @@ describe("buildAnnualScheduleUpdate", () => {
     expect(update.phases[1].proration_behavior).toBe("none");
   });
 
-  it("leaves the annual phase open-ended so it renews forever", () => {
+  // No duration is sent, so Stripe gives the phase one billing period and then
+  // ends the schedule. Paired with end_behavior "release" the subscription is
+  // handed back still on the annual price and keeps renewing — verified
+  // against a real subscription, where phase 1 came back as a bounded year.
+  it("sends no duration for the annual phase", () => {
     const update = buildAnnualScheduleUpdate(schedule(), ANNUAL_PRICE);
 
     expect(update.phases[1]).not.toHaveProperty("duration");
@@ -208,6 +212,69 @@ describe("buildAnnualScheduleUpdate", () => {
     );
 
     expect(update.phases[1].items).toEqual([{ price: ANNUAL_PRICE, quantity: 3 }]);
+  });
+
+  // Stripe's SDK serializes a null field to an empty string, and Stripe reads
+  // an empty string as "unset this parameter" — which it then refuses for
+  // fields that cannot be unset. A schedule created with `from_subscription`
+  // comes back with many nulls (`application_fee_percent`, `billing_thresholds`,
+  // `on_behalf_of`, `transfer_data`, and `collection_method` when the
+  // subscription bills by charge), so echoing the phase verbatim fails with
+  // "You passed an empty string for 'phases[0][collection_method]'".
+  it("drops null and undefined fields from the echoed phase", () => {
+    const update = buildAnnualScheduleUpdate(
+      schedule({
+        collection_method: null,
+        application_fee_percent: null,
+        on_behalf_of: undefined,
+      }),
+      ANNUAL_PRICE,
+    );
+
+    expect(update.phases[0]).not.toHaveProperty("collection_method");
+    expect(update.phases[0]).not.toHaveProperty("application_fee_percent");
+    expect(update.phases[0]).not.toHaveProperty("on_behalf_of");
+  });
+
+  // Stripe returns each discount as {coupon, discount, promotion_code} with the
+  // two unused slots null. Echoed back verbatim that trips
+  // "You may only specify one of these parameters: coupon, discount,
+  // promotion_code" — so the strip has to reach inside arrays and nested
+  // objects, not just the phase's own keys.
+  it("strips nulls nested inside arrays and objects", () => {
+    const update = buildAnnualScheduleUpdate(
+      schedule({
+        discounts: [
+          { coupon: "LAUNCH50", discount: null, promotion_code: null },
+        ],
+        automatic_tax: { enabled: false, disabled_reason: null, liability: null },
+        items: [
+          {
+            price: MONTHLY_PRICE,
+            quantity: 1,
+            billing_thresholds: null,
+            metadata: {},
+          },
+        ],
+      }),
+      ANNUAL_PRICE,
+    );
+
+    expect(update.phases[0].discounts).toEqual([{ coupon: "LAUNCH50" }]);
+    expect(update.phases[0].automatic_tax).toEqual({ enabled: false });
+    expect(update.phases[0].items).toEqual([
+      { price: MONTHLY_PRICE, quantity: 1, metadata: {} },
+    ]);
+  });
+
+  it("keeps a field whose value is legitimately falsy but not null", () => {
+    const update = buildAnnualScheduleUpdate(
+      schedule({ application_fee_percent: 0, metadata: {} }),
+      ANNUAL_PRICE,
+    );
+
+    expect(update.phases[0].application_fee_percent).toBe(0);
+    expect(update.phases[0].metadata).toEqual({});
   });
 
   it("rejects a schedule that has more than the one current phase", () => {


### PR DESCRIPTION
Follow-up to #279. The migration script shipped there **could not have completed a single migration** — Stripe rejected every update. Found by rehearsing the flow against a real Stripe test-mode subscription rather than trusting the unit fixtures.

## The two failures

```
You passed an empty string for 'phases[0][collection_method]'. We assume empty
values are an attempt to unset a parameter; however 'phases[0][collection_method]'
cannot be unset.
```

and once that was fixed:

```
You may only specify one of these parameters: coupon, discount, promotion_code.
```

## Root cause

`buildAnnualScheduleUpdate` echoed the current phase wholesale (`{...current}`). The *intent* is right and load-bearing — Stripe replaces a phase rather than merging into it, so an omitted discount is a silently lost discount. But a phase created via `from_subscription` is full of nulls, and Stripe's SDK serializes null to an empty string, which Stripe reads as "unset this parameter".

The second error is the subtler one: Stripe returns each discount as `{coupon, discount, promotion_code}` with the two unused slots null, so a verbatim echo reads as all three being supplied. Those nulls sit **inside an array of objects**, which is why the fix has to recurse rather than filter the phase's own keys.

The unit tests missed both because the fixtures were the minimal phase shape from Stripe's documentation example, not what the API actually returns:

```
collection_method       = null
application_fee_percent = null
billing_thresholds      = null
on_behalf_of            = null
transfer_data           = null
discounts               = [{"coupon": "…", "discount": null, "promotion_code": null}]
items                   = [{… "plan": …, "billing_thresholds": null, "tax_rates": []}]
```

## Fix

`stripNullish` walks the phase recursively, dropping only `null`/`undefined` — `0`, `""` and `{}` are values a customer may genuinely hold, and dropping those would be exactly the data loss the echo exists to prevent. `SchedulePhase` / `SchedulePhaseItem` gained index signatures so unnamed fields survive the round trip instead of being typed away.

## Also corrects a wrong claim

A final phase with no duration is **not** open-ended. Stripe gives it one billing period and then ends the schedule; `end_behavior: "release"` hands the subscription back still on the annual price, which is the steady state we want. Corrected in ADR 029, the runbook and the module docs — the observed phase 1 was a bounded year.

## Verification

Rehearsed end-to-end against a real test-mode subscription carrying a 50%-off coupon and metadata. Seven properties asserted on what Stripe returned:

```
PASS two phases
PASS phase 0 ends at the unchanged current period end
PASS phase 0 still on the old price
PASS coupon preserved on phase 0
PASS phase 1 is the annual price
PASS phase 1 prorates nothing
PASS end_behavior=release
```

Idempotency confirmed along the way — a re-run skipped the subscription as `already-scheduled` rather than double-applying. Fixtures cleaned up afterwards (subscription cancelled, prices and product archived, coupon and customer deleted).

Two regression tests added for the real API's shape. `npm test` 3950 passed / 0 failures, `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFA4Lvo1YAPcbHUrzpmyRd