### PR TITLE
test: keep the unit suite off the network

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Three-tier strategy. See [docs/testing-strategy.md](docs/testing-strategy.md) fo
 - Use `selectFeedInSidebar(page, name)` from `fixtures.ts` — it handles opening the sidebar on mobile.
 
 **happy-dom gotchas**:
+- happy-dom is a real resource loader: a `<link rel="stylesheet">` or `<iframe src>` in a fixture opens a socket to the URL. `vitest.config.js` disables CSS/JS file loading and iframe page loading (`environmentOptions.happyDOM.settings`), and `tests/environment/no-real-network.test.ts` pins it. A disabled iframe load still prints one `NotSupportedError` line per fixture; that is happy-dom's unconditional `console.error`, not a failure. Page code that calls `fetch` on mount still needs a stub in the test (`vi.stubGlobal("fetch", ...)`), or the request goes to `localhost:3000` and dies as an `ECONNREFUSED` trace that no assertion sees.
 - DOMPurify + happy-dom executes inline scripts during sanitization. Use non-callable fixtures (`var x = 1;`, not `alert(1)`).
 - CSS-escaped colons (`content\\:encoded`) may work in happy-dom but fail in browsers — always use `getElementsByTagName` for XML namespace-prefixed elements.
 - CDATA with namespace declarations may fail to parse. Use entity-escaped HTML (`&lt;p&gt;`) instead.

--- a/tests/environment/no-real-network.test.ts
+++ b/tests/environment/no-real-network.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import http from "node:http";
+import https from "node:https";
+
+/**
+ * The unit environment must never open a socket. happy-dom is a real
+ * resource loader: a `<link rel="stylesheet">` or `<iframe src>` inserted
+ * into the document makes it fetch the URL through node:http(s), which in
+ * the suite meant connection attempts to localhost:3000 and to fixture
+ * hosts (`https://evil.com/`) that showed up as ECONNREFUSED stack traces
+ * in every run. Nothing awaited those fetches, so the suite stayed green
+ * while doing real network I/O. Pinned here so the environment setting that
+ * silences it cannot be dropped without this failing.
+ */
+describe("unit environment: no real network", () => {
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("does not fetch a <link rel=stylesheet> inserted into the document", async () => {
+    const request = vi.spyOn(http, "request").mockImplementation(() => {
+      throw new Error("real network attempted");
+    });
+
+    document.body.innerHTML = '<link rel="stylesheet" href="/style.css">';
+    await settle();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("does not load the page of an <iframe src> inserted into the document", async () => {
+    const request = vi.spyOn(https, "request").mockImplementation(() => {
+      throw new Error("real network attempted");
+    });
+
+    document.body.innerHTML = '<iframe src="https://evil.com"></iframe>';
+    await settle();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/tests/pages/billing-success.test.tsx
+++ b/tests/pages/billing-success.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
@@ -33,6 +33,21 @@ function renderWithRoute(path: string) {
 }
 
 describe("BillingSuccess page", () => {
+  // Rendering with a session_id makes the page request the license for that
+  // session on mount. Tests that only assert copy never stubbed fetch, so
+  // happy-dom opened a real socket to localhost:3000 on every run. A default
+  // pending stub keeps the page in its initial state, which is what those
+  // tests were observing anyway; tests that need a response override it.
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("renders a confirmation heading", () => {
     renderWithRoute("/billing/success");
     expect(
@@ -48,6 +63,12 @@ describe("BillingSuccess page", () => {
     expect(
       screen.getByRole("button", { name: /save/i }),
     ).toBeInTheDocument();
+    // The page asks the server for this session's license rather than
+    // waiting for the user to paste — the input is the fallback.
+    const calls = (globalThis.fetch as unknown as Mock).mock.calls as Array<
+      [RequestInfo | URL, RequestInit?]
+    >;
+    expect(calls.some(([url]) => String(url).includes("/api/license/retrieve"))).toBe(true);
   });
 
   it("does NOT render the session id as page chrome on the polling-state happy path", async () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,6 +10,21 @@ export default defineConfig({
   },
   test: {
     environment: "happy-dom",
+    // happy-dom is a real resource loader: a <link rel="stylesheet"> or
+    // <iframe src> in a fixture makes it open a socket to the URL. The unit
+    // suite must never touch the network, and nothing awaited those loads,
+    // so they only showed up as ECONNREFUSED stack traces in every run.
+    // tests/environment/no-real-network.test.ts pins this.
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          disableCSSFileLoading: true,
+          disableJavaScriptFileLoading: true,
+          disableIframePageLoading: true,
+          handleDisabledFileLoadingAsSuccess: true,
+        },
+      },
+    },
     include: ["tests/**/*.test.{js,ts,tsx}"],
     setupFiles: ["tests/setup.ts"],
     // Unhandled rejections FAIL the run rather than printing "Errors 1"


### PR DESCRIPTION
## What
Every `npm test` run printed ~30 lines of `ECONNREFUSED` / `AbortError` / `AsyncTaskManager has been destroyed` stack traces. All tests passed, so it went unnoticed.

## Why
Two sources, attributed by temporarily wrapping `node:http.request` to name the running test:
1. **happy-dom is a real resource loader.** `<link rel="stylesheet">` and `<iframe src>` fixtures in `sanitizer.test.js`, `feed-service.test.js` and `strategies.test.js` made it open sockets to `localhost:3000` and `https://evil.com`.
2. **`billing-success.test.tsx`** rendered with a `session_id`, which fires the page's `/api/license/retrieve` fetch on mount, in three tests that never stubbed `fetch`.

Nothing awaited either, so the suite stayed green while doing real network I/O.

## Fix
- `vitest.config.js`: `environmentOptions.happyDOM.settings` disables CSS/JS file loading and iframe page loading.
- `billing-success.test.tsx`: file-level pending `fetch` stub, plus an assertion that the page requests the session's license (the behaviour those tests were silently exercising).

A disabled iframe load still prints one `NotSupportedError` line per fixture (happy-dom's unconditional `console.error`, 4 lines total). Silencing those would need a fetch interceptor that changes semantics for every unstubbed page fetch; not worth it.

## Prevention
- `tests/environment/no-real-network.test.ts` spies `node:http(s).request` and asserts a stylesheet link and an iframe insert never reach it (red before the config change).
- CLAUDE.md happy-dom gotchas record the setting and the fetch-stub rule.

## Verification
| | before | after |
|---|---|---|
| ECONNREFUSED lines | 30 | 0 |
| AbortError / AsyncTaskManager lines | ~12 | 0 |
| Tests | 3963 | 3965 passed |

`npx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQoLHbPfaTCHvPuaoqGZeJ