### PR TITLE
fix(reader): keep the feed's text above the paywall prompt and stop asserting a paywall

### DIFF
--- a/docs/features/019-authenticated-fetch.md
+++ b/docs/features/019-authenticated-fetch.md
@@ -25,7 +25,13 @@
 
 Paywall **gating** (by HTTP status) and the **"Open original"** fallback ship
 now: a publisher that refuses the anonymous fetch (401/402/403/451) shows a
-clean "Paywalled article → Open original" card instead of a broken extraction.
+"Full article not available → Open original" card *below the feed's own text*
+instead of a broken extraction. The card's copy is hedged ("likely requires a
+subscription or disallows fetching") because a gated status cannot distinguish
+a paywall from bot-blocking: NYT answers the proxy with a DataDome 403
+challenge page, and its feed carries only a ~170-character summary per item,
+so hiding that summary behind the card would leave the reader with less than
+Feed view shows.
 The **extension CTAs** (Install the FeedZero
 extension, Authorize `<publisher>`, session-expired sign-in) are gated behind
 `isExtensionEnabled()` (`src/core/extension/extension-enabled.ts`), which reads

--- a/src/components/reader/paywall-prompt.tsx
+++ b/src/components/reader/paywall-prompt.tsx
@@ -90,14 +90,12 @@ export function PaywallPrompt({
           <h3 className="font-medium leading-tight">
             {showSessionExpired
               ? `${publisher} session needs refreshing`
-              : "Paywalled article"}
+              : "Full article not available"}
           </h3>
           <p className="text-sm text-muted-foreground mt-1">
             {showSessionExpired
               ? `Your sign-in to ${publisher} appears to have expired. Open the publisher to sign back in, then reload this article.`
-              : publisher
-                ? `${publisher} requires a subscription to read the full article.`
-                : "This article appears to be behind a paywall."}
+              : `${publisher ?? "The publisher"} likely requires a subscription or disallows fetching.`}
           </p>
         </div>
       </header>

