### PR TITLE
fix(api): restore the ?domain= dispatch in the /api/icon Vercel wrapper

### DIFF
--- a/api/icon.ts
+++ b/api/icon.ts
@@ -3,8 +3,17 @@
 // esbuild entry point and overwrites it in place at build time. Committing
 // that build output detaches the endpoint from src/ permanently, and handler
 // changes silently stop deploying.
+import { handleFaviconRequest } from "../src/core/favicon/favicon-handler";
 import { handleProxyRequest } from "../src/core/proxy/proxy-handler";
 
+// One function serves two request shapes (Vercel's 12-function Hobby cap):
+// ?domain=<host> resolves the site's favicon; anything else proxies a known
+// image URL. server.ts and vite.config.js apply the same dispatch —
+// tests/api/icon-wrapper.test.ts holds this entry point to it.
 export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  if (url.searchParams.get("domain")) {
+    return handleFaviconRequest(req);
+  }
   return handleProxyRequest(req, "image/x-icon");
 }

--- a/tests/api/icon-wrapper.test.ts
+++ b/tests/api/icon-wrapper.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { GET } from "../../api/icon";
+
+/**
+ * Contract for the Vercel wrapper at api/icon.ts.
+ *
+ * /api/icon serves two request shapes through one function (Vercel's
+ * 12-function Hobby cap): `?domain=<host>` resolves the site's favicon,
+ * anything else proxies a known image URL. server.ts and vite.config.js
+ * both dispatch on that shape; the wrapper is the third entry point and
+ * must agree (CLAUDE.md "three-entry-point rule").
+ *
+ * PR #260 rewrote the wrapper as a thin proxy call and dropped the
+ * dispatch. In production every `?domain=` request (the client's primary
+ * path, src/components/feeds/feed-favicon.tsx) answered 400, the client
+ * fell back to proxying raw site URLs, and the generic proxy relayed
+ * multi-megabyte HTML bodies as "icons" with no CDN caching — the Vercel
+ * "5xx spike on /api/icon" alert and the Fast Origin Transfer exhaustion
+ * of 2026-09.
+ *
+ * Only the network is mocked here; both handlers run for real.
+ */
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+describe("api/icon.ts wrapper dispatch", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(PNG, {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves a favicon for ?domain= instead of demanding a url", async () => {
+    const res = await GET(
+      new Request("https://my.feedzero.app/api/icon?domain=example.com"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/^image\//);
+    expect(res.headers.get("cache-control")).toMatch(/max-age=86400/);
+  });
+
+  it("still proxies an explicit image url", async () => {
+    const res = await GET(
+      new Request(
+        "https://my.feedzero.app/api/icon?url=https%3A%2F%2Fexample.com%2Ffavicon.ico",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/^image\//);
+  });
+});

--- a/tests/smoke/icon.test.ts
+++ b/tests/smoke/icon.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Live check of /api/icon on the deployed system (SMOKE_TESTS=1).
+ *
+ * Both request shapes must be served by the single Vercel function: the
+ * client's primary `?domain=` path (favicon discovery) and the `?url=`
+ * fallback (image proxy). In 2026-09 the deployed wrapper answered every
+ * `?domain=` request with 400 while every unit test stayed green — the
+ * dispatch existed in server.ts and vite.config.js but not in api/icon.ts.
+ * Only a request against the real deployment can see that.
+ */
+const BASE = process.env.SMOKE_BASE_URL ?? "https://my.feedzero.app";
+const enabled = process.env.SMOKE_TESTS === "1";
+
+describe.skipIf(!enabled)("smoke: /api/icon", () => {
+  it("serves a favicon for ?domain= with a cacheable image response", async () => {
+    const res = await fetch(`${BASE}/api/icon?domain=example.com`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/^image\//);
+    expect(res.headers.get("cache-control")).toMatch(/max-age=86400/);
+  });
+
+  it("proxies an explicit image url", async () => {
+    const res = await fetch(
+      `${BASE}/api/icon?url=${encodeURIComponent("https://example.com/favicon.ico")}`,
+    );
+    // example.com has no favicon; the contract is that the proxy answers
+    // for the URL rather than rejecting the shape.
+    expect([200, 404, 502]).toContain(res.status);
+    expect(res.status).not.toBe(400);
+  });
+});


### PR DESCRIPTION
## What
Since #260 (2026-08-05) production answered every `/api/icon?domain=<host>` request with **400 "Missing url"**. That is the client's primary favicon path (`feed-favicon.tsx`), so every client fell back to proxying raw site URLs, and the generic proxy relayed whatever came back, including 1.3 MB of NYT homepage HTML per attempt, as an "icon" with `max-age=0`, never CDN-cached.

Two Vercel alerts trace to this: the **5xx spike on /api/icon** (2026-09-08, upstream 502s from the fallback path) and **Fast Origin Transfer at 100% of the free 10 GB** (2026-09-04).

Verified live before the fix:
```
/api/icon?domain=nytimes.com          -> 400, 21 B
/api/icon?url=https://www.nytimes.com -> 200, 1,372,581 B, text/html, max-age=0, x-vercel-cache: MISS
```

## Why
#260 rewrote `api/icon.ts` as a thin call to `handleProxyRequest` and dropped the query-shape dispatch that `server.ts` and `vite.config.js` both carry. The wrapper contract test only checks that `api/*.ts` import from `src/`, not what they route, and there was no smoke test for the endpoint.

## Fix
The wrapper dispatches `?domain=` to `handleFaviconRequest` and everything else to the image proxy, the same branch as the other two entry points (three-entry-point rule).

## Prevention
- `tests/api/icon-wrapper.test.ts`: runs the wrapper's `GET` with only `fetch` mocked and asserts both shapes (red before: 400).
- `tests/smoke/icon.test.ts`: asserts the deployed function serves `?domain=` as a cacheable image.

## Verification
- `npx vitest run`: full suite green. `npx tsc --noEmit`: clean. `scripts/build-api.js` bundles the new wrapper.
- After merge: `SMOKE_TESTS=1 npx vitest run tests/smoke/icon.test.ts` against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQoLHbPfaTCHvPuaoqGZeJ