### PR TITLE
fix(deps): lift @xmldom/xmldom to 0.9.12 to clear eleven high advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4005,9 +4005,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "optional": true,
       "engines": {


### PR DESCRIPTION
## What
The `npm audit + gitleaks` required check fails on every PR and on main itself since today, with 11 BLOCKING high advisories against `@xmldom/xmldom` 0.9.10 (ReDoS, quadratic parsing, `requireWellFormed` bypasses; GHSA-93r5-fhx6-vmg9 and ten siblings). Every merge is frozen until this lands.

## Why
xmldom is transitive: defuddle → mathml-to-latex → @xmldom/xmldom. The advisories were published today; the lockfile pinned 0.9.10, inside the vulnerable range (≤ 0.9.11).

## Fix
Lockfile-only `npm update @xmldom/xmldom` → 0.9.12. `mathml-to-latex` declares `^0.9.10`, so no direct dependency changes. No waiver: a fix exists, so the gate should be satisfied by the fix rather than an exception.

## Verification
- `node scripts/audit-gate.mjs`: "Audit gate passed."
- `npx vitest run`: full suite green, including `tests/core/extractor` (the defuddle path).

Unblocks #291 (vitest 4) and the TypeScript 7 PR that follows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQoLHbPfaTCHvPuaoqGZeJ