### PR TITLE
release: v0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feedzero",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feedzero",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedzero",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Privacy-first RSS reader",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/release-notes.mjs
+++ b/release-notes.mjs
@@ -32,6 +32,35 @@
  */
 export const releases = [
   {
+    version: "0.14.0",
+    date: "2026-09-05T12:00:00Z",
+    title: "One paid plan at $9 a year",
+    subtitle:
+      "Pricing collapses to a single annual plan. The Pro tier is retired, the free feed limit rises to 100, and the reader gains width, unread-only, and feed-icon preferences.",
+    added: [
+      "Added a reading width preference with narrow, comfortable, and wide options, stored in the encrypted vault and synced across devices.",
+      "Added an unread-only reading mode to the article list, which hides articles once they have been read.",
+      "Added a preference for showing feed icons in the article list.",
+    ],
+    changed: [
+      "Moved to a single paid plan at $9 a year, billed annually. The monthly plan is retired. Existing subscribers move to the annual price at their next renewal, with no proration and no mid-period charge.",
+      "Renamed the paid tier to Supporter. The licence format is unchanged, so existing licences keep working without reactivation.",
+      "Raised the free feed limit to 100 subscriptions.",
+      "Shortened the free trial to 14 days, which is long enough to import a subscription list and read through two weekly cycles.",
+      "Gave licences seven days of grace past the billing period end, applied on renewal. A card that fails and retries no longer locks the reader out mid-recovery.",
+    ],
+    removed: [
+      "Removed the Pro tier. Every feature listed under it was unbuilt, so nothing became unavailable. The four planned features moved to the paid tier at the same status.",
+    ],
+    fixed: [
+      "Fixed the desktop feed list not collapsing. The control rendered and responded but the panel never moved.",
+      "Fixed the self-hosted container writing sync vaults outside the configured data directory, which lost them on restart.",
+      "Fixed eleven API endpoints serving stale bundled output, so changes to their handlers reached production again.",
+      "Fixed the release feed being served with the wrong content type from its new origin.",
+      "Fixed both operator command line tools failing to start. They imported a module path that has never existed, so the licence recovery tool documented in the support runbook could not run.",
+    ],
+  },
+  {
     version: "0.13.0",
     date: "2026-08-02T12:00:00Z",
     title: "Mobile reading rebuilt around gestures",

--- a/tests/fixtures/release-feed.xml
+++ b/tests/fixtures/release-feed.xml
@@ -3,12 +3,48 @@
   <title>FeedZero Release Notes</title>
   <subtitle>What changed in FeedZero.</subtitle>
   <id>feedzero:changelog</id>
-  <updated>2026-08-02T12:00:00Z</updated>
+  <updated>2026-09-05T12:00:00Z</updated>
   <link rel="self" href="https://feedzero.app/releases.xml" />
   <link rel="alternate" type="text/html" href="https://feedzero.app/#releases" />
   <author>
     <name>FeedZero</name>
   </author>
+  <entry>
+    <id>feedzero:release:0.14.0</id>
+    <title>v0.14.0: One paid plan at $9 a year</title>
+    <link rel="alternate" href="https://feedzero.app/#releases" />
+    <published>2026-09-05T12:00:00Z</published>
+    <updated>2026-09-05T12:00:00Z</updated>
+    <summary>Pricing collapses to a single annual plan. The Pro tier is retired, the free feed limit rises to 100, and the reader gains width, unread-only, and feed-icon preferences.</summary>
+    <content type="html"><![CDATA[<p>Pricing collapses to a single annual plan. The Pro tier is retired, the free feed limit rises to 100, and the reader gains width, unread-only, and feed-icon preferences.</p>
+<h3>Added</h3>
+<ul>
+  <li>Added a reading width preference with narrow, comfortable, and wide options, stored in the encrypted vault and synced across devices.</li>
+  <li>Added an unread-only reading mode to the article list, which hides articles once they have been read.</li>
+  <li>Added a preference for showing feed icons in the article list.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+  <li>Moved to a single paid plan at $9 a year, billed annually. The monthly plan is retired. Existing subscribers move to the annual price at their next renewal, with no proration and no mid-period charge.</li>
+  <li>Renamed the paid tier to Supporter. The licence format is unchanged, so existing licences keep working without reactivation.</li>
+  <li>Raised the free feed limit to 100 subscriptions.</li>
+  <li>Shortened the free trial to 14 days, which is long enough to import a subscription list and read through two weekly cycles.</li>
+  <li>Gave licences seven days of grace past the billing period end, applied on renewal. A card that fails and retries no longer locks the reader out mid-recovery.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+  <li>Fixed the desktop feed list not collapsing. The control rendered and responded but the panel never moved.</li>
+  <li>Fixed the self-hosted container writing sync vaults outside the configured data directory, which lost them on restart.</li>
+  <li>Fixed eleven API endpoints serving stale bundled output, so changes to their handlers reached production again.</li>
+  <li>Fixed the release feed being served with the wrong content type from its new origin.</li>
+  <li>Fixed both operator command line tools failing to start. They imported a module path that has never existed, so the licence recovery tool documented in the support runbook could not run.</li>
+</ul>
+<h3>Removed</h3>
+<ul>
+  <li>Removed the Pro tier. Every feature listed under it was unbuilt, so nothing became unavailable. The four planned features moved to the paid tier at the same status.</li>
+</ul>]]></content>
+    <author><name>FeedZero</name></author>
+  </entry>
   <entry>
     <id>feedzero:release:0.13.0</id>
     <title>v0.13.0: Mobile reading rebuilt around gestures</title>


### PR DESCRIPTION
Release notes entry plus the version bump. Tag and image publish follow automatically once this merges (`release-tag.yml`).

**Overdue.** 18 commits had shipped to production since `v0.13.0` — including a breaking pricing change — with `package.json` still reporting `0.13.0`. This closes that gap.

## Version: 0.14.0, not the computed 1.0.0

`computeVersion` returned **1.0.0**, correctly: `feat(pricing)!` carries a breaking marker, and there is an explicit test asserting `major` from a `0.x` bumps to `1.0.0`.

Overridden to `0.14.0`. Standard semver for pre-1.0 is that breaking changes bump the minor while on `0.x`, and both the app and the landing page still describe the product as alpha. Spending the 1.0 moment on a pricing change, and silently contradicting the alpha framing, is not what that version number should mean. Worth deciding deliberately later.

## Notes were hand-edited

The auto-draft produced one flat sentence per commit subject and included internal tooling (`/ship loop`, "own the release notes"). The house style in `release-notes.mjs` is substantive, user-facing bullets. The entry now covers what changed for a user and drops the build-pipeline work.

`lintNotes` clean. One violation the drafter produced (`/ship loop…` failing `capitalized-start`, not auto-fixable) disappeared with the rewrite.

## What is in it

**Changed** — single paid plan at $9/year annual-only; paid tier renamed Supporter; free feed limit raised to 100; trial shortened to 14 days; licences get 7 days of renewal grace.

**Removed** — the Pro tier. Every feature under it was unbuilt, so nothing became unavailable.

**Added** — reading-width, unread-only, and feed-icon preferences.

**Fixed** — desktop feed list not collapsing; self-hosted container writing vaults outside the data directory; eleven API endpoints serving stale bundled output; release feed content type; and both operator CLIs failing to start on an import path that never existed, which meant the licence-recovery tool in the support runbook could not run.

## Verification

`npm test` 3950 passed / 0 failures. `npm run typecheck` clean (both projects). `tests/fixtures/release-feed.xml` regenerated from `npm run build:feed`, which is what made the two byte-compatibility tests pass again. Existing `feedzero:release:*` ids untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFA4Lvo1YAPcbHUrzpmyRd