--- a/src/components/reader/paywall-prompt.tsx
+++ b/src/components/reader/paywall-prompt.tsx
@@ -6,10 +6,15 @@ import { isExtensionEnabled } from "@/core/extension/extension-enabled.ts";
 import { cn } from "@/lib/utils.ts";
 
 /**
- * The four states the reader pane can show when /api/page returns content
- * the paywall detector flags as gated.
+ * The states the reader pane can show when the anonymous /api/page fetch
+ * was refused with a gated HTTP status (401/402/403/451).
  *
- * paywall          — anonymous fetch returned a stub; user has options
+ * The copy is deliberately hedged: a 403 can be a subscription gate or a
+ * bot challenge (NYT serves a DataDome page to datacenter IPs), and the
+ * status alone cannot tell them apart. Asserting "paywalled" would be
+ * wrong for a free article the publisher merely refused to serve us.
+ *
+ * paywall          — anonymous fetch was refused; user has options
  * session-expired  — extension fetched with cookies but still got a stub
  *                    (cookie expired since last grant)
  * authorize        — handled implicitly via extension status; not a prop value
@@ -32,7 +37,7 @@ interface PaywallPromptProps {
 const EXTENSION_INSTALL_URL = "https://feedzero.app/extension";
 
 /**
- * Reader-pane affordance for paywalled articles. Reads from the extension
+ * Reader-pane affordance for gated articles. Reads from the extension
  * store to pick the right call-to-action:
  *
  *   status=absent             → "Install the FeedZero extension" + Open original

--- a/src/components/reader/reader-panel.tsx
+++ b/src/components/reader/reader-panel.tsx
@@ -457,15 +457,18 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
           !cachedExtraction &&
           article.link &&
           paywallMap[article.link] ? (
-          <PaywallPrompt
-            publisher={paywallMap[article.link].publisher}
-            articleUrl={article.link}
-            reason={
-              paywallMap[article.link].reason === "session-expired"
-                ? "session-expired"
-                : "paywall"
-            }
-          />
+          <>
+            <ArticleContent html={getContent()} />
+            <PaywallPrompt
+              publisher={paywallMap[article.link].publisher}
+              articleUrl={article.link}
+              reason={
+                paywallMap[article.link].reason === "session-expired"
+                  ? "session-expired"
+                  : "paywall"
+              }
+            />
+          </>
         ) : (
           <ArticleContent html={getContent()} />
         )}

--- a/src/components/reader/reader-panel.tsx
+++ b/src/components/reader/reader-panel.tsx
@@ -272,7 +272,11 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
     if (viewMode === "extracted" && cachedExtraction) {
       return cachedExtraction;
     }
+    return getFeedContent();
+  }
 
+  /** The feed's own text for this article, regardless of view mode. */
+  function getFeedContent(): string {
     const content = article!.content || article!.summary || "";
     const showSubheading = hasSummarySubheading(
       article!.content,
@@ -376,7 +380,7 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
                   onClick={() => handleModeChange("extracted")}
                   title={
                     hasPaywallVerdict
-                      ? "Article is paywalled — open to authorize the publisher"
+                      ? "Full article couldn't be fetched — open to see options"
                       : extractionStatus === "failed"
                         ? "Extraction didn't find additional content"
                         : undefined
@@ -458,7 +462,9 @@ export function ReaderPanel({ nextArticle, prevArticle, onNavigate, onBack }: Re
           article.link &&
           paywallMap[article.link] ? (
           <>
-            <ArticleContent html={getContent()} />
+            {/* The feed's text is all we hold for a gated article; the prompt
+                explains why there is no more, it must not replace it. */}
+            <ArticleContent html={getFeedContent()} />
             <PaywallPrompt
               publisher={paywallMap[article.link].publisher}
               articleUrl={article.link}

--- a/tests/components/reader/paywall-prompt.test.tsx
+++ b/tests/components/reader/paywall-prompt.test.tsx
@@ -40,7 +40,7 @@ describe("PaywallPrompt", () => {
       );
 
       expect(
-        screen.getByRole("heading", { name: /paywalled article/i }),
+        screen.getByRole("heading", { name: /full article/i }),
       ).toBeInTheDocument();
       const install = screen.getByRole("link", { name: /install/i });
       expect(install).toBeInTheDocument();
@@ -206,7 +206,7 @@ describe("PaywallPrompt", () => {
       ).toBeInTheDocument();
     });
 
-    it("still shows the paywall heading + message so the user understands why", () => {
+    it("still shows the heading + message so the user understands why", () => {
       useExtensionStore.setState({ status: "absent" });
 
       render(
@@ -214,7 +214,30 @@ describe("PaywallPrompt", () => {
       );
 
       expect(
-        screen.getByRole("heading", { name: /paywalled article/i }),
+        screen.getByRole("heading", { name: /full article/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not claim a paywall outright: a gated status can also be bot-blocking (NYT serves a DataDome 403 to datacenter IPs)", () => {
+      useExtensionStore.setState({ status: "absent" });
+
+      render(
+        <PaywallPrompt publisher="nytimes.com" articleUrl="https://nytimes.com/x" />,
+      );
+
+      expect(
+        screen.getByText(/nytimes\.com likely requires a subscription or disallows fetching/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/paywalled article/i)).not.toBeInTheDocument();
+    });
+
+    it("falls back to 'the publisher' when the host is unparseable", () => {
+      useExtensionStore.setState({ status: "absent" });
+
+      render(<PaywallPrompt publisher={null} articleUrl="not-a-url" />);
+
+      expect(
+        screen.getByText(/the publisher likely requires a subscription or disallows fetching/i),
       ).toBeInTheDocument();
     });
   });

--- a/tests/components/reader/reader-panel-paywall.test.tsx
+++ b/tests/components/reader/reader-panel-paywall.test.tsx
@@ -99,7 +99,44 @@ describe("ReaderPanel paywall integration", () => {
     // Scoped to the prompt to avoid colliding with the article-title heading.
     expect(
       prompt.querySelector("h3"),
-    ).toHaveTextContent(/paywalled article/i);
+    ).toHaveTextContent(/full article/i);
+  });
+
+  it("keeps the feed's own text visible above the prompt in extracted view (NYT ships a one-line summary and nothing else)", () => {
+    // The verdict must not hide the only text we hold for the article:
+    // NYT's feed carries a ~170-char description per item and the anonymous
+    // fetch is refused, so replacing the pane with the prompt would leave the
+    // user with strictly less than Feed view showed them.
+    useArticleStore.setState({
+      selectedArticle: mockArticle(),
+      articles: [],
+      isLoading: false,
+    });
+
+    render(<ReaderPanel />);
+
+    act(() => {
+      useExtractionStore.setState({
+        cache: {},
+        statusMap: { "https://nytimes.com/article-x": "failed" },
+        paywallMap: {
+          "https://nytimes.com/article-x": {
+            paywalled: true,
+            publisher: "nytimes.com",
+            reason: "http-403",
+          },
+        },
+        viewMode: "extracted",
+      });
+    });
+
+    const prompt = screen.getByRole("region", { name: /paywall prompt/i });
+    const teaser = screen.getByText("Teaser.");
+    expect(teaser).toBeInTheDocument();
+    // Feed text first, prompt after: the prompt explains why there is no more.
+    expect(
+      teaser.compareDocumentPosition(prompt) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("does NOT render PaywallPrompt when in feed view (only on the extracted side)", () => {


### PR DESCRIPTION
## What
On a gated article, the Full text view replaced the pane with a "Paywalled article" card, hiding the feed's own summary. For NYT that summary (~170 chars per item, no `content:encoded`) is the only text FeedZero holds, so the user saw strictly less than Feed view.

## Why
- The prompt branch in `reader-panel.tsx` rendered `PaywallPrompt` *instead of* `ArticleContent`.
- The copy asserted a paywall on the strength of an HTTP 403 alone. Verified against production: NYT answers `/api/page` with a DataDome bot-challenge 403 ("Please enable JS and disable any ad blocker"), not a subscription gate. The status cannot tell the two apart.

## Fix
- Render the feed content before the prompt (`getFeedContent()` makes the intent explicit).
- Copy: **Full article not available** / "`<publisher>` likely requires a subscription or disallows fetching." (falls back to "The publisher" when the host is unparseable). Toggle tooltip and JSDoc updated to match.

## Prevention
- `tests/components/reader/reader-panel-paywall.test.tsx` pins feed text rendered above the prompt.
- `tests/components/reader/paywall-prompt.test.tsx` pins the hedged copy, the null-publisher fallback, and that "paywalled" no longer appears.
- `docs/features/019-authenticated-fetch.md` records the rationale.

## Verification
- `npm test`: 3963 passed. `npx tsc --noEmit`: clean.
- `npm run test:e2e`: 154 passed (needed `npx playwright install chromium` after #280's Playwright bump).
- Visual: Chromium screenshot of the reader against a mocked 403 shows summary above the card on desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQoLHbPfaTCHvPuaoqGZeJ